### PR TITLE
Add hyperlink for slurm and pbs resource keywords as a note in the documentation

### DIFF
--- a/doc/source/user/tuning.rst
+++ b/doc/source/user/tuning.rst
@@ -58,6 +58,13 @@ or to pass an instance of a ``QResources``, a generic object defining resources
 for standard use cases. These will be used to fill in a template and generate
 a suitable submission script.
 
+.. note::
+
+    There are `SLURM <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.slurm.html>`_ 
+    and `PBS <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.pbs.html>`_ 
+    specific keywords that can be passed to ``submit_flow`` to use the 
+    respective queueing system commands.
+
 How to tune
 ===========
 

--- a/doc/source/user/tuning.rst
+++ b/doc/source/user/tuning.rst
@@ -60,9 +60,9 @@ a suitable submission script.
 
 .. note::
 
-    There are `SLURM <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.slurm.html>`_ 
-    and `PBS <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.pbs.html>`_ 
-    specific keywords that can be passed to ``submit_flow`` to use the 
+    There are `SLURM <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.slurm.html>`_
+    and `PBS <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.pbs.html>`_
+    specific keywords that can be passed to ``submit_flow`` to use the
     respective queueing system commands.
 
 How to tune


### PR DESCRIPTION
Also see https://github.com/Matgenix/jobflow-remote/issues/143#issuecomment-2223981082