### PR TITLE
Allow list of jobs from scheduler using username

### DIFF
--- a/doc/source/user/projectconf.rst
+++ b/doc/source/user/projectconf.rst
@@ -103,6 +103,14 @@ configurations. Those can better be set with the :ref:`projectconf execconfig`.
     If a single worker is defined it will be used as default in the submission
     of new Flows.
 
+.. warning::
+
+    By default, jobflow-remote fetches the status of the jobs from the scheduler by
+    passing the list of ids. If the selected scheduler does not support this option
+    (e.g. SGE), it is also necessary to specify the username on the worker machine
+    through the ``scheduler_username`` option. Jobflow-remote will use that as a filter,
+    instead of the list of ids.
+
 .. _projectconf jobstore:
 
 JobStore

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -177,6 +177,12 @@ class WorkerBase(BaseModel):
         None,
         description="Options for batch execution. If define the worker will be considered a batch worker",
     )
+    scheduler_username: Optional[str] = Field(
+        None,
+        description="If defined, the list of jobs running on the worker will be fetched based on the"
+        "username instead that from the list of job ids. May be necessary for some "
+        "scheduler_type (e.g. SGE)",
+    )
     model_config = ConfigDict(extra="forbid")
 
     @field_validator("scheduler_type")

--- a/src/jobflow_remote/remote/queue.py
+++ b/src/jobflow_remote/remote/queue.py
@@ -220,6 +220,10 @@ class QueueManager:
         user: str | None = None,
         timeout: int | None = None,
     ) -> list[QJob]:
+        # in order to avoid issues with schedulers that do not support query by
+        # list of job ids, if the user is passed ignore the job ids.
+        if user is not None:
+            jobs = None
         job_cmd = self.scheduler_io.get_jobs_list_cmd(jobs, user)
         stdout, stderr, returncode = self.execute_cmd(job_cmd, timeout=timeout)
         return self.scheduler_io.parse_jobs_list_output(


### PR DESCRIPTION
Some schedulers (e.g. SGE) do not allow fetching job details providing a list of job ids, which is how jobflow-remote usually gets information about the running jobs. See https://github.com/Matgenix/qtoolkit/pull/43. To avoid this issue an option to use the username as filtering option has been added. If it is present, the runner will use that instead of the list of ids. 

@QuantumChemist, do you think this will be fine for your use case?