### PR TITLE
New CLI functionalities: tree, report, job info

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -68,10 +68,16 @@ jobs:
           pip install .[tests]
 
       - name: Unit tests
-        run: pytest --cov=jobflow_remote --cov-report=xml --cov-config pyproject.toml --ignore tests/integration
+        run: COVERAGE_FILE=.coverage.1 pytest --cov=jobflow_remote --cov-report= --cov-config pyproject.toml --ignore tests/integration
 
       - name: Integration tests
-        run: pytest --cov=jobflow_remote --cov-append --cov-report=xml --cov-config pyproject.toml tests/integration
+        run: COVERAGE_FILE=.coverage.2 pytest --cov=jobflow_remote --cov-report= --cov-config pyproject.toml tests/integration
+
+      # combining the reports with --cov-append did not seem to work
+      - name: Generate coverage report
+        run: |
+          coverage combine .coverage.1 .coverage.2
+          coverage xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     - tokenize-rt==4.1.0
     - types-paramiko
     - pydantic~=2.0
+    - types-python-dateutil
 - repo: https://github.com/codespell-project/codespell
   rev: v2.3.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "jobflow >= 0.1.14",
     "psutil >= 5.9,< 7.0",
     "pydantic ~= 2.4",
+    "python-dateutil>=2.8.2",
     "qtoolkit ~= 0.1, >= 0.1.4",
     "rich ~= 13.7",
     "ruamel.yaml >= 0.17",

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -333,6 +333,9 @@ def report(
         ),
     ] = None,
 ):
+    """
+    Generate a report about the Flows in the database.
+    """
     jc = get_job_controller()
 
     timezone = datetime.now(tzlocal()).tzname()

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -1,12 +1,18 @@
+from datetime import datetime
 from typing import Annotated, Optional
 
 import typer
+from dateutil.tz import tzlocal
 from jobflow.utils.graph import draw_graph
 from rich.prompt import Confirm
 from rich.text import Text
 
 from jobflow_remote import SETTINGS
