### PR TITLE
Restore queries based on job id

### DIFF
--- a/src/jobflow_remote/cli/admin.py
+++ b/src/jobflow_remote/cli/admin.py
@@ -9,7 +9,7 @@ from jobflow_remote.cli.types import (
     db_ids_opt,
     end_date_opt,
     force_opt,
-    job_ids_opt,
+    job_ids_indexes_opt,
     job_state_opt,
     remote_state_opt,
     start_date_opt,
@@ -17,6 +17,7 @@ from jobflow_remote.cli.types import (
 from jobflow_remote.cli.utils import (
     check_incompatible_opt,
     exit_with_error_msg,
+    get_job_ids_indexes,
     loading_spinner,
     out_console,
 )
@@ -102,7 +103,7 @@ def reset(
 
 @app_admin.command()
 def remove_lock(
-    job_id: job_ids_opt = None,
+    job_id: job_ids_indexes_opt = None,
     db_id: db_ids_opt = None,
     state: job_state_opt = None,
     remote_state: remote_state_opt = None,
@@ -116,6 +117,8 @@ def remove_lock(
     """
     check_incompatible_opt({"state": state, "remote-state": remote_state})
 
+    job_ids_indexes = get_job_ids_indexes(job_id)
+
     jc = JobController()
     if not force:
         with loading_spinner(False) as progress:
@@ -124,7 +127,7 @@ def remove_lock(
             )
 
             jobs_info = jc.get_jobs_info(
-                job_ids=job_id,
+                job_ids=job_ids_indexes,
                 db_ids=db_id,
                 state=state,
                 remote_state=remote_state,
@@ -133,7 +136,7 @@ def remove_lock(
                 end_date=end_date,
             )
 
-        text = Text(
+        text = Text.from_markup(
             f"[red]This operation will [bold]remove the lock[/bold] for (roughly) [bold]{len(jobs_info)} Job(s)[/bold]. Proceed anyway?[/red]"
         )
         confirmed = Confirm.ask(text, default=False)

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -68,7 +68,7 @@ def flows_list(
         flows_info = jc.get_flows_info(
             job_ids=job_id,
             db_ids=db_id,
-            flow_id=flow_id,
+            flow_ids=flow_id,
             state=state,
             start_date=start_date,
             end_date=end_date,
@@ -112,7 +112,7 @@ def delete(
         flows_info = jc.get_flows_info(
             job_ids=job_id,
             db_ids=db_id,
-            flow_id=flow_id,
+            flow_ids=flow_id,
             state=state,
             start_date=start_date,
             end_date=end_date,

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -10,12 +10,25 @@ from jobflow_remote.cli.utils import SerializeFileFormat, SortOption
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import JobState, RemoteState
 
+job_ids_indexes_opt = Annotated[
+    Optional[List[str]],
+    typer.Option(
+        "--job-id",
+        "-jid",
+        help="One or more pair of job ids (i.e. uuids) and job index formatted "
+        "as UUID:INDEX (e.g. e1d66c4f-81db-4fff-bda2-2bf1d79d5961:2). "
+        "The index is mandatory",
+    ),
+]
+
+
 job_ids_opt = Annotated[
     Optional[List[str]],
     typer.Option(
         "--job-id",
         "-jid",
-        help="One or more job ids (i.e. uuids)",
+        help="One or more job ids (i.e. uuids). Only the id is needed since "
+        "jobs with the same uuid belong to the same flow",
     ),
 ]
 
@@ -150,21 +163,18 @@ reverse_sort_flag_opt = Annotated[
 ]
 
 
-job_id_arg = Annotated[str, typer.Argument(help="The ID of the job (i.e. the uuid)")]
-
-db_id_arg = Annotated[
-    int, typer.Argument(help="The DB id of the job (i.e. an integer)")
+job_db_id_arg = Annotated[
+    str,
+    typer.Argument(
+        help="The ID of the job can the db id (i.e. an integer) or a string (i.e. the uuid)",
+        metavar="ID",
+    ),
 ]
-
-
-db_id_flag_opt = Annotated[
-    bool,
-    typer.Option(
-        "--db-id",
-        "-db",
-        help=(
-            "If set the id passed would be considered to be the DB id (i.e. an integer)"
-        ),
+job_index_arg = Annotated[
+    Optional[int],
+    typer.Argument(
+        help="The index of the job. If not defined the job with the largest index is selected",
+        metavar="INDEX",
     ),
 ]
 

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import uuid
 from contextlib import contextmanager
 from enum import Enum
 
@@ -121,6 +122,7 @@ def get_job_db_ids(job_db_id: str, job_index: int | None):
     except ValueError:
         db_id = None
         job_id = job_db_id
+        check_valid_uuid(job_id)
 
     if job_index and db_id is not None:
         out_console.print(
@@ -143,6 +145,7 @@ def get_job_ids_indexes(job_ids: list[str] | None) -> list[tuple[str, int]] | No
                 "(e.g. e1d66c4f-81db-4fff-bda2-2bf1d79d5961:2). "
                 f"Wrong format for {j}"
             )
+        check_valid_uuid(split[0])
         job_ids_indexes.append((split[0], int(split[1])))
 
     return job_ids_indexes
@@ -170,3 +173,14 @@ def cli_error_handler(func):
                 )
 
     return wrapper
+
+
+def check_valid_uuid(uuid_str):
+    try:
+        uuid_obj = uuid.UUID(uuid_str)
+        if str(uuid_obj) == uuid_str:
+            return
+    except ValueError:
+        pass
+
+    raise typer.BadParameter(f"UUID {uuid_str} is in the wrong format.")

--- a/src/jobflow_remote/fireworks/launchpad.py
+++ b/src/jobflow_remote/fireworks/launchpad.py
@@ -345,6 +345,12 @@ class RemoteLaunchPad:
     ) -> tuple[dict, list | None]:
         query: dict = {}
         sort: list | None = None
+
+        if (job_id is None) == (fw_id is None):
+            raise ValueError(
+                "One and only one among job_id and db_id should be defined"
+            )
+
         if fw_id:
             query["fw_id"] = fw_id
         if job_id:
@@ -363,8 +369,10 @@ class RemoteLaunchPad:
         job_id: str | None = None,
         job_index: int | None = None,
     ):
-        if job_id is None and fw_id is None:
-            raise ValueError("At least one among fw_id and job_id should be defined")
+        if (job_id is None) == (fw_id is None):
+            raise ValueError(
+                "One and only one among fw_id and job_id should be defined"
+            )
         if job_id:
             fw_id = self.get_fw_id_from_job_id(job_id, job_index)
         return fw_id, job_id

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -121,7 +121,7 @@ class JobController:
         self,
         job_ids: str | list[str] | None = None,
         db_ids: int | list[int] | None = None,
-        flow_id: str | None = None,
+        flow_ids: str | None = None,
         state: FlowState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
@@ -139,8 +139,8 @@ class JobController:
         if job_ids:
             query[f"fws.{FW_UUID_PATH}"] = {"$in": job_ids}
 
-        if flow_id:
-            query["metadata.flow_id"] = flow_id
+        if flow_ids:
+            query["metadata.flow_id"] = {"$in": flow_ids}
 
         if state:
             if state == FlowState.WAITING:
@@ -389,7 +389,7 @@ class JobController:
         self,
         job_ids: str | list[str] | None = None,
         db_ids: int | list[int] | None = None,
-        flow_id: str | None = None,
+        flow_ids: str | None = None,
         state: FlowState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
@@ -399,7 +399,7 @@ class JobController:
         query = self._build_query_wf(
             job_ids=job_ids,
             db_ids=db_ids,
-            flow_id=flow_id,
+            flow_ids=flow_ids,
             state=state,
             start_date=start_date,
             end_date=end_date,

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -4,6 +4,7 @@ import io
 import logging
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
+from typing import cast
 
 from fireworks import Firework
 from jobflow import JobStore
@@ -12,6 +13,7 @@ from monty.json import MontyDecoder
 from jobflow_remote.config.base import Project
 from jobflow_remote.config.manager import ConfigManager
 from jobflow_remote.fireworks.launchpad import (
+    FW_INDEX_PATH,
     FW_UUID_PATH,
     REMOTE_DOC_PATH,
     RemoteLaunchPad,
@@ -47,6 +49,7 @@ class JobController:
         self,
         job_id: str | None = None,
         db_id: str | None = None,
+        job_index: int | None = None,
         load_output: bool = False,
     ):
         fw, remote_run = self.rlpad.get_fw_remote_run_from_id(
@@ -63,7 +66,7 @@ class JobController:
 
     def _build_query_fw(
         self,
-        job_ids: str | list[str] | None = None,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
@@ -76,8 +79,9 @@ class JobController:
         if remote_state is not None:
             remote_state = [remote_state]
 
-        if job_ids is not None and not isinstance(job_ids, (list, tuple)):
-            job_ids = [job_ids]
+        if job_ids and not any(isinstance(ji, (list, tuple)) for ji in job_ids):
+            # without these cast mypy is confused about the type
+            job_ids = cast(list[tuple[str, int]], [job_ids])
         if db_ids is not None and not isinstance(db_ids, (list, tuple)):
             db_ids = [db_ids]
 
@@ -86,7 +90,11 @@ class JobController:
         if db_ids:
             query["fw_id"] = {"$in": db_ids}
         if job_ids:
-            query[FW_UUID_PATH] = {"$in": job_ids}
+            job_ids = cast(list[tuple[str, int]], job_ids)
+            or_list = []
+            for job_id, job_index in job_ids:
+                or_list.append({FW_UUID_PATH: job_id, FW_INDEX_PATH: job_index})
+            query["$or"] = or_list
 
         if state:
             fw_states, remote_state = state.to_states()
@@ -175,7 +183,7 @@ class JobController:
 
     def get_jobs_data(
         self,
-        job_ids: str | list[str] | None = None,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
@@ -243,7 +251,7 @@ class JobController:
 
     def get_jobs_info(
         self,
-        job_ids: str | list[str] | None = None,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
@@ -265,10 +273,13 @@ class JobController:
         return self.get_jobs_info_query(query=query, sort=sort, limit=limit)
 
     def get_job_info(
-        self, job_id: str | None, db_id: int | None, full: bool = False
+        self,
+        job_id: str | None,
+        db_id: int | None,
+        job_index: int | None = None,
+        full: bool = False,
     ) -> JobInfo | None:
-        self.check_ids(job_id, db_id)
-        query = self._build_query_fw(job_ids=job_id, db_ids=db_id)
+        query, sort = self.rlpad.generate_id_query(db_id, job_id, job_index)
 
         if full:
             proj = dict(job_info_projection)
@@ -279,27 +290,24 @@ class JobController:
                 }
             )
             data = list(
-                self.rlpad.get_fw_launch_remote_run_data(query=query, projection=proj)
+                self.rlpad.get_fw_launch_remote_run_data(
+                    query=query, projection=proj, sort=sort, limit=1
+                )
             )
         else:
             data = list(
-                self.rlpad.fireworks.find(query, projection=job_info_projection)
+                self.rlpad.fireworks.find(
+                    query, projection=job_info_projection, sort=sort, limit=1
+                )
             )
         if not data:
             return None
 
         return JobInfo.from_fw_dict(data[0])
 
-    @staticmethod
-    def check_ids(job_id: str | None, db_id: int | None):
-        if (job_id is None) == (db_id is None):
-            raise ValueError(
-                "One and only one among job_id and db_id should be defined"
-            )
-
     def rerun_jobs(
         self,
-        job_ids: str | list[str] | None = None,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
@@ -341,9 +349,12 @@ class JobController:
         return True
 
     def set_remote_state(
-        self, state: RemoteState, job_id: str | None, db_id: int | None
+        self,
+        state: RemoteState,
+        job_id: str | None,
+        db_id: int | None,
+        job_index: int | None = None,
     ) -> bool:
-        self.check_ids(job_id, db_id)
         values = {
             "state": state.value,
             "step_attempts": 0,
@@ -352,19 +363,27 @@ class JobController:
             "queue_state": None,
             "error": None,
         }
-        return self.rlpad.set_remote_values(values=values, job_id=job_id, fw_id=db_id)
+        return self.rlpad.set_remote_values(
+            values=values, job_id=job_id, fw_id=db_id, job_index=job_index
+        )
 
-    def reset_remote_attempts(self, job_id: str | None, db_id: int | None) -> bool:
-        self.check_ids(job_id, db_id)
+    def reset_remote_attempts(
+        self, job_id: str | None, db_id: int | None, job_index: int | None = None
+    ) -> bool:
         values = {
             "step_attempts": 0,
             "retry_time_limit": None,
         }
-        return self.rlpad.set_remote_values(values=values, job_id=job_id, fw_id=db_id)
+        return self.rlpad.set_remote_values(
+            values=values, job_id=job_id, fw_id=db_id, job_index=job_index
+        )
 
-    def reset_failed_state(self, job_id: str | None, db_id: int | None) -> bool:
-        self.check_ids(job_id, db_id)
-        return self.rlpad.reset_failed_state(job_id=job_id, fw_id=db_id)
+    def reset_failed_state(
+        self, job_id: str | None, db_id: int | None, job_index: int | None = None
+    ) -> bool:
+        return self.rlpad.reset_failed_state(
+            job_id=job_id, fw_id=db_id, job_index=job_index
+        )
 
     def get_flows_info(
         self,
@@ -426,7 +445,7 @@ class JobController:
 
     def remove_lock(
         self,
-        job_ids: str | list[str] | None = None,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,


### PR DESCRIPTION
Restoring the option to query based on job_id.

* for commands where a single id can be passed:
  *  the id can either be an integer or a string, it will then be recognized as a db_id or job_id depending on the type (thus the `--db-id` does not exist anymore)
  * an optional additional argument to specify the index has been added. if omitted the job corresponding to the last index will be used. 
  * query based on descending sort on the index
* for commands where multiple ids can be passed:
  * preserved the difference between job_ids and db_ids. Not sure if it would be easy to handle in case one passes a mix of the two if a single option is used. Could be enforced if it would be better to have a single option like in the previous type of commands
  * when querying based on job_ids the index is mandatory and should be provided in the form `UUID:INDEX` (e.g. `e1d66c4f-81db-4fff-bda2-2bf1d79d5961:2`)
  * the query is *not* an aggregation, using uuid+index to identify each job.
* when querying to get flows 
  * if job_ids are used the index is not need. Since all the jobs with the same uuid but different index will belong to the same flow it would be redundant.
  * passing the index will not work, but there is no check whether the index was actually passed in the format `UUID:INDEX`.It will just result it will simply not find the job, since there is no job with id with the form `e1d66c4f-81db-4fff-bda2-2bf1d79d5961:2`. Is it fine like this or should there be such a check? 
  * the query is the same as before
