### PR TITLE
Add options for remote JobStore

### DIFF
--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -540,9 +540,14 @@ class Project(BaseModel):
     )
     jobstore: dict = Field(
         default_factory=lambda: dict(DEFAULT_JOBSTORE),
-        description="The JobStore used for the input. Can contain the monty "
-        "serialized dictionary or the Store int the Jobflow format",
+        description="The JobStore used for the output. Can contain the monty "
+        "serialized dictionary or the Store in the Jobflow format",
         validate_default=True,
+    )
+    remote_jobstore: Optional[dict] = Field(
+        None,
+        description="The JobStore used for the data transfer between the Runner"
+        "and the workers. Can be a string with the standard values",
     )
     metadata: Optional[dict] = Field(
         None, description="A dictionary with metadata associated to the project"

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2820,7 +2820,9 @@ class JobController:
                     self.update_flow_state(host_flow_id)
                     return True
 
-                remote_store = get_remote_store(store, local_path)
+                remote_store = get_remote_store(
+                    store, local_path, self.project.remote_jobstore
+                )
 
                 update_store(store, remote_store, job_doc["db_id"])
 

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -576,7 +576,7 @@ class Runner:
         # serializer could undergo refactoring and this could break deserialization
         # of older FWs. It is set in the FireTask at runtime.
         remote_store = get_remote_store(
-            store=store, launch_dir=remote_path, add_orjson_serializer=False
+            store=store, work_dir=remote_path, config_dict=self.project.remote_jobstore
         )
 
         created = host.mkdir(remote_path)
@@ -745,7 +745,11 @@ class Runner:
             makedirs_p(local_path)
 
             fnames = [OUT_FILENAME]
-            fnames.extend(get_remote_store_filenames(store))
+            fnames.extend(
+                get_remote_store_filenames(
+                    store, config_dict=self.project.remote_jobstore
+                )
+            )
 
             for fname in fnames:
                 # in principle fabric should work by just passing the


### PR DESCRIPTION
Following #79, allow different options for the `JobStore` used remotely to dump the output. 
Can be configured with the `remote_jobstore` option to test different possibilities. The default is left to `None` to avoid constraining the structure of the configuration, as it is not clear what would be the best option in the future and to avoid issues with old configuration files in the future. The default corresponds to the old option. a maggma JSONStore with json files not zipped. The additional options are the json format based on [orjson](https://github.com/ijl/orjson) and [msgspec](https://jcristharif.com/msgspec/index.html), or [msgpack](https://github.com/msgpack/msgpack-python). Files can now optionally be zipped as well.