### PR TITLE
Add testing and runtime checks for additional stores

### DIFF
--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -45,7 +45,20 @@ def check_env_var() -> str:
 
 @job(big_files="data")
 def add_big(a: float, b: float):
-    """Adds two numbers together and writes the answer to an artificially large file."""
+    """Adds two numbers together and writes the answer to an artificially large file
+    which is stored in a pre-defined store."""
+    import pathlib
+
+    result = a + b
+    with open("file.txt", "w") as f:
+        f.writelines([f"{result}"] * int(1e5))
+    return Response({"data": pathlib.Path("file.txt"), "result": a + b})
+
+
+@job(undefined_store="data")
+def add_big_undefined_store(a: float, b: float):
+    """Adds two numbers together and writes the answer to an artificially large file
+    which is attempted to be stored in a undefined store."""
     import pathlib
 
     result = a + b

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -43,16 +43,16 @@ def check_env_var() -> str:
     return os.environ.get("TESTING_ENV_VAR", "unset")
 
 
-@job(big_files="data")
+@job(big_data="data")
 def add_big(a: float, b: float):
-    """Adds two numbers together and writes the answer to an artificially large file
-    which is stored in a pre-defined store."""
-    import pathlib
+    """Adds two numbers together and inflates the answer
+    to a large list list and tries to store that within
+    the defined store.
 
+    """
     result = a + b
-    with open("file.txt", "w") as f:
-        f.writelines([f"{result}"] * int(1e5))
-    return Response({"data": pathlib.Path("file.txt"), "result": a + b})
+    big_array = [result] * 5_000
+    return Response({"data": big_array, "result": a + b})
 
 
 @job(undefined_store="data")

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Callable, Optional, Union
 
-from jobflow import job
+from jobflow import Response, job
 
 
 @job
@@ -41,3 +41,14 @@ def check_env_var() -> str:
     import os
 
     return os.environ.get("TESTING_ENV_VAR", "unset")
+
+
+@job(big_files="data")
+def add_big(a: float, b: float):
+    """Adds two numbers together and writes the answer to an artificially large file."""
+    import pathlib
+
+    result = a + b
+    with open("file.txt", "w") as f:
+        f.writelines([f"{result}"] * int(1e5))
+    return Response({"data": pathlib.Path("file.txt"), "result": a + b})

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -198,7 +198,7 @@ def write_tmp_settings(
                 "collection_name": "docs",
             },
             "additional_stores": {
-                "big_files": {
+                "big_data": {
                     "type": "GridFSStore",
                     "database": store_database_name,
                     "host": "localhost",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -196,7 +196,16 @@ def write_tmp_settings(
                 "host": "localhost",
                 "port": db_port,
                 "collection_name": "docs",
-            }
+            },
+            "additional_stores": {
+                "big_files": {
+                    "type": "GridFSStore",
+                    "database": store_database_name,
+                    "host": "localhost",
+                    "port": db_port,
+                    "collection_name": "data",
+                },
+            },
         },
         queue={
             "store": {

--- a/tests/integration/test_slurm.py
+++ b/tests/integration/test_slurm.py
@@ -259,7 +259,7 @@ def test_additional_stores(worker, job_controller):
     runner.run(ticks=10)
 
     doc = job_controller.get_jobs({})[0]
-    fs = job_controller.jobstore.additional_stores["big_files"]
+    fs = job_controller.jobstore.additional_stores["big_data"]
     assert fs.count({"job_uuid": doc["job"]["uuid"]}) == 1
     assert job_controller.count_jobs(state=JobState.COMPLETED) == 1
     assert job_controller.count_flows(state=FlowState.COMPLETED) == 1
@@ -279,7 +279,7 @@ def test_undefined_additional_stores(worker, job_controller):
 
     from jobflow_remote import submit_flow
     from jobflow_remote.jobs.runner import Runner
-    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing import add_big_undefined_store
 
     job = add_big_undefined_store(100, 100)
@@ -293,5 +293,4 @@ def test_undefined_additional_stores(worker, job_controller):
     runner.run(ticks=10)
 
     # The job should fail, as the additional store is not defined
-    assert job_controller.count_jobs(state=JobState.FAILED) == 1
-    assert job_controller.count_flows(state=FlowState.FAILED) == 1
+    assert job_controller.count_jobs(state=JobState.REMOTE_ERROR) == 1

--- a/tests/integration/test_slurm.py
+++ b/tests/integration/test_slurm.py
@@ -292,8 +292,6 @@ def test_undefined_additional_stores(worker, job_controller):
     runner = Runner()
     runner.run(ticks=10)
 
-    # Probably this should error somewhere
-    doc = job_controller.get_jobs({})[0]
-    assert job_controller.count_jobs(state=JobState.COMPLETED) == 1
-    assert job_controller.count_flows(state=FlowState.COMPLETED) == 1
-    assert job_controller.jobstore.get_output(uuid=doc["job"]["uuid"])["result"] == 200
+    # The job should fail, as the additional store is not defined
+    assert job_controller.count_jobs(state=JobState.FAILED) == 1
+    assert job_controller.count_flows(state=FlowState.FAILED) == 1


### PR DESCRIPTION
This PR adds some integration tests that make use of `additional_stores`. In the process, I also added a check that makes sure that any `additional_stores` requested by a job are checked before the job executes, rather than failing afterwards.

We could also add a check at submission time for this, which should be a future PR.

Closes #76 