### PR TITLE
Add integration tests for MFA-enabled SSH/Slurm container

### DIFF
--- a/tests/integration/dockerfiles/Dockerfile.slurm.mfa
+++ b/tests/integration/dockerfiles/Dockerfile.slurm.mfa
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:experimental
+# NB: this image is identical to the slurm base image
+# except that it has MFA enabled for ssh
+# Unfortunately this cannot be converted into a single
+# multi-stage build dockerfile until the Docker Python SDK
+# supports BuildKit (see https://github.com/docker/docker-py/issues/2230)
+
+# Using the slurm base image, run an ssh server and install jobflow
+FROM nathanhess/slurm:full AS base
+ARG USERNAME=jobflow
+ARG PASSWORD=jobflow
+WORKDIR /opt
+USER root
+
+# Install OpenSSH server and set it to run on startup
+RUN apt update && apt install -y openssh-server && apt clean && rm -rf /var/lib/apt/lists/*
+RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+RUN sed -ie 's/^SCRIPT/service ssh start\nSCRIPT/g' /etc/startup.sh
+
+# Create desired user with blank password then give user access to startup script as sudo without password
+# See https://github.com/nathan-hess/docker-slurm/blob/a62133d66d624d9ff0ccefbd41a0b1b2abcb9925/dockerfile_base/Dockerfile#L62C1-L65C1
+RUN useradd -rm -d /home/${USERNAME} -s /bin/bash ${USERNAME} && usermod -a -G sudo ${USERNAME}
+RUN echo ${USERNAME}:${PASSWORD} | chpasswd
+RUN printf "${USERNAME} ALL=(root:root) NOPASSWD: /etc/startup.sh\n" >> /etc/sudoers.d/startup \
+    && chmod 0440 /etc/sudoers.d/startup \
+    && visudo -c
+
+# Reset workdir and make jobflow data directory
+WORKDIR /home/${USERNAME}
+USER ${USERNAME}
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Install jobflow from directory, assuming container
+# is built at the root of the jobflow repo
+RUN mkdir jobflow-remote
+COPY src/jobflow_remote jobflow-remote/src/jobflow_remote
+COPY pyproject.toml jobflow-remote/
+
+# versioningit refuses to install a package without its full git history
+# so here we remove versioningit config from pyproject.toml as we don't need
+# the full version number (which allows us to cache many more layers)
+RUN sed -i '/\[tool.versioningit.vcs\]/,+3d' jobflow-remote/pyproject.toml
+
+# Annoyingly we want to use this with the Python SDK
+# which does not support buildkit yet
+# so cannot use --chmod in the copy directly and
+# we have to become root for this step
+USER root
+RUN sudo chmod -R 0777 jobflow-remote
+USER ${USERNAME}
+
+# Install jobflow in a local native virtualenv
+WORKDIR /home/${USERNAME}/jobflow-remote
+# RUN git config --global --add safe.directory /home/${USERNAME}/jobflow-remote
+RUN python3 -m venv /home/${USERNAME}/.venv
+RUN /home/${USERNAME}/.venv/bin/pip install -U pip
+RUN /home/${USERNAME}/.venv/bin/pip install --verbose -e .
+
+# Make a job directory for jobflow
+WORKDIR /home/${USERNAME}
+RUN mkdir jfr
+
+# Install and configure MFA
+USER root
+RUN apt update && apt install -y libpam-google-authenticator && apt clean && rm -rf /var/lib/apt/lists/*
+# Add MFA to sshd pam config: `nullok` comes from the README here: https://github.com/google/google-authenticator-libpam?tab=readme-ov-file#setting-up-a-user
+RUN echo "auth required pam_google_authenticator.so nullok echo_verification_code" >> /etc/pam.d/sshd
+RUN sed -i 's/#PasswordAuthentication yes/ChallengeResponseAuthentication yes/g' /etc/ssh/sshd_config
+RUN cat /etc/ssh/sshd_config
+
+# Configure MFA for jobflow user
+USER ${USERNAME}
+# Secret key
+RUN echo "3GWUG4NXEEG7KQEXBYOT4AJH3Q" > /home/${USERNAME}/.google_authenticator
+# Settings (weird quotes necessary)
+RUN echo '" WINDOW_SIZE 17' >> /home/${USERNAME}/.google_authenticator
+RUN echo '" TOTP_AUTH' >> /home/${USERNAME}/.google_authenticator
+# Emergency backup codes
+RUN echo "13802822" >> /home/${USERNAME}/.google_authenticator
+RUN cat /home/${USERNAME}/.google_authenticator
+# Set appropriate permissions otherwise PAM fails
+RUN chmod 600 /home/${USERNAME}/.google_authenticator

--- a/tests/integration/test_slurm.py
+++ b/tests/integration/test_slurm.py
@@ -15,10 +15,10 @@ def test_project_init(random_project_name):
     assert len(cm.projects) == 1
     assert cm.projects[random_project_name]
     project = cm.get_project()
-    assert len(project.workers) == 2
+    assert len(project.workers) == 3
 
 
-def test_paramiko_ssh_connection(job_controller, slurm_ssh_port):
+def test_paramiko_ssh_connection(slurm_ssh_port):
     from paramiko import SSHClient
     from paramiko.client import WarningPolicy
 
@@ -27,6 +27,22 @@ def test_paramiko_ssh_connection(job_controller, slurm_ssh_port):
     client.connect(
         "localhost",
         port=slurm_ssh_port,
+        username="jobflow",
+        password="jobflow",
+        look_for_keys=False,
+        allow_agent=False,
+    )
+
+
+def test_paramiko_ssh_mfa_connection(slurm_ssh_mfa_port):
+    from paramiko import SSHClient
+    from paramiko.client import WarningPolicy
+
+    client = SSHClient()
+    client.set_missing_host_key_policy(WarningPolicy)
+    client.connect(
+        "localhost",
+        port=slurm_ssh_mfa_port,
         username="jobflow",
         password="jobflow",
         look_for_keys=False,
@@ -43,6 +59,7 @@ def test_project_check(job_controller, capsys):
     expected = [
         "✓ Worker test_local_worker",
         "✓ Worker test_remote_worker",
+        "✓ Worker test_remote_worker_mfa",
         "✓ Jobstore",
         "✓ Queue store",
     ]
@@ -52,7 +69,7 @@ def test_project_check(job_controller, capsys):
 
 @pytest.mark.parametrize(
     "worker",
-    ["test_local_worker", "test_remote_worker"],
+    ["test_local_worker", "test_remote_worker", "test_remote_worker_mfa"],
 )
 def test_submit_flow(worker, job_controller):
     from jobflow import Flow
@@ -90,7 +107,7 @@ def test_submit_flow(worker, job_controller):
 
 @pytest.mark.parametrize(
     "worker",
-    ["test_local_worker", "test_remote_worker"],
+    ["test_local_worker", "test_remote_worker", "test_remote_worker_mfa"],
 )
 def test_submit_flow_with_dependencies(worker, job_controller):
     from jobflow import Flow
@@ -136,7 +153,7 @@ def test_submit_flow_with_dependencies(worker, job_controller):
 
 @pytest.mark.parametrize(
     "worker",
-    ["test_local_worker", "test_remote_worker"],
+    ["test_local_worker", "test_remote_worker", "test_remote_worker_mfa"],
 )
 def test_job_with_callable_kwarg(worker, job_controller):
     """Test whether a callable can be successfully provided as a keyword
@@ -180,7 +197,7 @@ def test_job_with_callable_kwarg(worker, job_controller):
 
 @pytest.mark.parametrize(
     "worker",
-    ["test_local_worker", "test_remote_worker"],
+    ["test_local_worker", "test_remote_worker", "test_remote_worker_mfa"],
 )
 def test_expected_failure(worker, job_controller):
     from jobflow import Flow
@@ -209,7 +226,7 @@ def test_expected_failure(worker, job_controller):
 
 @pytest.mark.parametrize(
     "worker",
-    ["test_local_worker", "test_remote_worker"],
+    ["test_local_worker", "test_remote_worker", "test_remote_worker_mfa"],
 )
 def test_exec_config(worker, job_controller, random_project_name):
     """Tests that an environment variable set in the exec config


### PR DESCRIPTION
Related to #58.

This PR adds a test environment for an MFA-enabled SSH/Slurm worker. It uses the [google-authenticator-libpam](https://github.com/google/google-authenticator-libpam) wrapper for Ubuntu to set up time-based MFA on the default `jobflow` user, with a pre-defined emergency backup code (which can only be used for one login without container rebuild).

Currently, the tests fail, but should probably be upgraded to instead ensure that sensible errors are returned for the MFA enabled worker.

This is hopefully a **somewhat** realistic emulation of an MFA-enabled supercomputer (perhaps excluding the backup codes), and can be used to test potential future workarounds involving multiplexing or otherwise.

Note, as stated in the Dockerfile.slurm.mfa header, although the two integration test dockerfiles are the same except for the final build stage, as the Docker Python SDK does not support BuildKit (https://github.com/docker/docker-py/issues/2230), we cannot use multi-stage builds here.