### PR TITLE
Minor updates

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,7 +37,7 @@ jobs:
   test:
     services:
       local_mongodb:
-        image: mongo:4.4
+        image: mongo:5.0
         ports:
           - 27017:27017
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -203,7 +203,7 @@ htmlhelp_basename = "jobflow_remote_doc"
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/", None)}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -227,6 +227,12 @@ def delete(
                             f"since it may not contain a jobflow-remote execution",
                             stacklevel=2,
                         )
+            # explicitly close the connection to all the hosts
+            for host in hosts.values():
+                try:
+                    host.close()
+                except Exception:
+                    pass
 
         progress.add_task(description="Deleting data...", total=None)
 

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -829,7 +829,7 @@ def output(
         bool,
         typer.Option(
             "--load",
-            "-",
+            "-l",
             help="If enabled all the data from additional stores are also loaded ",
         ),
     ] = False,

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -172,14 +172,6 @@ def job_info(
             "The -v flag will be ignored if --pid is used.",
         ),
     ] = None,
-    with_error: Annotated[
-        bool,
-        typer.Option(
-            "--with-error",
-            "-err",
-            help="DEPRECATED: not needed anymore to fetch errors",
-        ),
-    ] = False,
     show_none: Annotated[
         bool,
         typer.Option(

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -221,7 +221,7 @@ def get_job_db_ids(job_db_id: str, job_index: int | None):
 
     if job_index and db_id is not None:
         out_console.print(
-            "The index is defined even if a db_id is passed as an ID. Will be ignored",
+            "The index is defined while a db_id is passed as an ID. Will be ignored",
             style="yellow",
         )
 

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -221,7 +221,7 @@ def get_job_db_ids(job_db_id: str, job_index: int | None):
 
     if job_index and db_id is not None:
         out_console.print(
-            "The index is defined even if an integer is passed as an ID. Will be ignored",
+            "The index is defined even if a db_id is passed as an ID. Will be ignored",
             style="yellow",
         )
 

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -448,7 +448,7 @@ class DaemonManager:
         ):
             return True
 
-        if status == DaemonStatus.RUNNING:
+        if status in (DaemonStatus.RUNNING, DaemonStatus.PARTIALLY_RUNNING):
             interface = self.get_interface()
             if wait:
                 result = interface.supervisor.stopAllProcesses()

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -364,6 +364,18 @@ class RemoteError(RuntimeError):
         self.no_retry = no_retry
 
 
+projection_flow_info_jobs = [
+    "db_id",
+    "uuid",
+    "index",
+    "state",
+    "job.name",
+    "worker",
+    "parents",
+    "job.hosts",
+]
+
+
 class FlowInfo(BaseModel):
     """
     Model with information extracted from a FlowDoc.

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -93,13 +93,13 @@ class BaseHost(MSONable):
     @abc.abstractmethod
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
         """Recursively delete a directory tree on a host.
-        
+
         This method must be implemented by subclasses of  `BaseHost`.
         It is intended to remove an entire directory tree, including all files
         and subdirectories, on the host represented by the subclass.
-        
-        Parameters:
-        -----------
+
+        Parameters
+        ----------
         path : str or Path
             The path to the directory tree to be removed.
 
@@ -108,6 +108,11 @@ class BaseHost(MSONable):
             attempt to continue removing remaining files and directories.
             Otherwise, any errors encountered during the removal process
             will raise an exception.
+
+        Returns
+        -------
+        bool
+            True if the directory tree was successfully removed, False otherwise.
         """
         raise NotImplementedError
 

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -90,6 +90,10 @@ class BaseHost(MSONable):
     def remove(self, path: str | Path):
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        raise NotImplementedError
+
     @property
     def interactive_login(self) -> bool:
         """

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -92,6 +92,23 @@ class BaseHost(MSONable):
 
     @abc.abstractmethod
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        """Recursively delete a directory tree on a host.
+        
+        This method must be implemented by subclasses of  `BaseHost`.
+        It is intended to remove an entire directory tree, including all files
+        and subdirectories, on the host represented by the subclass.
+        
+        Parameters:
+        -----------
+        path : str or Path
+            The path to the directory tree to be removed.
+
+        raise_on_error : bool, optional
+            If set to `False` (default), errors will be ignored, and the method will
+            attempt to continue removing remaining files and directories.
+            Otherwise, any errors encountered during the removal process
+            will raise an exception.
+        """
         raise NotImplementedError
 
     @property

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -103,7 +103,7 @@ class BaseHost(MSONable):
         path : str or Path
             The path to the directory tree to be removed.
 
-        raise_on_error : bool, optional
+        raise_on_error : bool
             If set to `False` (default), errors will be ignored, and the method will
             attempt to continue removing remaining files and directories.
             Otherwise, any errors encountered during the removal process

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -117,7 +117,7 @@ class LocalHost(BaseHost):
         os.remove(path)
 
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
-        """Recursively delete a directory tree on a host.
+        """Recursively delete a directory tree on a local host.
 
         It is intended to remove an entire directory tree, including all files
         and subdirectories, on the host represented by the subclass.

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import warnings
 from pathlib import Path
 
 from monty.os import cd
@@ -114,3 +115,15 @@ class LocalHost(BaseHost):
 
     def remove(self, path: str | Path) -> None:
         os.remove(path)
+
+    def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        removed = True
+
+        def onerror(func, dir_path, err):
+            nonlocal removed
+            removed = False
+            warnings.warn(f"Error while deleting folder {path}: {err[1]}", stacklevel=2)
+
+        shutil.rmtree(path, onerror=onerror if not raise_on_error else None)
+
+        return removed

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -119,7 +119,6 @@ class LocalHost(BaseHost):
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
         """Recursively delete a directory tree on a host.
 
-        This method must be implemented by subclasses of  `BaseHost`.
         It is intended to remove an entire directory tree, including all files
         and subdirectories, on the host represented by the subclass.
 
@@ -128,7 +127,7 @@ class LocalHost(BaseHost):
         path : str or Path
             The path to the directory tree to be removed.
 
-        raise_on_error : bool, optional
+        raise_on_error : bool
             If set to `False` (default), errors will be ignored, and the method will
             attempt to continue removing remaining files and directories.
             Otherwise, any errors encountered during the removal process

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -117,6 +117,28 @@ class LocalHost(BaseHost):
         os.remove(path)
 
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        """Recursively delete a directory tree on a host.
+
+        This method must be implemented by subclasses of  `BaseHost`.
+        It is intended to remove an entire directory tree, including all files
+        and subdirectories, on the host represented by the subclass.
+
+        Parameters
+        ----------
+        path : str or Path
+            The path to the directory tree to be removed.
+
+        raise_on_error : bool, optional
+            If set to `False` (default), errors will be ignored, and the method will
+            attempt to continue removing remaining files and directories.
+            Otherwise, any errors encountered during the removal process
+            will raise an exception.
+
+        Returns
+        -------
+        bool
+            True if the directory tree was successfully removed, False otherwise.
+        """
         removed = True
 
         def onerror(func, dir_path, err):

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -120,7 +120,7 @@ class LocalHost(BaseHost):
         """Recursively delete a directory tree on a local host.
 
         It is intended to remove an entire directory tree, including all files
-        and subdirectories, on the host represented by the subclass.
+        and subdirectories, on this local host.
 
         Parameters
         ----------

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -334,7 +334,7 @@ class RemoteHost(BaseHost):
         path : str or Path
             The path to the directory tree to be removed.
 
-        raise_on_error : bool, optional
+        raise_on_error : bool
             If set to `False` (default), errors will be ignored, and the method will
             attempt to continue removing remaining files and directories.
             Otherwise, any errors encountered during the removal process

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -326,7 +326,7 @@ class RemoteHost(BaseHost):
         """Recursively delete a directory tree on a remote host.
 
         It is intended to remove an entire directory tree, including all files
-        and subdirectories, on the host represented by the subclass.
+        and subdirectories, on this remote host.
 
         Parameters
         ----------

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -325,7 +325,6 @@ class RemoteHost(BaseHost):
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
         """Recursively delete a directory tree on a host.
 
-        This method must be implemented by subclasses of  `BaseHost`.
         It is intended to remove an entire directory tree, including all files
         and subdirectories, on the host represented by the subclass.
 

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -323,7 +323,7 @@ class RemoteHost(BaseHost):
         self._execute_remote_func(self.connection.sftp().remove, str(path))
 
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
-        """Recursively delete a directory tree on a host.
+        """Recursively delete a directory tree on a remote host.
 
         It is intended to remove an entire directory tree, including all files
         and subdirectories, on the host represented by the subclass.

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -5,6 +5,7 @@ import io
 import logging
 import shlex
 import traceback
+import warnings
 from pathlib import Path
 
 import fabric
@@ -320,6 +321,16 @@ class RemoteHost(BaseHost):
         self._check_connected()
 
         self._execute_remote_func(self.connection.sftp().remove, str(path))
+
+    def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        stdout, stderr, exit_code = self.execute(f"rm -r {path}")
+        if exit_code != 0:
+            msg = f"Error while deleting folder {path}. stdout: {stdout}, stderr: {stderr}"
+            if raise_on_error:
+                raise RuntimeError(msg)
+            warnings.warn(msg, stacklevel=2)
+            return False
+        return True
 
     def _check_connected(self) -> bool:
         """

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -323,6 +323,28 @@ class RemoteHost(BaseHost):
         self._execute_remote_func(self.connection.sftp().remove, str(path))
 
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        """Recursively delete a directory tree on a host.
+
+        This method must be implemented by subclasses of  `BaseHost`.
+        It is intended to remove an entire directory tree, including all files
+        and subdirectories, on the host represented by the subclass.
+
+        Parameters
+        ----------
+        path : str or Path
+            The path to the directory tree to be removed.
+
+        raise_on_error : bool, optional
+            If set to `False` (default), errors will be ignored, and the method will
+            attempt to continue removing remaining files and directories.
+            Otherwise, any errors encountered during the removal process
+            will raise an exception.
+
+        Returns
+        -------
+        bool
+            True if the directory tree was successfully removed, False otherwise.
+        """
         stdout, stderr, exit_code = self.execute(f"rm -r {path}")
         if exit_code != 0:
             msg = f"Error while deleting folder {path}. stdout: {stdout}, stderr: {stderr}"

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -1,3 +1,5 @@
+import os.path
+
 import pytest
 
 
@@ -31,8 +33,11 @@ def test_delete(job_controller, two_flows_four_jobs) -> None:
     runner = Runner()
     job_1_uuid = two_flows_four_jobs[0].jobs[0].uuid
     runner.run_one_job(job_id=(job_1_uuid, 1))
-    assert job_controller.get_job_doc(job_id=job_1_uuid).state == JobState.COMPLETED
+    job_1_doc = job_controller.get_job_doc(job_id=job_1_uuid)
+    assert job_1_doc.state == JobState.COMPLETED
     assert job_controller.jobstore.get_output(job_1_uuid) == 6
+
+    assert os.path.isdir(job_1_doc.run_dir)
 
     run_check_cli(
         ["flow", "delete", "-fid", two_flows_four_jobs[0].uuid],
@@ -41,6 +46,9 @@ def test_delete(job_controller, two_flows_four_jobs) -> None:
     )
     assert job_controller.count_flows() == 1
     assert job_controller.jobstore.get_output(job_1_uuid) == 6
+
+    # check that the directory was not deleted
+    assert os.path.isdir(job_1_doc.run_dir)
 
     # run the command without returning any match
     run_check_cli(
@@ -61,24 +69,34 @@ def test_delete(job_controller, two_flows_four_jobs) -> None:
     )
     assert job_controller.count_flows() == 1
 
-    # run one job and delete with the outputs
+    # run all the remaining jobs and delete with the outputs
     runner = Runner()
     job_2_uuid = two_flows_four_jobs[1].jobs[0].uuid
-    runner.run_one_job(job_id=(job_2_uuid, 1))
-    assert job_controller.get_job_doc(job_id=job_2_uuid).state == JobState.COMPLETED
+    runner.run_all_jobs()
+    job_3_doc = job_controller.get_job_doc(job_id=job_2_uuid)
+    job_4_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[1].uuid)
+    assert job_3_doc.state == JobState.COMPLETED
     assert job_controller.jobstore.get_output(job_2_uuid) == 6
 
+    # remove the jfremote_in.json file from one of the folders, so it will
+    # not be deleted
+    os.remove(os.path.join(job_4_doc.run_dir, "jfremote_in.json"))
+
     outputs = [f"Deleted Flow(s) with id: {two_flows_four_jobs[1].uuid}"]
-    run_check_cli(
-        ["flow", "delete", "-fid", two_flows_four_jobs[1].uuid, "-o"],
-        required_out=outputs,
-        cli_input="y",
-    )
+    with pytest.warns(UserWarning, match=f"Did not delete folder {job_4_doc.run_dir}"):
+        run_check_cli(
+            ["flow", "delete", "-fid", two_flows_four_jobs[1].uuid, "-a"],
+            required_out=outputs,
+            cli_input="y",
+        )
     assert job_controller.count_flows() == 0
 
     # output should be deleted
     with pytest.raises(ValueError, match=".*has no outputs.*"):
         job_controller.jobstore.get_output(job_2_uuid)
+
+    assert not os.path.isdir(job_3_doc.run_dir)
+    assert os.path.isdir(job_4_doc.run_dir)
 
 
 def test_flow_info(job_controller, two_flows_four_jobs) -> None:


### PR DESCRIPTION
A few minor updates.
* Minimize the amount of data fetched during the aggregation joining the flow and job documents. To avoid exceeding memmory limits (see discussion in #149)
* small fix in cli and daemon
* add the option to delete the job execution folders on the worker when deleting a Flow.

A few points to be discussed concerning the last functionality:
* the deletion is implemented in the CLI and thus only available there. In general I would prefer not to overload the JobController with different functionalities, but would it be better to move the file deletion there?
* I added a safeguard before deleting the file to avoid the risk of mistakenly deleting other data: the folder to be deleted should contain the `jfremote_in.json` file, singaling that it is indeed a folder where jobflow-remote was executed. This requires an additional request to the host of the worker for each folder to be deleted. Maybe could be replaced by a check on the folder name (i.e. should match the `UUID_INDEX` format? This would be faster and probably as safe as the other check.
* Paramiko does not expose a method to delete recursively a folder and all its content, so the `rmtree` for the remote host relies on the unix `rm -r`. In the remote host it is declared and used that some commands expect the remote system to be unix. But could this an issue? A potential solution using only paramiko is [this](https://stackoverflow.com/questions/20507055/recursive-remove-directory-using-sftp/20507586#20507586), but I am not convinced that it would be much better.

Apparently the tests did not like the first change. They run fine on my laptop, so I suppose the problem is the mongoDB version. We are using a a mongodb 4.4 for the testings. Mine is 6.0.6 and the most recent is 7.0.12. Can we consider increasing the MongoDB version for the tests? Or should it preserve more backward compatibility?