### PR TITLE
Require date to reset DB

### DIFF
--- a/doc/source/user/projectconf.rst
+++ b/doc/source/user/projectconf.rst
@@ -239,28 +239,29 @@ Project specs
 
 .. _projectconf general:
 
-General Settings
-================
+General Settings - Environment variables
+========================================
 
 Aside from the project specific configuration, a few options can also be
 defined in general. There are two ways to set these options:
 
 * set the value in the ``~/.jfremote.yaml`` configuration file.
-* export the variable name prepended by the ``jfremote`` prefix::
+* set an environment variable composed by the name of the variable and
+  prepended by the ``JFREMOTE_`` prefix::
 
-    export jfremote_project=project_name
+    export JFREMOTE_PROJECT=project_name
 
 .. note::
 
-    The name of the exported variables is case-insensitive (i.e. JFREMOTE_PROJECT
+    The name of the exported variables is case-insensitive (i.e. jfremote_project
     is equally valid).
 
 The most useful variable to set is the ``project`` one, allowing to select the
 default project to be used in a multi-project environment.
 
 Other generic options are the location of the projects folder, instead of
-``~/.jfremote`` (``projects_folder``) and the path to the ``~/.jfremote.yaml``
-file itself (``config_file``).
+``~/.jfremote`` (``JFREMOTE_PROJECT_FOLDER``) and the path to the ``~/.jfremote.yaml``
+file itself (``JFREMOTE_CONFIG_FILE``).
 
 Some customization options are also available for the behaviour of the CLI.
 For more details see the API documentation :py:class:`jobflow_remote.config.settings.JobflowRemoteSettings`.

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -164,7 +164,7 @@ def job_controller(random_project_name):
     from jobflow_remote.jobs.jobcontroller import JobController
 
     jc = JobController.from_project_name(random_project_name)
-    assert jc.reset()
+    assert jc.reset(max_limit=0)
     return jc
 
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -558,11 +558,31 @@ def test_set_job_doc_properties(job_controller, one_job) -> None:
 
 
 def test_reset(job_controller, two_flows_four_jobs):
+    from datetime import datetime
+
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.testing import add
+
     assert job_controller.count_jobs() == 4
 
     assert not job_controller.reset(max_limit=1)
+    assert job_controller.count_jobs() == 4
     assert job_controller.reset(max_limit=10, reset_output=True)
 
+    assert job_controller.count_jobs() == 0
+
+    for _ in range(4):
+        f = Flow(add(1, 2))
+        submit_flow(f, worker="test_local_worker")
+
+    assert job_controller.count_jobs() == 4
+    assert not job_controller.reset(max_limit=1, validation="1327-01-01")
+    assert job_controller.count_jobs() == 4
+    assert job_controller.reset(
+        max_limit=1, validation=datetime.now().strftime("%Y-%m-%d")
+    )
     assert job_controller.count_jobs() == 0
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -286,5 +286,5 @@ def job_controller(random_project_name):
     from jobflow_remote.jobs.jobcontroller import JobController
 
     jc = JobController.from_project_name(random_project_name)
-    assert jc.reset()
+    assert jc.reset(max_limit=0)
     return jc


### PR DESCRIPTION
After some internal discussion, we have decided to address  #102 by requiring the addition of today's date from the CLI to reduce the probability of an accidental DB reset.

This also includes an update of the documentation concerning configuration with environment variables. @janosh, can you check if this fits your expectations?