### PR TITLE
Add index to the folder name

### DIFF
--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -336,7 +336,7 @@ class Runner:
             except Exception:
                 logging.error(f"error while closing the store {store}", exc_info=True)
 
-        remote_path = get_job_path(job.uuid, fw_job_data.worker.work_dir)
+        remote_path = get_job_path(job.uuid, job.index, fw_job_data.worker.work_dir)
 
         # Set the value of the original store for dynamical workflow. Usually it
         # will be None don't add the serializer, at this stage the default_orjson
@@ -436,7 +436,7 @@ class Runner:
 
         remote_path = remote_doc["run_dir"]
         loca_base_dir = Path(self.project.tmp_dir, "download")
-        local_path = get_job_path(job.uuid, loca_base_dir)
+        local_path = get_job_path(job.uuid, job.index, loca_base_dir)
 
         makedirs_p(local_path)
 
@@ -465,7 +465,9 @@ class Runner:
         fw_job_data = self.get_fw_data(doc)
 
         loca_base_dir = Path(self.project.tmp_dir, "download")
-        local_path = get_job_path(fw_job_data.job.uuid, loca_base_dir)
+        local_path = get_job_path(
+            fw_job_data.job.uuid, fw_job_data.job.index, loca_base_dir
+        )
 
         try:
             remote_data = loadfn(Path(local_path, "FW_offline.json"), cls=None)

--- a/src/jobflow_remote/remote/data.py
+++ b/src/jobflow_remote/remote/data.py
@@ -11,13 +11,13 @@ from maggma.stores.mongolike import JSONStore
 from jobflow_remote.utils.data import uuid_to_path
 
 
-def get_job_path(job_id: str, base_path: str | Path | None = None) -> str:
+def get_job_path(job_id: str, index: int, base_path: str | Path | None = None) -> str:
     if base_path:
         base_path = Path(base_path)
     else:
         base_path = Path()
 
-    relative_path = uuid_to_path(job_id)
+    relative_path = uuid_to_path(job_id, index)
     return str(base_path / relative_path)
 
 

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -77,7 +77,7 @@ def check_dict_keywords(obj: Any, keywords: list[str]) -> bool:
     return False
 
 
-def uuid_to_path(uuid: str, num_subdirs: int = 3, subdir_len: int = 2):
+def uuid_to_path(uuid: str, index: int = 1, num_subdirs: int = 3, subdir_len: int = 2):
     u = UUID(uuid)
     u_hex = u.hex
 
@@ -87,8 +87,11 @@ def uuid_to_path(uuid: str, num_subdirs: int = 3, subdir_len: int = 2):
         for i in range(0, num_subdirs * subdir_len, subdir_len)
     ]
 
+    # add the index to the final dir name
+    dir_name = f"{uuid}_{index}"
+
     # Combine root directory and subdirectories to form the final path
-    return os.path.join(*subdirs, uuid)
+    return os.path.join(*subdirs, dir_name)
 
 
 def store_from_dict(store_dict: dict) -> Store:


### PR DESCRIPTION
Bugfix: the execution folder does not consider the index, ending up overwriting the data when the job is replaced. Added the index to the folder name.