-from jobflow_remote.cli.formatting import format_flow_info, get_flow_info_table
+from jobflow_remote.cli.formatting import (
+    format_flow_info,
+    get_flow_info_table,
+    get_flow_report_components,
+)
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
@@ -31,6 +37,7 @@ from jobflow_remote.cli.types import (
     verbosity_opt,
 )
 from jobflow_remote.cli.utils import (
+    ReportInterval,
     SortOption,
     check_incompatible_opt,
     exit_with_error_msg,
@@ -42,6 +49,7 @@ from jobflow_remote.cli.utils import (
     out_console,
 )
 from jobflow_remote.jobs.graph import get_graph, plot_dash
+from jobflow_remote.jobs.report import FlowsReport
 
 app_flow = JFRTyper(
     name="flow", help="Commands for managing the flows", no_args_is_help=True
@@ -306,3 +314,33 @@ def graph(
             plt.savefig(file_path)
         else:
             plt.show()
+
+
+@app_flow.command()
+def report(
+    interval: Annotated[
+        ReportInterval,
+        typer.Argument(
+            help="The interval of the trends for the report",
+            metavar="INTERVAL",
+        ),
+    ] = ReportInterval.DAYS,
+    num_intervals: Annotated[
+        Optional[int],
+        typer.Argument(
+            help="The number of intervals to consider. Default depends on the interval type",
+            metavar="NUM_INTERVALS",
+        ),
+    ] = None,
+):
+    jc = get_job_controller()
+
+    timezone = datetime.now(tzlocal()).tzname()
+
+    jobs_report = FlowsReport.generate_report(
+        job_controller=jc,
+        interval=interval.value,
+        num_intervals=num_intervals,
+        timezone=timezone,
+    )
+    out_console.print(*get_flow_report_components(jobs_report))

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -329,7 +329,7 @@ def get_job_report_components(report: JobsReport) -> list[RenderableType]:
     # Find the max count to normalize the histograms
     max_count = max(*state_counts.values(), 1)
 
-    total_count = sum(state_counts.values())
+    total_count = sum(state_counts.values()) or 1
 
     # Display job states in a histogram
     state_colors = {
@@ -432,7 +432,7 @@ def get_flow_report_components(report: FlowsReport) -> list[RenderableType]:
     # Find the max count to normalize the histograms
     max_count = max(*state_counts.values(), 1)
 
-    total_count = sum(state_counts.values())
+    total_count = sum(state_counts.values()) or 1
 
     # Display job states in a histogram
     state_colors = {

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -6,17 +6,21 @@ import time
 from typing import TYPE_CHECKING
 
 from monty.json import jsanitize
+from rich.panel import Panel
 from rich.scope import render_scope
 from rich.table import Table
 from rich.text import Text
 
 from jobflow_remote.cli.utils import ReprStr, fmt_datetime
-from jobflow_remote.jobs.state import JobState
+from jobflow_remote.jobs.state import FlowState, JobState
 from jobflow_remote.utils.data import convert_utc_time
 
 if TYPE_CHECKING:
+    from rich.console import RenderableType
+
     from jobflow_remote.config.base import ExecutionConfig, WorkerBase
     from jobflow_remote.jobs.data import FlowInfo, JobDoc, JobInfo
+    from jobflow_remote.jobs.report import FlowsReport, JobsReport
 
 
 def get_job_info_table(jobs_info: list[JobInfo], verbosity: int):
@@ -136,6 +140,33 @@ def get_flow_info_table(flows_info: list[FlowInfo], verbosity: int):
     return table
 
 
+JOB_INFO_ORDER = [
+    "db_id",
+    "uuid",
+    "index",
+    "name",
+    "state",
+    "error",
+    "remote",
+    "previous_state",
+    "job",
+    "created_on",
+    "updated_on",
+    "start_time",
+    "end_time",
+    "metadata",
+    "run_dir",
+    "parents",
+    "priority",
+    "worker",
+    "resources",
+    "exec_config",
+    "lock_id",
+    "lock_time",
+    "stored_data",
+]
+
+
 def format_job_info(
     job_info: JobInfo | JobDoc, verbosity: int, show_none: bool = False
 ):
@@ -162,7 +193,14 @@ def format_job_info(
     if remote_error:
         d["remote"]["error"] = ReprStr(remote_error)
 
-    return render_scope(d)
+    # reorder the keys
+    # Do not check here that all the keys in JobInfo are in JOB_INFO_ORDER. Check in the tests
+    sorted_d = {}
+    for k in JOB_INFO_ORDER:
+        if k in d:
+            sorted_d[k] = d[k]
+
+    return render_scope(sorted_d, sort_keys=False)
 
 
 def format_flow_info(flow_info: FlowInfo):
@@ -255,3 +293,188 @@ def get_worker_table(workers: dict[str, WorkerBase], verbosity: int = 0):
         table.add_row(*row)
 
     return table
+
+
+def create_bar(count, max_count, size=30, color="white"):
+    """Creates a text-based bar for a histogram with fixed color per state."""
+    bar_filled = "█" * int(size * count / max_count)
+    bar_empty = " " * (size - len(bar_filled))
+    return f"[{color}]{bar_filled}[white]{bar_empty}"
+
+
+def get_job_report_components(report: JobsReport) -> list[RenderableType]:
+    components = []
+
+    # Summary of Key Metrics
+    summary_table = Table(title="Job Summary", title_style="bold green")
+    summary_table.add_column("Metric", style="cyan", justify="right")
+    summary_table.add_column("Count", style="green", justify="center")
+
+    summary_table.add_row("Completed Jobs", str(report.completed))
+    summary_table.add_row("Running Jobs", str(report.running))
+    summary_table.add_row("Error Jobs", str(report.error))
+    summary_table.add_row("Active Jobs", str(report.active))
+
+    components.append(summary_table)
+
+    # Job State Distribution
+    components.append(
+        Panel("[bold green]Job State Distribution[/bold green]", expand=False)
+    )
+
+    # Remove COMPLETED, as this will likely account for most of the jobs present in the DB
+    state_counts = dict(report.state_counts)
+    state_counts.pop(JobState.COMPLETED)
+
+    # Find the max count to normalize the histograms
+    max_count = max(*state_counts.values(), 1)
+
+    total_count = sum(state_counts.values())
+
+    # Display job states in a histogram
+    state_colors = {
+        JobState.WAITING: "grey39",
+        JobState.READY: "cyan",
+        JobState.CHECKED_OUT: "bright_cyan",
+        JobState.UPLOADED: "deep_sky_blue1",
+        JobState.SUBMITTED: "blue",
+        JobState.RUNNING: "green",
+        JobState.TERMINATED: "red",
+        JobState.DOWNLOADED: "blue_violet",
+        JobState.REMOTE_ERROR: "yellow",
+        JobState.COMPLETED: "green",
+        JobState.FAILED: "red",
+        JobState.PAUSED: "magenta",
+        JobState.STOPPED: "dark_orange",
+        JobState.USER_STOPPED: "orange4",
+        JobState.BATCH_SUBMITTED: "light_slate_blue",
+        JobState.BATCH_RUNNING: "chartreuse3",
+    }
+
+    newline = ""
+    for state, color in state_colors.items():
+        if state not in state_counts:
+            continue
+        count = state_counts[state]
+        percentage = round((count / total_count) * 100)
+        bar = create_bar(count, max_count, color=color)
+        components.extend(
+            [f"{newline}{state.name:15} [{count:>3}] ({percentage:>3}%):", bar]
+        )
+        newline = "\n"
+
+    # Longest Running Jobs
+    if report.longest_running:
+        longest_running_table = get_job_info_table(report.longest_running, verbosity=1)
+        longest_running_table.title = "Longest running jobs"
+        longest_running_table.title_style = "bold green"
+        components.append(longest_running_table)
+
+    # Worker Utilization
+    if report.worker_utilization:
+        worker_table = Table(title="Worker Jobs Distribution", title_style="bold green")
+        worker_table.add_column("Worker", style="cyan", justify="center")
+        worker_table.add_column("Job Count", style="green", justify="center")
+
+        for worker, count in report.worker_utilization.items():
+            worker_table.add_row(worker, str(count))
+
+        components.append(worker_table)
+
+    # Job Trends
+    if report.trends:
+        trends = report.trends
+        trends_table = Table(
+            title=f"Job Trends ({trends.num_intervals} {trends.interval}) [{trends.timezone}]",
+            title_style="bold green",
+        )
+        trends_table.add_column("Date", justify="center", style="cyan", no_wrap=True)
+        trends_table.add_column("Completed", justify="center", style="green")
+        trends_table.add_column("Failed", justify="center", style="red")
+        trends_table.add_column("Remote Error", justify="center", style="yellow")
+
+        for i in range(trends.num_intervals):
+            trends_table.add_row(
+                trends.dates[i],
+                f"{trends.completed[i]}",
+                f"{trends.failed[i]}",
+                f"{trends.remote_error[i]}",
+            )
+
+        components.append(trends_table)
+
+    return components
+
+
+def get_flow_report_components(report: FlowsReport) -> list[RenderableType]:
+    components = []
+
+    # Summary of Key Metrics
+    summary_table = Table(title="Flow Summary", title_style="bold green")
+    summary_table.add_column("Metric", style="cyan", justify="right")
+    summary_table.add_column("Count", style="green", justify="center")
+
+    summary_table.add_row("Completed Flows", str(report.completed))
+    summary_table.add_row("Running Flows", str(report.running))
+    summary_table.add_row("Error Flows", str(report.error))
+
+    components.append(summary_table)
+
+    # Job State Distribution
+    components.append(
+        Panel("[bold green]Flow State Distribution[/bold green]", expand=False)
+    )
+
+    # Remove COMPLETED, as this will likely account for most of the jobs present in the DB
+    state_counts = dict(report.state_counts)
+    state_counts.pop(FlowState.COMPLETED)
+
+    # Find the max count to normalize the histograms
+    max_count = max(*state_counts.values(), 1)
+
+    total_count = sum(state_counts.values())
+
+    # Display job states in a histogram
+    state_colors = {
+        FlowState.WAITING: "grey39",
+        FlowState.READY: "cyan",
+        FlowState.RUNNING: "green",
+        FlowState.COMPLETED: "green",
+        FlowState.FAILED: "red",
+        FlowState.PAUSED: "magenta",
+        FlowState.STOPPED: "dark_orange",
+    }
+
+    newline = ""
+    for state, color in state_colors.items():
+        if state not in state_counts:
+            continue
+        count = state_counts[state]
+        percentage = round((count / total_count) * 100)
+        bar = create_bar(count, max_count, color=color)
+        components.extend(
+            [f"{newline}{state.name:15} [{count:>3}] ({percentage:>3}%):", bar]
+        )
+        newline = "\n"
+
+    # Job Trends
+    if report.trends:
+        trends = report.trends
+        trends_table = Table(
+            title=f"Flow Trends ({trends.num_intervals} {trends.interval}) [{trends.timezone}]",
+            title_style="bold green",
+        )
+        trends_table.add_column("Date", justify="center", style="cyan", no_wrap=True)
+        trends_table.add_column("Completed", justify="center", style="green")
+        trends_table.add_column("Failed", justify="center", style="red")
+
+        for i in range(trends.num_intervals):
+            trends_table.add_row(
+                trends.dates[i],
+                f"{trends.completed[i]}",
+                f"{trends.failed[i]}",
+            )
+
+        components.append(trends_table)
+
+    return components

--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -143,16 +143,6 @@ def tree(
 ):
     """
     Display a tree representation of the CLI command structure.
-
-    This command shows the structure of the CLI application as a tree, with options to customize the output.
-
-    Args:
-        ctx (typer.Context): The Typer context object.
-        start_path (List[str]): Path to the starting command for the tree.
-        show_options (bool): If True, show command options in the tree.
-        show_docs (bool): If True, show documentation for commands and options.
-        show_hidden (bool): If True, show hidden commands.
-        max_depth (Optional[int]): Maximum depth of the tree to display.
     """
     # Get the top-level app
     main_app = ctx.find_root().command

--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -1,15 +1,13 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from rich.text import Text
-from rich.tree import Tree
 
 from jobflow_remote.cli.jfr_typer import JFRTyper
+from jobflow_remote.cli.types import tree_opt
 from jobflow_remote.cli.utils import (
     cleanup_job_controller,
     complete_profiling,
-    find_subcommand,
-    get_command_tree,
     get_config_manager,
     initialize_config_manager,
     out_console,
@@ -68,6 +66,7 @@ def main(
             hidden=True,
         ),
     ] = False,
+    print_tree: tree_opt = False,  # If selected will print the tree of the CLI and exit
 ) -> None:
     """The controller CLI for jobflow-remote."""
     from jobflow_remote import SETTINGS
@@ -99,67 +98,3 @@ def main(
     except ConfigError:
         # no warning printed if not needed as this seems to be confusing for the user
         pass
-
-
-@app.command()
-def tree(
-    ctx: typer.Context,
-    start_path: Annotated[
-        Optional[list[str]],
-        typer.Argument(help="Path to the starting command. e.g. 'jf tree job set'"),
-    ] = None,
-    show_options: Annotated[
-        bool,
-        typer.Option(
-            "--options",
-            "-o",
-            help="Show command options in the tree",
-        ),
-    ] = False,
-    show_docs: Annotated[
-        bool,
-        typer.Option(
-            "--docs",
-            "-D",
-            help="Show hidden commands",
-        ),
-    ] = False,
-    show_hidden: Annotated[
-        bool,
-        typer.Option(
-            "--hidden",
-            "-h",
-            help="Show hidden commands",
-        ),
-    ] = False,
-    max_depth: Annotated[
-        Optional[int],
-        typer.Option(
-            "--max-depth",
-            "-d",
-            help="Maximum depth of the tree to display",
-        ),
-    ] = None,
-):
-    """
-    Display a tree representation of the CLI command structure.
-    """
-    # Get the top-level app
-    main_app = ctx.find_root().command
-
-    if start_path:
-        start_command = find_subcommand(main_app, start_path)
-        if start_command is None:
-            typer.echo(f"Error: Command '{' '.join(start_path)}' not found", err=True)
-            raise typer.Exit(code=1)
-        tree_title = f"[bold red]{' '.join(start_path)}[/bold red]"
-    else:
-        start_command = main_app
-        tree_title = "[bold red]CLI App[/bold red]"
-
-    tree = Tree(tree_title)
-    command_tree = get_command_tree(
-        start_command, tree, show_options, show_docs, show_hidden, max_depth
-    )
-
-    out_console.print(command_tree)

--- a/src/jobflow_remote/cli/jfr_typer.py
+++ b/src/jobflow_remote/cli/jfr_typer.py
@@ -3,6 +3,7 @@ from typing import Callable
 import typer
 from typer.models import CommandFunctionType
 
+from jobflow_remote.cli.types import tree_opt
 from jobflow_remote.cli.utils import cli_error_handler
 
 
@@ -17,6 +18,9 @@ class JFRTyper(typer.Typer):
 
         if "rich_markup_mode" not in kwargs:
             kwargs["rich_markup_mode"] = "rich"
+
+        if "callback" not in kwargs:
+            kwargs["callback"] = default_callback
 
         # if "result_callback" not in kwargs:
         #     kwargs["result_callback"] = test_cb
@@ -44,3 +48,7 @@ class JFRTyper(typer.Typer):
             return typer_wrapper(fn)
 
         return wrapper
+
+
+def default_callback(print_tree: tree_opt = False):
+    pass

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -704,6 +704,9 @@ def report(
         ),
     ] = None,
 ):
+    """
+    Generate a report about the Jobs in the database.
+    """
     jc = get_job_controller()
 
     timezone = datetime.now(tzlocal()).tzname()
@@ -718,7 +721,7 @@ def report(
 
 
 app_job_set = JFRTyper(
-    name="set", help="Commands for managing the jobs", no_args_is_help=True
+    name="set", help="Commands for setting properties for jobs", no_args_is_help=True
 )
 app_job.add_typer(app_job_set)
 
@@ -1162,6 +1165,9 @@ def files_get(
         ),
     ] = None,
 ) -> None:
+    """
+    Retrieve files from the Job's execution folder.
+    """
     db_id, job_id = get_job_db_ids(job_db_id, job_index)
 
     cm = get_config_manager()

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -7,7 +7,12 @@ from rich.text import Text
 from jobflow_remote.cli.formatting import get_exec_config_table, get_worker_table
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
-from jobflow_remote.cli.types import force_opt, serialize_file_format_opt, verbosity_opt
+from jobflow_remote.cli.types import (
+    force_opt,
+    serialize_file_format_opt,
+    tree_opt,
+    verbosity_opt,
+)
 from jobflow_remote.cli.utils import (
     SerializeFileFormat,
     check_incompatible_opt,
@@ -86,7 +91,10 @@ def list_projects(
 
 
 @app_project.callback(invoke_without_command=True)
-def current_project(ctx: typer.Context) -> None:
+def current_project(
+    ctx: typer.Context,
+    print_tree: tree_opt = False,  # If selected will print the tree of the CLI and exit
+) -> None:
     """Print the list of the project currently selected."""
     # only run if no other subcommand is executed
     if ctx.invoked_subcommand is None:
@@ -266,6 +274,9 @@ app_project.add_typer(app_exec_config)
 def list_exec_config(
     verbosity: verbosity_opt = 0,
 ) -> None:
+    """
+    The list of defined Execution configurations
+    """
     cm = get_config_manager()
     project = cm.get_project()
     table = get_exec_config_table(project.exec_config, verbosity)
@@ -289,6 +300,9 @@ app_project.add_typer(app_worker)
 def list_worker(
     verbosity: verbosity_opt = 0,
 ) -> None:
+    """
+    The list of defined workers
+    """
     cm = get_config_manager()
     project = cm.get_project()
     table = get_worker_table(project.workers, verbosity)

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -9,9 +9,20 @@ from jobflow_remote.cli.utils import (
     SerializeFileFormat,
     SortOption,
     str_to_dict,
+    tree_callback,
 )
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import FlowState, JobState
+
+tree_opt = Annotated[
+    bool,
+    typer.Option(
+        "--tree",
+        help="Display a tree representation of the CLI command structure",
+        is_eager=True,
+        callback=tree_callback,
+    ),
+]
 
 job_ids_indexes_opt = Annotated[
     Optional[list[str]],

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -63,7 +63,7 @@ from jobflow_remote.utils.db import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Generator, Sequence
 
     from maggma.stores import MongoStore
 
@@ -2946,7 +2946,7 @@ class JobController:
 
     def get_trends(
         self,
-        states: list[JobState | FlowState],
+        states: Sequence[JobState | FlowState],
         interval: str = "days",
         num_intervals: int | None = None,
         interval_timezone: str = "UTC",
@@ -3017,7 +3017,7 @@ class JobController:
 
         if isinstance(states[0], JobState):
             collection = self.jobs
-            state_cls = JobState
+            state_cls: type = JobState
         elif isinstance(states[0], FlowState):
             collection = self.flows
             state_cls = FlowState

--- a/src/jobflow_remote/jobs/report.py
+++ b/src/jobflow_remote/jobs/report.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from jobflow_remote.jobs.data import JobInfo, projection_job_info
+from jobflow_remote.jobs.state import FlowState, JobState
+
+if TYPE_CHECKING:
+    from jobflow_remote import JobController
+
+
+@dataclass
+class JobTrends:
+    """
+    Trends of job states over time.
+    """
+
+    interval: str
+    dates: list[str]
+    completed: list[int]
+    failed: list[int]
+    remote_error: list[int]
+    timezone: str
+
+    @property
+    def num_intervals(self) -> int:
+        return len(self.dates)
+
+
+@dataclass
+class JobsReport:
+    """
+    A report of the job states.
+    """
+
+    state_counts: dict[JobState, int] = field(default_factory=dict)
+    trends: JobTrends | None = None
+    longest_running: list[JobInfo] = field(default_factory=list)
+    worker_utilization: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def running(self) -> int:
+        """Returns the count of running jobs."""
+        return self.state_counts.get(JobState.RUNNING, 0)
+
+    @property
+    def completed(self) -> int:
+        """Returns the count of completed jobs."""
+        return self.state_counts.get(JobState.COMPLETED, 0)
+
+    @property
+    def error(self) -> int:
+        """Returns the sum of failed, remote error, and paused jobs (i.e., error states)."""
+        return sum(
+            self.state_counts.get(state, 0)
+            for state in [JobState.FAILED, JobState.REMOTE_ERROR]
+        )
+
+    @property
+    def active(self) -> int:
+        """Returns the sum of failed, remote error, and paused jobs (i.e., error states)."""
+        return sum(
+            self.state_counts.get(state, 0)
+            for state in [
+                JobState.CHECKED_OUT,
+                JobState.UPLOADED,
+                JobState.UPLOADED,
+                JobState.SUBMITTED,
+                JobState.RUNNING,
+                JobState.TERMINATED,
+                JobState.DOWNLOADED,
+                JobState.BATCH_SUBMITTED,
+                JobState.BATCH_RUNNING,
+            ]
+        )
+
+    @classmethod
+    def generate_report(
+        cls,
+        job_controller: JobController,
+        interval: str = "days",
+        num_intervals: int | None = None,
+        timezone: str = "UTC",
+    ) -> JobsReport:
+        """
+        Generates a report of the job states.
+
+        Parameters
+        ----------
+        job_controller
+            The JobController instance to generate the report from.
+        interval
+            The interval of the trends for the report.
+        num_intervals
+            The number of intervals to consider.
+        timezone
+            The timezone to use for the report.
+
+        Returns
+        -------
+        JobsReport
+            A report of the job states.
+        """
+        now = datetime.utcnow()
+
+        state_counts = job_controller.count_jobs_states(list(JobState))
+
+        # Job trends over time
+        states_trends = [JobState.COMPLETED, JobState.FAILED, JobState.REMOTE_ERROR]
+        trends_dict = job_controller.get_trends(
+            states=states_trends,
+            interval=interval,
+            num_intervals=num_intervals,
+            interval_timezone=timezone,
+        )
+        trends_dates = sorted(trends_dict)
+        trends = JobTrends(
+            interval=interval,
+            dates=trends_dates,
+            completed=[trends_dict[d][JobState.COMPLETED] for d in trends_dates],
+            failed=[trends_dict[d][JobState.FAILED] for d in trends_dates],
+            remote_error=[trends_dict[d][JobState.REMOTE_ERROR] for d in trends_dates],
+            timezone=timezone,
+        )
+
+        # Longest running jobs (Top 5)
+        projection_longest: dict = {k: 1 for k in projection_job_info}
+        projection_longest["duration"] = {"$subtract": [now, "$start_time"]}
+        pipeline_longest = [
+            {"$match": {"state": "RUNNING"}},
+            {"$project": projection_longest},
+            {"$sort": {"duration": -1}},
+            {"$limit": 5},
+        ]
+        longest_running_result = job_controller.jobs.aggregate(pipeline_longest)
+        longest_running = [
+            JobInfo.from_query_output(doc) for doc in longest_running_result
+        ]
+
+        # Worker utilization (number of jobs assigned to each worker)
+        pipeline_worker_utilization = [
+            {"$group": {"_id": "$worker", "count": {"$sum": 1}}},
+            {"$sort": {"count": -1}},
+        ]
+        worker_utilization_result = job_controller.jobs.aggregate(
+            pipeline_worker_utilization
+        )
+        worker_utilization = {
+            doc["_id"]: doc["count"] for doc in worker_utilization_result
+        }
+
+        return cls(
+            state_counts=state_counts,
+            trends=trends,
+            longest_running=longest_running,
+            worker_utilization=worker_utilization,
+        )
+
+
+@dataclass
+class FlowTrends:
+    """
+    Trends of flow states over time.
+    """
+
+    interval: str
+    dates: list[str]
+    completed: list[int]
+    failed: list[int]
+    timezone: str
+
+    @property
+    def num_intervals(self) -> int:
+        return len(self.dates)
+
+
+@dataclass
+class FlowsReport:
+    """
+    A report of the flow states.
+    """
+
+    state_counts: dict[FlowState, int]
+    trends: FlowTrends
+
+    @property
+    def running(self) -> int:
+        """Returns the count of running flows."""
+        return self.state_counts.get(FlowState.RUNNING, 0)
+
+    @property
+    def completed(self) -> int:
+        """Returns the count of completed flows."""
+        return self.state_counts.get(FlowState.COMPLETED, 0)
+
+    @property
+    def error(self) -> int:
+        """Returns the count of failed flows."""
+        return self.state_counts.get(FlowState.FAILED, 0)
+
+    @classmethod
+    def generate_report(
+        cls,
+        job_controller: JobController,
+        interval: str = "days",
+        num_intervals: int = None,
+        timezone: str = "UTC",
+    ):
+        """
+        Generates a report of the flow states.
+
+        Parameters
+        ----------
+        job_controller
+            The JobController instance to generate the report from.
+        interval
+            The interval of the trends for the report.
+        num_intervals
+            The number of intervals to consider.
+        timezone
+            The timezone to use for the report.
+
+        Returns
+        -------
+        FlowsReport
+            A report of the flow states.
+        """
+        state_counts = job_controller.count_flows_states(list(FlowState))
+
+        trends_dict = job_controller.get_trends(
+            states=[FlowState.COMPLETED, FlowState.FAILED],
+            interval=interval,
+            num_intervals=num_intervals,
+            interval_timezone=timezone,
+        )
+        trends_dates = sorted(trends_dict)
+        trends = FlowTrends(
+            interval=interval,
+            dates=trends_dates,
+            completed=[trends_dict[d][FlowState.COMPLETED] for d in trends_dates],
+            failed=[trends_dict[d][FlowState.FAILED] for d in trends_dates],
+            timezone=timezone,
+        )
+
+        # Create report instance
+        return cls(state_counts=state_counts, trends=trends)

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -8,6 +8,8 @@ from typing import Any
 from uuid import UUID
 
 import maggma.stores  # required to enable subclass searching
+from dateutil.relativedelta import relativedelta
+from dateutil.tz import gettz
 from maggma.core.store import Store
 from monty.json import MontyDecoder
 
@@ -144,6 +146,78 @@ def convert_utc_time(datetime_value: datetime) -> datetime:
         The datetime in the zone of the current system
     """
     return datetime_value.replace(tzinfo=timezone.utc).astimezone(tz=None)
+
+
+def get_past_time_rounded(
+    interval: str, num_intervals: int, reference: datetime | None = None
+) -> datetime:
+    """
+    Return a datetime object that is the specified number of intervals in the
+    past relative to the given reference datetime. The returned datetime is
+    rounded to the nearest interval start time.
+
+    Parameters
+    ----------
+    interval
+        One of 'hours', 'days', 'weeks', 'months', 'years'
+    num_intervals
+        The number of intervals to go back in time
+    reference
+        The datetime to use as the reference for the calculation. If not
+        specified, the current time is used.
+
+    Returns
+    -------
+    datetime
+        The datetime object that is the specified number of intervals in the
+        past relative to the given reference datetime.
+    """
+    if not reference:
+        reference = datetime.utcnow()
+    past = reference - relativedelta(**{interval: num_intervals - 1})  # type: ignore[arg-type]
+
+    # Define starting point modifications based on quantity type
+    start_modifiers = {
+        "hours": lambda dt: dt.replace(minute=0, second=0, microsecond=0),
+        "days": lambda dt: dt.replace(hour=0, minute=0, second=0, microsecond=0),
+        "weeks": lambda dt: dt.replace(hour=0, minute=0, second=0, microsecond=0)
+        - relativedelta(days=dt.weekday()),
+        "months": lambda dt: dt.replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        ),
+        "years": lambda dt: dt.replace(
+            month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        ),
+    }
+
+    return start_modifiers[interval](past)
+
+
+def get_utc_offset(timezone: str):
+    # Get current time in the specified timezone
+    """
+    Return the UTC offset of the given timezone as a string.
+
+    Parameters
+    ----------
+    timezone
+        The timezone for which to get the UTC offset.
+
+    Returns
+    -------
+    str
+        The UTC offset as a string in the format +/-HH:MM.
+    """
+    now = datetime.now(gettz(timezone))
+
+    # Get the UTC offset
+    utc_offset = now.utcoffset()
+
+    # Extract hours and minutes
+    hours, remainder = divmod(utc_offset.total_seconds(), 3600)
+    minutes = remainder // 60
+
+    return f"{int(hours):+03d}:{int(minutes):02d}"
 
 
 # TODO imported this from jobflow remote for backward compatibility.

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -208,7 +208,10 @@ def get_utc_offset(timezone: str):
     str
         The UTC offset as a string in the format +/-HH:MM.
     """
-    now = datetime.now(gettz(timezone))
+    tz_info_val = gettz(timezone)
+    if not tz_info_val:
+        raise ValueError(f"Could not determine the timezone for {timezone}")
+    now = datetime.now(tz_info_val)
 
     # Get the UTC offset
     utc_offset = now.utcoffset()

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -139,3 +139,30 @@ def test_flow_info(job_controller, two_flows_four_jobs) -> None:
     run_check_cli(
         ["flow", "info", "-j", "1"], required_out=outputs, excluded_out=excluded
     )
+
+
+def test_report(job_controller) -> None:
+    from datetime import datetime
+
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.testing import add_sleep
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # a long sleeping job. Will not finish.
+    j = add_sleep(1, 10)
+    flow = Flow([j])
+    submit_flow(flow, worker="test_local_worker")
+
+    now = datetime.now()
+    output = [
+        "Flow Summary",
+        "Flow State Distribution",
+        "Flow Trends",
+        now.strftime("%Y-%m-%d"),
+    ]
+    run_check_cli(
+        ["flow", "report", "days", "2"],
+        required_out=[*output, "Running Flows │   0"],
+    )

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -150,11 +150,7 @@ def test_report(job_controller) -> None:
     from jobflow_remote.testing import add_sleep
     from jobflow_remote.testing.cli import run_check_cli
 
-    # a long sleeping job. Will not finish.
-    j = add_sleep(1, 10)
-    flow = Flow([j])
-    submit_flow(flow, worker="test_local_worker")
-
+    # run first with an empty db to check that everything works fine
     now = datetime.now()
     output = [
         "Flow Summary",
@@ -162,6 +158,16 @@ def test_report(job_controller) -> None:
         "Flow Trends",
         now.strftime("%Y-%m-%d"),
     ]
+    run_check_cli(
+        ["flow", "report", "days", "2"],
+        required_out=[*output, "Running Flows │   0"],
+    )
+
+    # a long sleeping job. Will not finish.
+    j = add_sleep(1, 10)
+    flow = Flow([j])
+    submit_flow(flow, worker="test_local_worker")
+
     run_check_cli(
         ["flow", "report", "days", "2"],
         required_out=[*output, "Running Flows │   0"],

--- a/tests/db/cli/test_formatting.py
+++ b/tests/db/cli/test_formatting.py
@@ -1,0 +1,7 @@
+def test_job_info():
+    from jobflow_remote.cli.formatting import JOB_INFO_ORDER
+    from jobflow_remote.jobs.data import JobDoc, JobInfo
+
+    # check that all the keys in JobInfo and JobDoc are present in JOB_INFO_ORDER
+    assert set(JOB_INFO_ORDER).issuperset(set(JobInfo.model_fields.keys()))
+    assert set(JOB_INFO_ORDER).issuperset(set(JobDoc.model_fields.keys()))

--- a/tests/db/cli/test_jf.py
+++ b/tests/db/cli/test_jf.py
@@ -1,0 +1,26 @@
+def test_jobs_list() -> None:
+    from jobflow_remote.testing.cli import run_check_cli
+
+    outputs = ["job", "set", "resources", "admin"]
+    excluded = ["execution", "start_date"]  # hidden, option
+    run_check_cli(["tree"], required_out=outputs, excluded_out=excluded)
+
+    # max depth
+    outputs = ["job", "set"]
+    excluded = ["execution", "start_date", "resources"]
+    run_check_cli(["tree", "-d", "2"], required_out=outputs, excluded_out=excluded)
+
+    # hidden
+    outputs = ["job", "set", "resources", "execution"]
+    excluded = ["start_date"]
+    run_check_cli(["tree", "-h"], required_out=outputs, excluded_out=excluded)
+
+    # options
+    outputs = ["job", "set", "resources", "start_date"]
+    excluded = ["execution"]
+    run_check_cli(["tree", "-o"], required_out=outputs, excluded_out=excluded)
+
+    # start from
+    outputs = ["job set", "resources"]
+    excluded = ["execution", "start_date", "admin"]
+    run_check_cli(["tree", "job", "set"], required_out=outputs, excluded_out=excluded)

--- a/tests/db/cli/test_jf.py
+++ b/tests/db/cli/test_jf.py
@@ -2,25 +2,10 @@ def test_jobs_list() -> None:
     from jobflow_remote.testing.cli import run_check_cli
 
     outputs = ["job", "set", "resources", "admin"]
-    excluded = ["execution", "start_date"]  # hidden, option
-    run_check_cli(["tree"], required_out=outputs, excluded_out=excluded)
+    excluded = ["─ execution", "start_date"]  # hidden, option
+    run_check_cli(["--tree"], required_out=outputs, excluded_out=excluded)
 
-    # max depth
-    outputs = ["job", "set"]
-    excluded = ["execution", "start_date", "resources"]
-    run_check_cli(["tree", "-d", "2"], required_out=outputs, excluded_out=excluded)
-
-    # hidden
-    outputs = ["job", "set", "resources", "execution"]
-    excluded = ["start_date"]
-    run_check_cli(["tree", "-h"], required_out=outputs, excluded_out=excluded)
-
-    # options
-    outputs = ["job", "set", "resources", "start_date"]
-    excluded = ["execution"]
-    run_check_cli(["tree", "-o"], required_out=outputs, excluded_out=excluded)
-
-    # start from
-    outputs = ["job set", "resources"]
-    excluded = ["execution", "start_date", "admin"]
-    run_check_cli(["tree", "job", "set"], required_out=outputs, excluded_out=excluded)
+    # test also on subcommands
+    outputs = ["job", "resources"]
+    excluded = ["─ execution", "start_date", "admin"]
+    run_check_cli(["job", "--tree"], required_out=outputs, excluded_out=excluded)

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -400,20 +400,29 @@ def test_report(job_controller) -> None:
     from jobflow_remote.testing import add_sleep
     from jobflow_remote.testing.cli import run_check_cli
 
+    now = datetime.now()
+    output = [
+        "Job Summary",
+        "Job State Distribution",
+        "Job Trends",
+        now.strftime("%Y-%m-%d"),
+    ]
+    excluded = ["Longest running jobs"]
+
+    # run first with an empty db to check that everything works fine
+    run_check_cli(
+        ["job", "report", "days", "2"],
+        required_out=[*output, "Running Jobs │   0"],
+        excluded_out=excluded,
+    )
+
     # a long sleeping job. Will not finish.
     j = add_sleep(1, 10)
     flow = Flow([j])
     submit_flow(flow, worker="test_local_worker")
 
-    now = datetime.now()
-    output = [
-        "Job Summary",
-        "Job State Distribution",
-        "Worker Jobs Distribution",
-        "Job Trends",
-        now.strftime("%Y-%m-%d"),
-    ]
-    excluded = ["Longest running jobs"]
+    output.append("Worker Jobs Distribution")
+
     run_check_cli(
         ["job", "report", "days", "2"],
         required_out=[*output, "Running Jobs │   0"],

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -390,7 +390,7 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
     )
 
 
-def test_report(job_controller, one_job) -> None:
+def test_report(job_controller) -> None:
     from datetime import datetime
 
     from jobflow import Flow

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -388,3 +388,42 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
         ["job", "play", "--name", "add*"],
         required_out="Operation completed: 1 jobs modified",
     )
+
+
+def test_report(job_controller, one_job) -> None:
+    from datetime import datetime
+
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.runner import Runner
+    from jobflow_remote.testing import add_sleep
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # a long sleeping job. Will not finish.
+    j = add_sleep(1, 10)
+    flow = Flow([j])
+    submit_flow(flow, worker="test_local_worker")
+
+    now = datetime.now()
+    output = [
+        "Job Summary",
+        "Job State Distribution",
+        "Worker Jobs Distribution",
+        "Job Trends",
+        now.strftime("%Y-%m-%d"),
+    ]
+    excluded = ["Longest running jobs"]
+    run_check_cli(
+        ["job", "report", "days", "2"],
+        required_out=[*output, "Running Jobs │   0"],
+        excluded_out=excluded,
+    )
+
+    runner = Runner()
+    runner.run(ticks=2)
+
+    run_check_cli(
+        ["job", "report", "days", "2"],
+        required_out=output + excluded + ["Running Jobs │   1"],
+    )

--- a/tests/db/jobs/test_report.py
+++ b/tests/db/jobs/test_report.py
@@ -1,0 +1,31 @@
+def test_jobs_report(job_controller, two_flows_four_jobs):
+    from datetime import datetime
+
+    import dateutil
+
+    from jobflow_remote.jobs.report import JobsReport
+    from jobflow_remote.jobs.runner import Runner
+
+    tzname = datetime.now(dateutil.tz.tzlocal()).tzname()
+
+    runner = Runner()
+    runner.run_one_job()
+
+    report = JobsReport.generate_report(job_controller=job_controller, timezone=tzname)
+    trends = report.trends
+    assert trends.interval == "days"
+    assert trends.num_intervals == 7
+    assert len(trends.dates) == 7
+    assert trends.completed[0] == 0
+    assert trends.completed[-1] == 1
+    assert trends.failed[-1] == 0
+    assert trends.remote_error[-1] == 0
+
+    assert report.completed == 1
+    assert report.running == 0
+    assert report.error == 0
+    assert report.active == 0
+
+    assert report.longest_running == []
+
+    assert report.worker_utilization["test_local_worker"] == 4

--- a/tests/db/utils/test_data.py
+++ b/tests/db/utils/test_data.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_get_past_time_rounded():
     from datetime import datetime
 
@@ -52,7 +55,9 @@ def test_get_past_time_rounded():
 def test_get_utc_offset():
     from jobflow_remote.utils.data import get_utc_offset
 
-    assert get_utc_offset("America/Los_Angeles") == r"-07:00"
-    assert get_utc_offset("CEST") == r"+02:00"
-    assert get_utc_offset("UTC") == r"+00:00"
-    assert get_utc_offset("Asia/Shanghai") == r"+08:00"
+    assert get_utc_offset("America/Los_Angeles") == "-07:00"
+    assert get_utc_offset("Europe/Paris") == "+02:00"
+    assert get_utc_offset("UTC") == "+00:00"
+    assert get_utc_offset("Asia/Shanghai") == "+08:00"
+    with pytest.raises(ValueError, match="Could not determine the timezone for XXX"):
+        get_utc_offset("XXX")

--- a/tests/db/utils/test_data.py
+++ b/tests/db/utils/test_data.py
@@ -1,0 +1,58 @@
+def test_get_past_time_rounded():
+    from datetime import datetime
+
+    from jobflow_remote.utils.data import get_past_time_rounded
+
+    ref_date = datetime.fromisoformat("2024-09-16T16:53:36.414174")
+
+    past = get_past_time_rounded(interval="hours", num_intervals=2, reference=ref_date)
+    assert ref_date.replace(hour=15, minute=0, second=0, microsecond=0) == past
+
+    past = get_past_time_rounded(interval="days", num_intervals=1, reference=ref_date)
+    assert ref_date.replace(day=16, hour=0, minute=0, second=0, microsecond=0) == past
+
+    past = get_past_time_rounded(interval="days", num_intervals=5, reference=ref_date)
+    assert ref_date.replace(day=12, hour=0, minute=0, second=0, microsecond=0) == past
+
+    past = get_past_time_rounded(interval="weeks", num_intervals=1, reference=ref_date)
+    assert ref_date.replace(day=16, hour=0, minute=0, second=0, microsecond=0) == past
+
+    past = get_past_time_rounded(interval="weeks", num_intervals=3, reference=ref_date)
+    assert ref_date.replace(day=2, hour=0, minute=0, second=0, microsecond=0) == past
+
+    past = get_past_time_rounded(interval="months", num_intervals=1, reference=ref_date)
+    assert (
+        ref_date.replace(month=9, day=1, hour=0, minute=0, second=0, microsecond=0)
+        == past
+    )
+
+    past = get_past_time_rounded(interval="months", num_intervals=3, reference=ref_date)
+    assert (
+        ref_date.replace(month=7, day=1, hour=0, minute=0, second=0, microsecond=0)
+        == past
+    )
+
+    past = get_past_time_rounded(interval="years", num_intervals=1, reference=ref_date)
+    assert (
+        ref_date.replace(
+            year=2024, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        == past
+    )
+
+    past = get_past_time_rounded(interval="years", num_intervals=4, reference=ref_date)
+    assert (
+        ref_date.replace(
+            year=2021, month=1, day=1, hour=0, minute=0, second=0, microsecond=0
+        )
+        == past
+    )
+
+
+def test_get_utc_offset():
+    from jobflow_remote.utils.data import get_utc_offset
+
+    assert get_utc_offset("America/Los_Angeles") == r"-07:00"
+    assert get_utc_offset("CEST") == r"+02:00"
+    assert get_utc_offset("UTC") == r"+00:00"
+    assert get_utc_offset("Asia/Shanghai") == r"+08:00"

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -59,7 +59,7 @@ def test_max_jobs_worker(job_controller, daemon_manager) -> None:
     running_states = (JobState.RUNNING, JobState.SUBMITTED)
 
     max_running_jobs = 0
-    for _ in range(20):
+    for _ in range(30):
         time.sleep(1)
         jobs_info = job_controller.get_jobs_info(job_ids=job_ids)
         if all(ji.state in finished_states for ji in jobs_info):


### PR DESCRIPTION
Some new functionalities for the CLI:
* To hopefully help new users explore the functionalities of the CLI, I have added a `jf tree` command. This prints a tree with the all the commands available. Can optionally control the depth of the tree, choose the starting point, show also the options for each command and the docstring for each branch of the tree. I thought it may be useful to have a quick bird-eye view if one is searching a specific command.
* A new functionality to get a summary report of the state of the Jobs and Flows in the DB. Modeled on the report from Fireworks, can summarize the current number of jobs in different states and trends over time. Commands: `jf job report`, `jf flow report`.
* Previously `jf job info` printed the content of `JobInfo` (or `JobDoc`) in alphabetical order. Now the order is predetermined, keeping close entried that are related to each other (e.g. all the dates).