### PR TITLE
Run CI on PRs to develop branch

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,7 +4,7 @@ on:
   push:
 
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   lint:


### PR DESCRIPTION
If `develop` is the default branch of this repo (at least for now), then it would be helpful to run the CI for PRs to it. This is required to properly test #27.