### PR TITLE
jf flow info and other cli updates

### DIFF
--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -141,6 +141,33 @@ def format_job_info(job_info: JobInfo, show_none: bool = False):
     return render_scope(d)
 
 
+def format_flow_info(flow_info: FlowInfo):
+
+    title = f"Flow: {flow_info.name} - {flow_info.flow_id} - {flow_info.state.name}"
+    table = Table(title=title)
+    table.title_style = "bold"
+    table.add_column("DB id")
+    table.add_column("Name")
+    table.add_column("State [Remote]")
+    table.add_column("Job id  (Index)")
+    table.add_column("Worker")
+
+    for i, job_id in enumerate(flow_info.job_ids):
+        state = flow_info.job_states[i].name
+
+        row = [
+            str(flow_info.db_ids[i]),
+            flow_info.job_names[i],
+            state,
+            f"{job_id}  ({flow_info.job_indexes[i]})",
+            flow_info.workers[i],
+        ]
+
+        table.add_row(*row)
+
+    return table
+
+
 def get_exec_config_table(exec_config: dict[str, ExecutionConfig], verbosity: int = 0):
     table = Table(title="Execution config", show_lines=verbosity > 0)
     table.add_column("Name")

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -13,12 +13,15 @@ from jobflow_remote.cli.types import (
     days_opt,
     db_ids_opt,
     end_date_opt,
+    flow_ids_opt,
     job_db_id_arg,
     job_ids_indexes_opt,
     job_index_arg,
     job_state_opt,
     locked_opt,
     max_results_opt,
+    metadata_opt,
+    name_opt,
     query_opt,
     remote_state_arg,
     remote_state_opt,
@@ -30,6 +33,7 @@ from jobflow_remote.cli.types import (
 from jobflow_remote.cli.utils import (
     SortOption,
     check_incompatible_opt,
+    convert_metadata,
     exit_with_error_msg,
     exit_with_warning_msg,
     get_job_db_ids,
@@ -53,10 +57,13 @@ app.add_typer(app_job)
 def jobs_list(
     job_id: job_ids_indexes_opt = None,
     db_id: db_ids_opt = None,
+    flow_id: flow_ids_opt = None,
     state: job_state_opt = None,
     remote_state: remote_state_opt = None,
     start_date: start_date_opt = None,
     end_date: end_date_opt = None,
+    name: name_opt = None,
+    metadata: metadata_opt = None,
     days: days_opt = None,
     verbosity: verbosity_opt = 0,
     max_results: max_results_opt = 100,
@@ -71,6 +78,7 @@ def jobs_list(
     check_incompatible_opt({"state": state, "remote-state": remote_state})
     check_incompatible_opt({"start_date": start_date, "days": days})
     check_incompatible_opt({"end_date": end_date, "days": days})
+    metadata_dict = convert_metadata(metadata)
 
     job_ids_indexes = get_job_ids_indexes(job_id)
 
@@ -92,11 +100,14 @@ def jobs_list(
             jobs_info = jc.get_jobs_info(
                 job_ids=job_ids_indexes,
                 db_ids=db_id,
+                flow_ids=flow_id,
                 state=state,
                 remote_state=remote_state,
                 start_date=start_date,
                 locked=locked,
                 end_date=end_date,
+                name=name,
+                metadata=metadata_dict,
                 limit=max_results,
                 sort=sort,
             )

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -82,6 +82,28 @@ remote_state_opt = Annotated[
     ),
 ]
 
+name_opt = Annotated[
+    Optional[str],
+    typer.Option(
+        "--name",
+        "-n",
+        help="The name. A regex can be passed (e.g. .*test.*)",
+    ),
+]
+
+
+metadata_opt = Annotated[
+    Optional[str],
+    typer.Option(
+        "--metadata",
+        "-meta",
+        help="A string representing the metadata to be queried. Can be either"
+        " a single key=value pair or a string with the JSON representation "
+        "of a dictionary containing the mongoDB query for the metadata "
+        'subdocument (e.g \'{"key1.key2": 1, "key3": "test"}\')',
+    ),
+]
+
 
 remote_state_arg = Annotated[
     RemoteState, typer.Argument(help="One of the remote states")
@@ -176,7 +198,7 @@ reverse_sort_flag_opt = Annotated[
 job_db_id_arg = Annotated[
     str,
     typer.Argument(
-        help="The ID of the job can the db id (i.e. an integer) or a string (i.e. the uuid)",
+        help="The ID of the job. Can be the db id (i.e. an integer) or a string (i.e. the uuid)",
         metavar="ID",
     ),
 ]
@@ -185,6 +207,15 @@ job_index_arg = Annotated[
     typer.Argument(
         help="The index of the job. If not defined the job with the largest index is selected",
         metavar="INDEX",
+    ),
+]
+
+
+flow_db_id_arg = Annotated[
+    str,
+    typer.Argument(
+        help="The ID of the flow. Can the db id (i.e. an integer) or a string (i.e. the uuid)",
+        metavar="ID",
     ),
 ]
 
@@ -198,6 +229,16 @@ force_opt = Annotated[
     ),
 ]
 
+
+job_flow_id_flag_opt = Annotated[
+    bool,
+    typer.Option(
+        "--job",
+        "-j",
+        help="The passed ID will be the ID of one of the jobs"
+        " belonging to the flow, instead of the ID of the flow.",
+    ),
+]
 
 locked_opt = Annotated[
     bool,

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -87,7 +87,7 @@ name_opt = Annotated[
     typer.Option(
         "--name",
         "-n",
-        help="The name. A regex can be passed (e.g. .*test.*)",
+        help="The name. Default is an exact match, but all conventions from python fnmatch can be used (e.g. *test*)",
     ),
 ]
 

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import json
 import uuid
 from contextlib import contextmanager
 from enum import Enum
@@ -184,3 +185,19 @@ def check_valid_uuid(uuid_str):
         pass
 
     raise typer.BadParameter(f"UUID {uuid_str} is in the wrong format.")
+
+
+def convert_metadata(string_metadata: str | None) -> dict | None:
+    if not string_metadata:
+        return None
+
+    try:
+        metadata = json.loads(string_metadata)
+    except json.JSONDecodeError:
+        split = string_metadata.split("=")
+        if len(split) != 2:
+            raise typer.BadParameter(f"Wrong format for metadata {string_metadata}")
+
+        metadata = {split[0]: split[1]}
+
+    return metadata

--- a/src/jobflow_remote/fireworks/launchpad.py
+++ b/src/jobflow_remote/fireworks/launchpad.py
@@ -21,6 +21,7 @@ from jobflow_remote.utils.db import MongoLock
 logger = logging.getLogger(__name__)
 
 
+FW_JOB_PATH = "spec._tasks.job"
 FW_UUID_PATH = "spec._tasks.job.uuid"
 FW_INDEX_PATH = "spec._tasks.job.index"
 REMOTE_DOC_PATH = "spec.remote"

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import fnmatch
 import io
 import logging
 from contextlib import redirect_stdout
@@ -125,7 +126,7 @@ class JobController:
             query[f"{REMOTE_DOC_PATH}.{MongoLock.LOCK_KEY}"] = {"$exists": True}
 
         if name:
-            query["name"] = {"$regex": name}
+            query["name"] = {"$regex": fnmatch.translate(name)}
 
         if metadata:
             metadata_dict = {
@@ -212,7 +213,7 @@ class JobController:
             query["updated_on"] = {"$lte": end_date_str}
 
         if name:
-            query["name"] = {"$regex": name}
+            query["name"] = {"$regex": fnmatch.translate(name)}
 
         return query
 

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -60,7 +60,7 @@ class JobController:
         state = JobState.from_states(fw.state, remote_run.state if remote_run else None)
         output = None
         jobstore = fw.tasks[0].get("store") or self.jobstore
-        if load_output and state == RemoteState.COMPLETED:
+        if load_output and state == JobState.COMPLETED:
             output = jobstore.query_one({"uuid": job_id}, load=True)
 
         return JobData(job=job, state=state, db_id=fw.fw_id, output=output)
@@ -258,7 +258,7 @@ class JobController:
             info = JobInfo.from_fw_dict(fw_dict)
 
             output = None
-            if state == RemoteState.COMPLETED and load_output:
+            if state == JobState.COMPLETED and load_output:
                 output = store.query_one({"uuid": job.uuid}, load=True)
             jobs_data.append(
                 JobData(

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -14,6 +14,7 @@ from jobflow_remote.config.base import Project
 from jobflow_remote.config.manager import ConfigManager
 from jobflow_remote.fireworks.launchpad import (
     FW_INDEX_PATH,
+    FW_JOB_PATH,
     FW_UUID_PATH,
     REMOTE_DOC_PATH,
     RemoteLaunchPad,
@@ -53,7 +54,7 @@ class JobController:
         load_output: bool = False,
     ):
         fw, remote_run = self.rlpad.get_fw_remote_run_from_id(
-            job_id=job_id, fw_id=db_id
+            job_id=job_id, fw_id=db_id, job_index=job_index
         )
         job = fw.tasks[0].get("job")
         state = JobState.from_states(fw.state, remote_run.state if remote_run else None)
@@ -68,11 +69,14 @@ class JobController:
         self,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
+        flow_ids: str | list[str] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
         locked: bool = False,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
+        metadata: dict | None = None,
     ) -> dict:
         if state is not None and remote_state is not None:
             raise ValueError("state and remote_state cannot be queried simultaneously")
@@ -84,6 +88,8 @@ class JobController:
             job_ids = cast(list[tuple[str, int]], [job_ids])
         if db_ids is not None and not isinstance(db_ids, (list, tuple)):
             db_ids = [db_ids]
+        if flow_ids and not isinstance(flow_ids, (list, tuple)):
+            flow_ids = [flow_ids]
 
         query: dict = {}
 
@@ -95,6 +101,9 @@ class JobController:
             for job_id, job_index in job_ids:
                 or_list.append({FW_UUID_PATH: job_id, FW_INDEX_PATH: job_index})
             query["$or"] = or_list
+
+        if flow_ids:
+            query[f"{FW_JOB_PATH}.hosts"] = {"$in": flow_ids}
 
         if state:
             fw_states, remote_state = state.to_states()
@@ -115,6 +124,15 @@ class JobController:
         if locked:
             query[f"{REMOTE_DOC_PATH}.{MongoLock.LOCK_KEY}"] = {"$exists": True}
 
+        if name:
+            query["name"] = {"$regex": name}
+
+        if metadata:
+            metadata_dict = {
+                f"{FW_JOB_PATH}.metadata.{k}": v for k, v in metadata.items()
+            }
+            query.update(metadata_dict)
+
         return query
 
     def _build_query_wf(
@@ -125,6 +143,7 @@ class JobController:
         state: FlowState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
     ) -> dict:
 
         if job_ids is not None and not isinstance(job_ids, (list, tuple)):
@@ -166,7 +185,12 @@ class JobController:
             elif state == FlowState.FAILED:
                 query["$or"] = [
                     {"state": "FIZZLED"},
-                    {"$and": [{"state": "DEFUSED"}, {"fws.state": {"$in": ["FIZZLED"]}}]},
+                    {
+                        "$and": [
+                            {"state": "DEFUSED"},
+                            {"fws.state": {"$in": ["FIZZLED"]}},
+                        ]
+                    },
                     {
                         f"fws.{REMOTE_DOC_PATH}.state": {
                             "$in": [JobState.FAILED.value, JobState.REMOTE_ERROR.value]
@@ -187,16 +211,22 @@ class JobController:
             end_date_str = end_date.astimezone(timezone.utc)
             query["updated_on"] = {"$lte": end_date_str}
 
+        if name:
+            query["name"] = {"$regex": name}
+
         return query
 
     def get_jobs_data(
         self,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
+        flow_ids: str | list[str] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
+        metadata: dict | None = None,
         sort: dict | None = None,
         limit: int = 0,
         load_output: bool = False,
@@ -204,10 +234,13 @@ class JobController:
         query = self._build_query_fw(
             job_ids=job_ids,
             db_ids=db_ids,
+            flow_ids=flow_ids,
             state=state,
             remote_state=remote_state,
             start_date=start_date,
             end_date=end_date,
+            name=name,
+            metadata=metadata,
         )
 
         data = self.rlpad.fireworks.find(query, sort=sort, limit=limit)
@@ -261,10 +294,13 @@ class JobController:
         self,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
+        flow_ids: str | list[str] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
+        metadata: dict | None = None,
         locked: bool = False,
         sort: list[tuple] | None = None,
         limit: int = 0,
@@ -272,11 +308,14 @@ class JobController:
         query = self._build_query_fw(
             job_ids=job_ids,
             db_ids=db_ids,
+            flow_ids=flow_ids,
             state=state,
             remote_state=remote_state,
             locked=locked,
             start_date=start_date,
             end_date=end_date,
+            name=name,
+            metadata=metadata,
         )
         return self.get_jobs_info_query(query=query, sort=sort, limit=limit)
 
@@ -317,20 +356,26 @@ class JobController:
         self,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
+        flow_ids: str | list[str] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
+        metadata: dict | None = None,
         sort: dict | None = None,
         limit: int = 0,
     ) -> list[int]:
         query = self._build_query_fw(
             job_ids=job_ids,
             db_ids=db_ids,
+            flow_ids=flow_ids,
             state=state,
             remote_state=remote_state,
             start_date=start_date,
             end_date=end_date,
+            name=name,
+            metadata=metadata,
         )
 
         fw_ids = self.rlpad.get_fw_ids(query=query, sort=sort, limit=limit)
@@ -401,6 +446,7 @@ class JobController:
         state: FlowState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
         sort: list[tuple] | None = None,
         limit: int = 0,
     ) -> list[FlowInfo]:
@@ -411,6 +457,7 @@ class JobController:
             state=state,
             start_date=start_date,
             end_date=end_date,
+            name=name,
         )
 
         data = self.rlpad.get_wf_fw_data(
@@ -455,19 +502,25 @@ class JobController:
         self,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: int | list[int] | None = None,
+        flow_ids: str | list[str] | None = None,
         state: JobState | None = None,
         remote_state: RemoteState | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        name: str | None = None,
+        metadata: dict | None = None,
     ) -> int:
         query = self._build_query_fw(
             job_ids=job_ids,
             db_ids=db_ids,
+            flow_ids=flow_ids,
             state=state,
             remote_state=remote_state,
             start_date=start_date,
             end_date=end_date,
             locked=True,
+            name=name,
+            metadata=metadata,
         )
 
         return self.rlpad.remove_lock(query=query)


### PR DESCRIPTION
* new CLI command: `jf flow info ID`. Since there are few flow related data, aside from those belonging to the single jobs, the output is mainly a table with the jobs belonging to the flow.
* option to search jobs based on flow_id, name and metadata
* option to search flow based on name