### PR TITLE
Small updates to JobController and CLI

### DIFF
--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -412,7 +412,6 @@ class Runner:
         if job_id:
             query["uuid"] = job_id[0]
             query["index"] = job_id[1]
-        print(query)
         job_data = self.job_controller.checkout_job(query=query)
         if not job_data:
             if not db_id and not job_id:

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -412,6 +412,7 @@ class Runner:
         if job_id:
             query["uuid"] = job_id[0]
             query["index"] = job_id[1]
+        print(query)
         job_data = self.job_controller.checkout_job(query=query)
         if not job_data:
             if not db_id and not job_id:

--- a/tests/db/cli/test_admin.py
+++ b/tests/db/cli/test_admin.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_reset(job_controller, four_jobs):
+def test_reset(job_controller, two_flows_four_jobs):
     from jobflow_remote.testing.cli import run_check_cli
 
     run_check_cli(

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_flows_list(job_controller, four_jobs):
+def test_flows_list(job_controller, two_flows_four_jobs):
     from jobflow_remote.testing.cli import run_check_cli
 
     columns = ["DB id", "Name", "State", "Flow id", "Num Jobs", "Last updated"]
@@ -17,23 +17,25 @@ def test_flows_list(job_controller, four_jobs):
     run_check_cli(["flow", "list", "-m", "1"], required_out=outputs)
 
     outputs = ["READY"]
-    run_check_cli(["flow", "list", "-fid", four_jobs[0].uuid], required_out=outputs)
+    run_check_cli(
+        ["flow", "list", "-fid", two_flows_four_jobs[0].uuid], required_out=outputs
+    )
 
 
-def test_delete(job_controller, four_jobs):
+def test_delete(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.runner import Runner
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
     # run one of the jobs to check that the output is not deleted
     runner = Runner()
-    job_1_uuid = four_jobs[0].jobs[0].uuid
+    job_1_uuid = two_flows_four_jobs[0].jobs[0].uuid
     runner.run_one_job(job_id=(job_1_uuid, 1))
     assert job_controller.get_job_doc(job_id=job_1_uuid).state == JobState.COMPLETED
     assert job_controller.jobstore.get_output(job_1_uuid) == 6
 
     run_check_cli(
-        ["flow", "delete", "-fid", four_jobs[0].uuid],
+        ["flow", "delete", "-fid", two_flows_four_jobs[0].uuid],
         required_out="Deleted Flow",
         cli_input="y",
     )
@@ -42,15 +44,18 @@ def test_delete(job_controller, four_jobs):
 
     # run the command without returning any match
     run_check_cli(
-        ["flow", "delete", "-fid", four_jobs[0].uuid],
+        ["flow", "delete", "-fid", two_flows_four_jobs[0].uuid],
         required_out="No flows matching criteria",
     )
 
     # don't confirm and verbose option
     # only check the first characters of the uuid because it may be cut in the output
-    outputs = ["This operation will delete the following 1 Flow", four_jobs[1].uuid[:5]]
+    outputs = [
+        "This operation will delete the following 1 Flow",
+        two_flows_four_jobs[1].uuid[:5],
+    ]
     run_check_cli(
-        ["flow", "delete", "-fid", four_jobs[1].uuid, "-v"],
+        ["flow", "delete", "-fid", two_flows_four_jobs[1].uuid, "-v"],
         required_out=outputs,
         cli_input="n",
     )
@@ -58,14 +63,14 @@ def test_delete(job_controller, four_jobs):
 
     # run one job and delete with the outputs
     runner = Runner()
-    job_2_uuid = four_jobs[1].jobs[0].uuid
+    job_2_uuid = two_flows_four_jobs[1].jobs[0].uuid
     runner.run_one_job(job_id=(job_2_uuid, 1))
     assert job_controller.get_job_doc(job_id=job_2_uuid).state == JobState.COMPLETED
     assert job_controller.jobstore.get_output(job_2_uuid) == 6
 
-    outputs = [f"Deleted Flow(s) with id: {four_jobs[1].uuid}"]
+    outputs = [f"Deleted Flow(s) with id: {two_flows_four_jobs[1].uuid}"]
     run_check_cli(
-        ["flow", "delete", "-fid", four_jobs[1].uuid, "-o"],
+        ["flow", "delete", "-fid", two_flows_four_jobs[1].uuid, "-o"],
         required_out=outputs,
         cli_input="y",
     )
@@ -76,7 +81,7 @@ def test_delete(job_controller, four_jobs):
         job_controller.jobstore.get_output(job_2_uuid)
 
 
-def test_flow_info(job_controller, four_jobs):
+def test_flow_info(job_controller, two_flows_four_jobs):
     from jobflow_remote.testing.cli import run_check_cli
 
     columns = ["DB id", "Name", "State", "Job id", "(Index)", "Worker"]

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -1,4 +1,4 @@
-def test_jobs_list(job_controller, four_jobs):
+def test_jobs_list(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -30,7 +30,7 @@ def test_jobs_list(job_controller, four_jobs):
     )
 
 
-def test_job_info(job_controller, four_jobs):
+def test_job_info(job_controller, two_flows_four_jobs):
     from jobflow_remote.testing.cli import run_check_cli
 
     outputs = ["name = 'add1'", "state = 'READY'"]
@@ -40,7 +40,7 @@ def test_job_info(job_controller, four_jobs):
 
     outputs += excluded_n
     run_check_cli(
-        ["job", "info", four_jobs[0].jobs[0].uuid, "-n"], required_out=outputs
+        ["job", "info", two_flows_four_jobs[0].jobs[0].uuid, "-n"], required_out=outputs
     )
 
     outputs = ["state = 'READY'", "job = {"]
@@ -51,7 +51,7 @@ def test_job_info(job_controller, four_jobs):
     )
 
 
-def test_set_state(job_controller, four_jobs):
+def test_set_state(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -66,7 +66,7 @@ def test_set_state(job_controller, four_jobs):
     )
 
 
-def test_rerun(job_controller, four_jobs):
+def test_rerun(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -81,7 +81,7 @@ def test_rerun(job_controller, four_jobs):
     run_check_cli(["job", "rerun", "-did", "1"], required_out="Error while rerunning")
 
 
-def test_retry(job_controller, four_jobs):
+def test_retry(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -96,7 +96,7 @@ def test_retry(job_controller, four_jobs):
     run_check_cli(["job", "retry", "-did", "2"], required_out="Error while retrying")
 
 
-def test_play_pause(job_controller, four_jobs):
+def test_play_pause(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -115,7 +115,7 @@ def test_play_pause(job_controller, four_jobs):
     run_check_cli(["job", "play", "-did", "1"], required_out="Error while playing")
 
 
-def test_stop(job_controller, four_jobs):
+def test_stop(job_controller, two_flows_four_jobs):
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -182,7 +182,7 @@ def one_job(random_project_name):
 
 
 @pytest.fixture(scope="function")
-def four_jobs(random_project_name):
+def two_flows_four_jobs(random_project_name):
     """
     Add two flows with two jobs each to the DB
     """

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -511,6 +511,36 @@ def test_set_job_run_properties(job_controller, one_job):
     assert job_controller.get_job_doc(job_id=one_job[0].uuid).resources == qr
 
 
+def test_set_job_doc_properties(job_controller, one_job):
+    from jobflow_remote.jobs.state import JobState
+
+    # error missing input
+    with pytest.raises(
+        ValueError, match="One and only one among job_id and db_id should be defined"
+    ):
+        job_controller.set_job_doc_properties(
+            values={"job.metadata.x": "y"}, acceptable_states=[JobState.COMPLETED]
+        )
+
+    # error wrong state
+    with pytest.raises(
+        ValueError, match="Job in state READY. The action cannot be performed"
+    ):
+        job_controller.set_job_doc_properties(
+            values={"job.metadata.x": "y"},
+            job_id=one_job[0].uuid,
+            acceptable_states=[JobState.COMPLETED],
+        )
+
+    job_controller.set_job_doc_properties(
+        values={"job.metadata.x": "y"},
+        job_id=one_job[0].uuid,
+        acceptable_states=[JobState.READY],
+    )
+
+    assert job_controller.get_job_doc(job_id=one_job[0].uuid).job.metadata == {"x": "y"}
+
+
 def test_reset(job_controller, four_jobs):
     assert job_controller.count_jobs() == 4
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -541,7 +541,7 @@ def test_set_job_doc_properties(job_controller, one_job):
     assert job_controller.get_job_doc(job_id=one_job[0].uuid).job.metadata == {"x": "y"}
 
 
-def test_reset(job_controller, four_jobs):
+def test_reset(job_controller, two_flows_four_jobs):
     assert job_controller.count_jobs() == 4
 
     assert not job_controller.reset(max_limit=1)


### PR DESCRIPTION
Addressing a few points discusses in issues:
*  `set_job_doc_properties` is a public method, deprecated `_set_job_properties` #125
* Added option `-v` and `-o` to `jf flow delete` to print the list of flows that will be deleted and delete also the outputs from the `JobStore` #129 #130