### PR TITLE
delete_job functionality

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -112,6 +112,16 @@ def delete(
     days: days_opt = None,
     hours: hours_opt = None,
     force: force_opt = False,
+    max_limit: Annotated[
+        int,
+        typer.Option(
+            "--max",
+            "-m",
+            help=(
+                "The Flows will be deleted only if the total number is lower than the specified limit. 0 means no limit"
+            ),
+        ),
+    ] = 10,
     verbosity: Annotated[
         int,
         typer.Option(
@@ -181,9 +191,9 @@ def delete(
 
         jc.delete_flows(
             flow_ids=to_delete,
-            confirm=True,
             delete_output=delete_output,
             delete_files=delete_files,
+            max_limit=max_limit,
         )
 
     out_console.print(

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -497,6 +497,61 @@ def stop(
 
 
 @app_job.command()
+def delete(
+    job_db_id: job_db_id_arg = None,
+    job_index: job_index_arg = None,
+    job_id: job_ids_indexes_opt = None,
+    db_id: db_ids_opt = None,
+    flow_id: flow_ids_opt = None,
+    state: job_state_opt = None,
+    start_date: start_date_opt = None,
+    end_date: end_date_opt = None,
+    name: name_opt = None,
+    metadata: metadata_opt = None,
+    days: days_opt = None,
+    hours: hours_opt = None,
+    verbosity: verbosity_opt = 0,
+    wait: wait_lock_opt = None,
+    raise_on_error: raise_on_error_opt = False,
+    delete_output: Annotated[
+        bool,
+        typer.Option(
+            "--output",
+            "-o",
+            help="Also delete the outputs of the Jobs in the output Store",
+        ),
+    ] = False,
+) -> None:
+    """
+    Delete Jobs individually. The Flow document will be updated accordingly but
+    no consistency check is performed. The Flow may be left in an inconsistent state.
+    For advanced users only.
+    """
+    jc = get_job_controller()
+
+    execute_multi_jobs_cmd(
+        single_cmd=jc.delete_job,
+        multi_cmd=jc.delete_jobs,
+        job_db_id=job_db_id,
+        job_index=job_index,
+        job_ids=job_id,
+        db_ids=db_id,
+        flow_ids=flow_id,
+        states=state,
+        start_date=start_date,
+        end_date=end_date,
+        name=name,
+        metadata=metadata,
+        days=days,
+        hours=hours,
+        verbosity=verbosity,
+        wait=wait,
+        raise_on_error=raise_on_error,
+        delete_output=delete_output,
+    )
+
+
+@app_job.command()
 def queue_out(
     job_db_id: job_db_id_arg,
     job_index: job_index_arg = None,

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -17,6 +17,9 @@ from jobflow_remote.cli.types import (
     break_lock_opt,
     days_opt,
     db_ids_opt,
+    delete_all_opt,
+    delete_files_opt,
+    delete_output_opt,
     end_date_opt,
     flow_ids_opt,
     hours_opt,
@@ -513,20 +516,19 @@ def delete(
     verbosity: verbosity_opt = 0,
     wait: wait_lock_opt = None,
     raise_on_error: raise_on_error_opt = False,
-    delete_output: Annotated[
-        bool,
-        typer.Option(
-            "--output",
-            "-o",
-            help="Also delete the outputs of the Jobs in the output Store",
-        ),
-    ] = False,
+    delete_output: delete_output_opt = False,
+    delete_files: delete_files_opt = False,
+    delete_all: delete_all_opt = False,
 ) -> None:
     """
     Delete Jobs individually. The Flow document will be updated accordingly but
     no consistency check is performed. The Flow may be left in an inconsistent state.
     For advanced users only.
     """
+
+    if delete_all:
+        delete_files = delete_output = True
+
     jc = get_job_controller()
 
     execute_multi_jobs_cmd(
@@ -548,6 +550,7 @@ def delete(
         wait=wait,
         raise_on_error=raise_on_error,
         delete_output=delete_output,
+        delete_files=delete_files,
     )
 
 

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -308,6 +308,36 @@ raise_on_error_opt = Annotated[
 ]
 
 
+delete_output_opt = Annotated[
+    bool,
+    typer.Option(
+        "--output",
+        "-o",
+        help="Also delete the outputs of the Jobs in the output Store",
+    ),
+]
+
+
+delete_files_opt = Annotated[
+    bool,
+    typer.Option(
+        "--files",
+        "-fi",
+        help="Also delete the files on the worker",
+    ),
+]
+
+
+delete_all_opt = Annotated[
+    bool,
+    typer.Option(
+        "--all",
+        "-a",
+        help="enable --output and --files",
+    ),
+]
+
+
 # as of typer version 0.9.0 the dict is not a supported type. Define a custom one
 class DictType(dict):
     pass

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -361,6 +361,8 @@ def execute_multi_jobs_cmd(
                 modified_ids = single_cmd(
                     job_id=job_id, job_index=job_index, db_id=db_id, **kwargs
                 )
+                if not isinstance(modified_ids, (list, tuple)):
+                    modified_ids = [] if modified_ids is None else [modified_ids]
                 if not modified_ids:
                     exit_with_error_msg("Could not perform the requested operation")
         else:

--- a/src/jobflow_remote/jobs/state.py
+++ b/src/jobflow_remote/jobs/state.py
@@ -70,6 +70,10 @@ RESETTABLE_STATES = RUNNING_STATES
 
 RESETTABLE_STATES_V = RUNNING_STATES_V
 
+DELETABLE_STATES = [
+    s for s in JobState if s not in [JobState.BATCH_SUBMITTED, JobState.BATCH_RUNNING]
+]
+
 
 class FlowState(Enum):
     """States of a Flow."""

--- a/src/jobflow_remote/testing/cli.py
+++ b/src/jobflow_remote/testing/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import IO, TYPE_CHECKING, Any
 
 from typer.testing import CliRunner, Result
@@ -41,12 +42,20 @@ def run_check_cli(
         error == (result.exit_code != 0)
     ), f"cli should have {'' if error else 'not '}failed. exit code: {result.exit_code}. stdout: {result.stdout}"
 
+    # the print of the output in the console during the tests may result in newlines added
+    # that prevent the output to be matched. replace all spaces with a single space.
+    single_space_output = re.sub(r"[\n\t\s]*", " ", result.stdout)
+
     if required_out:
         for ro in required_out:
-            assert ro in result.stdout, f"{ro} missing from stdout: {result.stdout}"
+            assert (
+                re.sub(r"[\n\t\s]*", " ", ro) in single_space_output
+            ), f"{ro} missing from stdout: {result.stdout}"
 
     if excluded_out:
         for eo in excluded_out:
-            assert eo not in result.stdout, f"{eo} present in stdout: {result.stdout}"
+            assert (
+                re.sub(r"[\n\t\s]*", " ", eo) not in single_space_output
+            ), f"{eo} present in stdout: {result.stdout}"
 
     return result

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -109,10 +109,23 @@ def test_delete(job_controller, two_flows_four_jobs) -> None:
         flow = Flow([j1])
         submit_flow(flow, worker="test_local_worker")
 
-    outputs = ["Deleted Flow(s) with id"]
+    outputs = [
+        " Cannot delete 11 Flows as they exceeds the specified maximum limit (10)"
+    ]
+    done_output = ["Deleted Flow(s) with id"]
+    # try deleting the flow with max=10. It fails
     run_check_cli(
         ["flow", "delete"],
         required_out=outputs,
+        excluded_out=done_output,
+        cli_input="y",
+        error=True,
+    )
+
+    # increase the maximum value to succeed
+    run_check_cli(
+        ["flow", "delete", "-m", "20"],
+        required_out=done_output,
         cli_input="y",
     )
 

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -274,3 +274,18 @@ def test_files_get(job_controller, one_job, tmp_dir) -> None:
         error=True,
         required_out="No data matching the request",
     )
+
+
+def test_delete(job_controller, two_flows_four_jobs) -> None:
+    from jobflow_remote.testing.cli import run_check_cli
+
+    run_check_cli(
+        ["job", "delete", "-did", "2", "--output"],
+        required_out="Operation completed: 1 jobs modified",
+    )
+    flow_doc = job_controller.get_flow_info_by_job_uuid(two_flows_four_jobs[0][0].uuid)
+
+    assert len(flow_doc["jobs"]) == 1
+    assert len(flow_doc["ids"]) == 1
+    assert len(flow_doc["parents"]) == 1
+    assert len(flow_doc["parents"][two_flows_four_jobs[0][0].uuid]["1"]) == 0

--- a/tests/db/jobs/test_daemon.py
+++ b/tests/db/jobs/test_daemon.py
@@ -118,7 +118,7 @@ def test_kill_supervisord(job_controller, daemon_manager, caplog) -> None:
     # present" in log_msg[-1]
 
 
-def test_kill_one_process(job_controller, daemon_manager, caplog) -> None:
+def test_kill_one_process(job_controller, daemon_manager) -> None:
     import signal
     import time
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -566,7 +566,7 @@ def test_delete_job(job_controller, two_flows_four_jobs, runner):
     from jobflow import Flow
 
     from jobflow_remote import submit_flow
-    from jobflow_remote.utils.test import add
+    from jobflow_remote.testing import add
 
     runner.run_one_job(job_id=[two_flows_four_jobs[0][0].uuid, 1])
     flow_doc = job_controller.get_flow_info_by_flow_uuid(two_flows_four_jobs[0].uuid)

--- a/tests/db/utils/test_db.py
+++ b/tests/db/utils/test_db.py
@@ -1,0 +1,156 @@
+import threading
+import time
+from contextlib import ExitStack
+
+import pytest
+
+from jobflow_remote.utils.db import MongoLock
+
+
+@pytest.fixture()
+def test_collection(mongoclient, store_database_name):
+    collection = mongoclient[store_database_name]["test_lock_collection"]
+    collection.delete_many({})
+    collection.insert_many([{"test_id": 1}, {"test_id": 2}])
+    yield collection
+    collection.delete_many({})
+
+
+def test_mongo_lock_acquire(test_collection):
+    with MongoLock(test_collection, {"test_id": 1}) as lock:
+        assert lock.locked_document is not None
+        assert lock.locked_document["test_id"] == 1
+        assert (
+            test_collection.count_documents(
+                {"test_id": 1, MongoLock.LOCK_KEY: lock.lock_id}
+            )
+            == 1
+        )
+        assert (
+            test_collection.count_documents({"test_id": 2, MongoLock.LOCK_KEY: None})
+            == 1
+        )
+
+    assert (
+        test_collection.count_documents({"test_id": 1, MongoLock.LOCK_KEY: None}) == 1
+    )
+
+
+def test_mongo_lock_acquire_already_locked(test_collection):
+    with MongoLock(test_collection, {"test_id": 1}) as lock:
+        assert lock.locked_document is not None
+        with MongoLock(test_collection, {"test_id": 1}) as another_lock:
+            assert another_lock.locked_document is None
+            assert another_lock.unavailable_document is None
+
+        # check with get_locked_doc
+        with MongoLock(
+            test_collection, {"test_id": 1}, get_locked_doc=True
+        ) as another_lock:
+            assert another_lock.locked_document is None
+            assert another_lock.unavailable_document is not None
+
+
+def lock_and_sleep(test_collection, thread_lock):
+    with MongoLock(test_collection, {"test_id": 1}, sleep=0.1) as lock:
+        assert lock.locked_document is not None
+        thread_lock.set()
+        time.sleep(2)
+
+
+def test_mongo_lock_max_wait(test_collection):
+    thread_lock = threading.Event()
+
+    t = threading.Thread(target=lock_and_sleep, args=(test_collection, thread_lock))
+    t.start()
+
+    thread_lock.wait()
+    with MongoLock(test_collection, {"test_id": 1}, sleep=0.1, max_wait=0.1) as lock:
+        assert lock.locked_document is None
+
+    with MongoLock(test_collection, {"test_id": 1}, sleep=0.5, max_wait=10) as lock:
+        assert lock.locked_document is not None
+
+    t.join()
+
+
+def test_mongo_lock_break_lock(test_collection):
+    # the warning is raised by the first lock. It will not be able to release the lock
+    # since it was already released by the second lock.
+    with (
+        pytest.warns(UserWarning, match="Could not release lock for document"),
+        MongoLock(test_collection, {"test_id": 1}) as lock,
+    ):
+        assert (
+            test_collection.count_documents(
+                {"test_id": 1, MongoLock.LOCK_KEY: lock.lock_id}
+            )
+            == 1
+        )
+        with MongoLock(
+            test_collection, {"test_id": 1}, break_lock=True
+        ) as another_lock:
+            assert another_lock.locked_document is not None
+            assert (
+                test_collection.count_documents(
+                    {"test_id": 1, MongoLock.LOCK_KEY: another_lock.lock_id}
+                )
+                == 1
+            )
+
+
+def test_mongo_lock_update_on_release(test_collection):
+    with MongoLock(test_collection, {"test_id": 1}) as lock:
+        lock.update_on_release = {"$set": {"status": "updated"}}
+        assert test_collection.count_documents({"test_id": 1, "status": "updated"}) == 0
+    assert test_collection.count_documents({"test_id": 1, "status": "updated"}) == 1
+
+
+def test_mongo_lock_update_on_release_multiple_fields(test_collection):
+    with MongoLock(test_collection, {"test_id": 1}) as lock:
+        lock.update_on_release = {"$set": {"status": "updated", "counter": 1}}
+        assert (
+            test_collection.count_documents(
+                {"test_id": 1, "status": "updated", "counter": 1}
+            )
+            == 0
+        )
+    assert (
+        test_collection.count_documents(
+            {"test_id": 1, "status": "updated", "counter": 1}
+        )
+        == 1
+    )
+
+
+def test_mongo_lock_update_on_release_with_exception(test_collection):
+    # mypy does not like multiple statements inside pytest.raises inside, but
+    # they are necessary to properly test the functionality. This is the only
+    # way I managed to make it accept it.
+    with ExitStack() as stack:
+        stack.enter_context(pytest.raises(RuntimeError, match="Test exception"))
+        lock = stack.enter_context(MongoLock(test_collection, {"test_id": 1}))
+        lock.update_on_release = {"$set": {"status": "updated"}}
+        raise RuntimeError("Test exception")
+
+    assert test_collection.count_documents({"test_id": 1, "status": "updated"}) == 0
+
+
+def test_mongo_lock_delete_on_release(test_collection):
+    with MongoLock(test_collection, {"test_id": 1}) as lock:
+        lock.delete_on_release = True
+        assert test_collection.count_documents({"test_id": 1}) == 1
+    assert test_collection.count_documents({"test_id": 1}) == 0
+
+
+def test_mongo_lock_delete_on_release_with_exception(test_collection):
+    # mypy does not like multiple statements inside pytest.raises inside, but
+    # they are necessary to properly test the functionality. This is the only
+    # way I managed to make it accept it.
+    with ExitStack() as stack:
+        stack.enter_context(pytest.raises(RuntimeError, match="Test exception"))
+        lock = stack.enter_context(MongoLock(test_collection, {"test_id": 1}))
+        lock.delete_on_release = True
+        raise RuntimeError("Test exception")
+
+    assert test_collection.count_documents({"test_id": 1}) == 1


### PR DESCRIPTION
A new option to delete a single Job of a Flow.
No checks for consistency are performed, so it is the user's responsibility to leave the Flow in a consistent state.