### PR TITLE
Check `work_dir` with project check CLI and enforce absolute paths

### DIFF
--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -40,7 +40,6 @@ def get_job_info_table(jobs_info: list[JobInfo], verbosity: int):
     for ji in jobs_info:
         state = ji.state.name
         if ji.remote_state is not None and ji.state not in excluded_states:
-
             if ji.retry_time_limit is not None:
                 state += f" [[bold red]{ji.remote_state.name}[/]]"
             else:
@@ -136,6 +135,9 @@ def format_job_info(job_info: JobInfo, show_none: bool = False):
     error_remote = d.get("error_remote")
     if error_remote:
         d["error_remote"] = ReprStr(error_remote)
+    error_job = d.get("error_job")
+    if error_job:
+        d["error_job"] = ReprStr(error_job)
     return render_scope(d)
 
 

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -146,6 +146,12 @@ class WorkerBase(BaseModel):
             raise ValueError(f"Unknown scheduler type {scheduler_type}")
         return scheduler_type
 
+    @validator("work_dir", always=True)
+    def check_work_dir(cls, v) -> Path:
+        if not v.is_absolute():
+            raise ValueError("`work_dir` must be an absolute path")
+        return v
+
     def get_scheduler_io(self) -> BaseSchedulerIO:
         """
         Get the BaseSchedulerIO from QToolKit depending on scheduler_type.

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -111,8 +111,8 @@ class WorkerBase(BaseModel):
     scheduler_type: str = Field(
         description="Type of the scheduler. Depending on the values supported by QToolKit"
     )
-    work_dir: str = Field(
-        description="Path to the directory of the worker where subfolders for "
+    work_dir: Path = Field(
+        description="Absolute path of the directory of the worker where subfolders for "
         "executing the calculation will be created"
     )
     resources: dict | None = Field(

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -107,8 +107,9 @@ class RemoteHost(BaseHost):
         # TODO: check if this works:
         if not workdir:
             workdir = "."
-        else:
-            workdir = str(workdir)
+
+        workdir = Path(workdir)
+
         timeout = timeout or self.timeout_execute
 
         if self.shell_cmd:
@@ -135,10 +136,8 @@ class RemoteHost(BaseHost):
         self, directory: str | Path, recursive: bool = True, exist_ok: bool = True
     ) -> bool:
         """Create directory on the host."""
-        command = "mkdir "
-        if recursive:
-            command += "-p "
-        command += str(directory)
+        directory = Path(directory)
+        command = f"mkdir {'-p ' if recursive else ''}{str(directory)!r}"
         try:
             stdout, stderr, returncode = self.execute(command)
             if returncode != 0:


### PR DESCRIPTION
~Continuation of my last PR, this closes #14~ and also adds a task for checking the configured `work_dir` (c.f. #13). I fell into various pits trying to set mine up (using e.g., `~`, `$HOME` or relative dirs did not work, so I changed the config description to force absolute paths).