### PR TITLE
Handle enums properly

### DIFF
--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -59,7 +59,7 @@ def get_initial_job_doc_dict(
     worker = job.config.manager_config.get("worker") or worker
 
     job_doc = JobDoc(
-        job=jsanitize(job, strict=True, enum_values=True),
+        job=jsanitize(job, strict=True),
         uuid=job.uuid,
         index=job.index,
         db_id=db_id,
@@ -314,7 +314,6 @@ class FlowDoc(BaseModel):
             self.model_dump(mode="python"),
             strict=True,
             allow_bson=True,
-            enum_values=True,
         )
         return d
 

--- a/src/jobflow_remote/remote/data.py
+++ b/src/jobflow_remote/remote/data.py
@@ -39,7 +39,6 @@ def get_remote_in_file(job, remote_store):
         {"job": job, "store": remote_store},
         strict=True,
         allow_bson=True,
-        enum_values=True,
     )
     return io.BytesIO(orjson.dumps(d, default=default_orjson_serializer))
 


### PR DESCRIPTION
This pull request suggests to store the full enum info properly serialized in the database and use in the jf_remote_in.json file and so on. 

This will be possible due to the support in monty, which is already partially there, the remaining part is in https://github.com/materialsvirtuallab/monty/pull/640/ and the support in jobflow, which I proposed in https://github.com/materialsproject/jobflow/pull/565

I am not sure whether this breaks anything. But a first small test worked fine for me. 

Any thoughts?