### PR TITLE
Pin dependency versions for testing, add PyPI release and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 50
+  target-branch: develop
+  labels:
+  - dependency_updates
+  rebase-strategy: "disabled"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "05:33"
+  target-branch: develop
+  labels:
+  - CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install -e .[all]
+        pip install -r requirements/requirements.txt
+        pip install -e .[docs]
 
     - name: Set git config
       run: |
@@ -62,7 +63,6 @@ jobs:
       run: |
         # Required to generate rst files from markdown
         sudo apt install pandoc
-        pip install .[docs]
 
     - name: Build Sphinx docs
       working-directory: doc
@@ -92,7 +92,7 @@ jobs:
         release_branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
-        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,skip_changelog"
+        exclude_labels: "duplicate,question,invalid,wontfix,dependency_updates,CI,skip_changelog"
 
     - name: Append changelog to release body
       run: |
@@ -113,6 +113,12 @@ jobs:
         user: __token__
         password: ${{ secrets.TEST_PYPI_PASSWORD }}
         repository-url: https://test.pypi.org/legacy/
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
 
   deploy_docs:
     if: github.repository == 'matgenix/jobflow-remote' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[strict,tests,dev]
+          pip install -r requirements/requirements.txt
+          pip install .[dev]
 
       - name: Lint
         run: pre-commit run --all-files --show-diff-on-failure
@@ -52,7 +53,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-            pip install .[strict,tests,docs]
+          pip install -r requirements/requirements.txt
+          pip install .[tests]
 
       - name: Unit tests
         run: pytest --cov=jobflow_remote --cov-report=xml --ignore tests/integration
@@ -87,6 +89,7 @@ jobs:
         pip install -U setuptools wheel
         # Required to generate rst files from markdown
         sudo apt install pandoc
+        pip install -r requirements/requirements.txt
         pip install .[docs]
 
     - name: Build Sphinx docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 42", "versioningit ~= 1.0", "wheel"]
+requires = ["setuptools >= 42", "versioningit  ~=  1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -25,18 +25,18 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies =[
-    "jobflow",
-    "pydantic>=2.0.1",
-    "fabric",
-    "tomlkit",
-    "qtoolkit",
-    "typer",
-    "rich",
-    "psutil",
-    "supervisor",
-    "ruamel.yaml",
-    "schedule",
-    "flufl.lock"
+    "jobflow >= 0.1.14",
+    "pydantic ~= 2.5",
+    "fabric ~= 3.2",
+    "tomlkit ~= 0.12",
+    "qtoolkit ~= 0.1",
+    "typer ~= 0.9",
+    "rich ~= 13.7",
+    "psutil ~= 5.9",
+    "supervisor ~= 4.2",
+    "ruamel.yaml ~= 0.17",
+    "schedule ~= 1.2",
+    "flufl.lock ~= 8.0"
 ]
 
 [project.optional-dependencies]
@@ -44,12 +44,9 @@ dev = [
     "pre-commit>=3.0.0",
 ]
 tests = [
-    "pytest==7.2.1",
-    "pytest-cov==4.0.0",
-    "docker~=7.0",
-    ]
-maintain = [
-    "git-changelog>=0.6",
+    "pytest ~= 7.2",
+    "pytest-cov ~= 4.0",
+    "docker ~= 7.0",
 ]
 docs = [
     "sphinx",
@@ -59,7 +56,6 @@ docs = [
     "autodoc_pydantic>=2.0.0",
     "sphinxcontrib-mermaid"
 ]
-strict = []
 
 [project.scripts]
 jf = "jobflow_remote.cli.jf:app"

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -1,0 +1,9 @@
+# Strict requirements
+
+These files contain pinned direct dependencies for use in testing, monitored by
+dependabot to ensure version upgrades compatible with `pyproject.toml` do not
+break the released version.
+
+In cases where dependabot updates a requirements file and the tests no longer
+pass, this may indicate that the supported versions in `pyproject.toml` need to
+be upgraded (and a release made).

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,12 @@
+jobflow==0.1.17
+pydantic==2.5.3
+fabric==3.2.2
+tomlkit==0.12.3
+qtoolkit==0.1.0
+typer==0.9.0
+rich==13.7.0
+psutil==5.9.8
+supervisor==4.2.5
+ruamel.yaml==0.17.35
+schedule==1.2.1
+flufl.lock==8.0.2


### PR DESCRIPTION
This PR addresses some remaining issues from #53.

- [x] Add pinned dependency versions in a `requirements.txt` file that can be monitored by dependabot
- [x] Add some loose pins in `pyproject.toml` to avoid major version breakages
- [x] Update CI to use these pins
- [x] Update CI to do a proper PyPI release if Test PyPI works fine
- [x] Enable dependabot

Perhaps @gpetretto and @davidwaroquiers we could briefly discuss some of this as part of the review (either on here or on teams)