### PR TITLE
Add integration test for job with a callable as a kwarg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ rst-roles = "class, func, ref, obj"
 [tool.mypy]
 ignore_missing_imports = true
 no_strict_optional = true
+follow_imports = "skip"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -1,4 +1,5 @@
 """A series of toy workflows that can be used for testing."""
+from typing import Callable, Optional, Union
 
 from jobflow import job
 
@@ -20,3 +21,15 @@ def write_file(n):
     with open("results.txt", "w") as f:
         f.write(str(n))
     return
+
+
+@job
+def arithmetic(
+    a: Union[float, list[float]],
+    b: Union[float, list[float]],
+    op: Optional[Callable] = None,
+) -> Optional[float]:
+    if op:
+        return op(a, b)
+
+    return None


### PR DESCRIPTION
Related to #44 and builds atop #32, showing how callables can be used as keyword arguments to jobs. Note that this doesn't seem to work for `lambda`s (see the default kwarg for `jobflow_remote.testing.arithmetic`).

Closes #45.