### PR TITLE
Bugfix: improve collection indexes to prevent duplications

### DIFF
--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -4,7 +4,12 @@ from typing import Annotated, Optional
 import click
 import typer
 
-from jobflow_remote.cli.utils import IndexDirection, SerializeFileFormat, SortOption, str_to_dict
+from jobflow_remote.cli.utils import (
+    IndexDirection,
+    SerializeFileFormat,
+    SortOption,
+    str_to_dict,
+)
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import FlowState, JobState
 

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 import click
 import typer
 
-from jobflow_remote.cli.utils import SerializeFileFormat, SortOption, str_to_dict
+from jobflow_remote.cli.utils import IndexDirection, SerializeFileFormat, SortOption, str_to_dict
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import FlowState, JobState
 
@@ -329,6 +329,31 @@ delete_all_opt = Annotated[
         "--all",
         "-a",
         help="enable --output and --files",
+    ),
+]
+
+foreground_index_opt = Annotated[
+    bool,
+    typer.Option(
+        "--foreground",
+        "-fg",
+        help="The build of the indexes will not be executed in the background",
+    ),
+]
+
+index_key_arg = Annotated[
+    str,
+    typer.Argument(
+        help="The field on which the index will be created",
+        metavar="INDEX",
+    ),
+]
+
+index_direction_arg = Annotated[
+    Optional[IndexDirection],
+    typer.Argument(
+        help="The direction of the index",
+        metavar="DIRECTION",
     ),
 ]
 

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -107,6 +107,20 @@ class SerializeFileFormat(str, Enum):
     TOML = "toml"
 
 
+class IndexDirection(str, Enum):
+    ASC = "asc"
+    DESC = "desc"
+
+    @property
+    def as_pymongo(self):
+        import pymongo
+
+        return {
+            IndexDirection.ASC: pymongo.ASCENDING,
+            IndexDirection.DESC: pymongo.DESCENDING,
+        }[self]
+
+
 class ReprStr(str):
     r"""
     Helper class that overrides the standard __repr__ to return the string itself

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -482,6 +482,12 @@ class DynamicResponseType(Enum):
     ADDITION = "addition"
 
 
+class DbCollection(Enum):
+    JOBS = "jobs"
+    FLOWS = "flows"
+    AUX = "aux"
+
+
 def get_reset_job_base_dict() -> dict:
     """
     Generate a dictionary with the basic properties to update in case of reset.


### PR DESCRIPTION
As pointed out by @fraricci, at the moment a code like this allows to insert multiple flows and jobs with duplicated UUIDs:
```python
j = add(1,2)
flow = Flow([j])
 
for i in range(5):
    submit_flow(flow)
```
This should not happen, because the code assumes in some points that the uuid+index should be unique for the jobs collection and uuid for the flows collection.

To prevent this, unique indexes have been added to the collections.
This also includes functionalitites to rebuild the indexes from the CLI, as users are encouraged to run `jf admin index rebuild` to prevent such issues in already existing DBs.