### PR TITLE
Reduce pydantic pin to allow installation of `atomate2[strict]==0.0.13`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies =[
     "jobflow >= 0.1.14",
-    "pydantic ~= 2.5",
+    "pydantic ~= 2.4",
     "fabric ~= 3.2",
     "tomlkit ~= 0.12",
     "qtoolkit ~= 0.1, >= 0.1.3",


### PR DESCRIPTION
Currently atomate2 cannot be installed without strict dependencies, and unfortunately those strict dependencies are not compatible with those laid out in our `pyproject.toml`. This PR lowers the min version of pydantic to fix this.