### PR TITLE
Add backup functionality

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -56,6 +56,9 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
+      - name: Install mongo-tools
+        run: sudo dpkg -l mongodb-database-tools
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -57,7 +57,9 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       - name: Install mongo-tools
-        run: sudo dpkg -l mongodb-database-tools
+        run: |
+          wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.10.0.deb
+          sudo apt install ./mongodb-database-tools-*-100.10.0.deb
 
       - name: Install dependencies
         run: |

--- a/doc/source/user/backup.rst
+++ b/doc/source/user/backup.rst
@@ -22,7 +22,7 @@ There are two options to create and restore a backup. The default relies on the 
 MongoDB tools: ``mongodump`` and ``mongorestore``. For this to work the
 `MongoDB database tools <https://www.mongodb.com/docs/database-tools>`_  need to be
 installed. The connection details provided in the project configuration will be used
-to executed the commands. This is the preferred option, since it is faster and also
+to execute the commands. This is the preferred option, since it is faster and also
 dumps and restores all the metadata of the collections. However, not all the connection
 options defined in the ``queue`` Store may be supported or it may be not possible
 to install the tools. For this reason a second option, based on a pure python implementation

--- a/doc/source/user/backup.rst
+++ b/doc/source/user/backup.rst
@@ -1,0 +1,82 @@
+.. _backup:
+
+******
+Backup
+******
+
+As explained in the :ref:`projectconf` section, jobflow-remote uses a MongoDB
+database to store the information about the state of Jobs and Flows. This is
+defined in the ``queue`` section of the project configuration.
+In several circumstances it may be required to perform a backup of this
+database. For this reason jobflow-remote offers an option to create a dump
+of the relevant collections for a project and restore it if needed.
+
+.. warning::
+    This functionality does **not create a backup of the** ``JobStore`` **containing
+    the output of the workflows**. Since the output store can be any kind of ``Store``
+    and the result may be split in the ``additional_stores``, if a backup is needed
+    it will be required to do that through the ``JobStore`` or directly with
+    the storage system.
+
+There are two options to create and restore a backup. The default relies on the official
+MongoDB tools: ``mongodump`` and ``mongorestore``. For this to work the
+`MongoDB database tools <https://www.mongodb.com/docs/database-tools>`_  need to be
+installed. The connection details provided in the project configuration will be used
+to executed the commands. This is the preferred option, since it is faster and also
+dumps and restores all the metadata of the collections. However, not all the connection
+options defined in the ``queue`` Store may be supported or it may be not possible
+to install the tools. For this reason a second option, based on a pure python implementation
+is also available. This can be activated by selecting the ``--python`` option from
+the CLI.
+
+.. warning::
+    The python version of the backup and restore will not preserve the metadata of the
+    collection. After restoring a backup with this option it would be better to
+    regenerate the standard indexes using the ``jf admin index rebuild`` command.
+
+.. note::
+    It is of course possible to manually create a backup using the MongoDB tools.
+    This jobflow-remote feature is meant to ease the procedure by automatically
+    selecting the appropriate collections to backup.
+
+Create a backup
+===============
+
+A backup can be created with the command::
+
+    jf backup create
+
+As already mentioned, this will use the ``mongodump`` executable, unless the ``--python``
+option is specified. It is possible to specify the destination path of the backup and the
+output folder contains the ``jobs.bson``, ``flows.bson`` and ``jf_auxiliary.bson``
+files. If the ``mongodump`` command is used, the folder will also contain the metadata
+files for each collection. It is also possible to request that the backup files will
+be gzipped, by adding the ``--compress`` option.
+
+.. note::
+    The folder creation follows the convention of the ``mongodump`` executable, so
+    inside the folder specified in the ``create`` command there will be a subfolder
+    with the name of the database.
+
+.. note::
+    The name of the files will be the standard ones, even if the names of the collections
+    defined in the project configuration file are different.
+
+Restore a backup
+================
+
+To restore a backup the following command can be used::
+
+    jf backup restore /path/to/backup/folder
+
+The path should point to the folder containing the bson files generated during the creation.
+The code will automatically determine if the files are zipped, based on their extension.
+
+.. note::
+    The name of the target collection are determined by the values defined in the project
+    settings, not by the names of the files, nor by the names of the collections from
+    which the backup was created.
+
+.. note::
+    The backup can be restored only in an empty database. The code will raise an error
+    if the target database already contains jobs and flows.

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -19,6 +19,7 @@ details are found in :ref:`reference`.
    errors
    states
    advancedoptions
+   backup
 
 .. toctree::
    :hidden:

--- a/src/jobflow_remote/cli/__init__.py
+++ b/src/jobflow_remote/cli/__init__.py
@@ -1,5 +1,6 @@
 # Import the submodules with a local app to register them to the main app
 import jobflow_remote.cli.admin
+import jobflow_remote.cli.backup
 import jobflow_remote.cli.execution
 import jobflow_remote.cli.flow
 import jobflow_remote.cli.job

--- a/src/jobflow_remote/cli/backup.py
+++ b/src/jobflow_remote/cli/backup.py
@@ -1,0 +1,134 @@
+from typing import Annotated, Optional
+
+import typer
+
+from jobflow_remote.cli.jf import app
+from jobflow_remote.cli.jfr_typer import JFRTyper
+from jobflow_remote.cli.utils import (
+    check_stopped_runner,
+    get_job_controller,
+    loading_spinner,
+    out_console,
+)
+
+app_backup = JFRTyper(
+    name="backup",
+    help="Commands for handling backup of the database",
+    no_args_is_help=True,
+)
+app.add_typer(app_backup)
+
+
+@app_backup.command()
+def create(
+    out_path: Annotated[
+        str,
+        typer.Argument(
+            help="The path of the folder where the output files will be saved",
+            metavar="PATH",
+        ),
+    ] = ".",
+    compress: Annotated[
+        bool,
+        typer.Option(
+            "--compress",
+            "-c",
+            help="Compress the output files",
+        ),
+    ] = False,
+    mongo_dir: Annotated[
+        Optional[str],
+        typer.Option(
+            "--mongo-dir",
+            "-m",
+            help=(
+                "The path to a folder containing the mongodump executable, if not present in the PATH"
+            ),
+        ),
+    ] = None,
+    python: Annotated[
+        bool,
+        typer.Option(
+            "--python",
+            "-p",
+            help="If selected a python implementation will be used to create a backup. "
+            "WARNING: In this case metadata of the collections will not be saved",
+        ),
+    ] = False,
+) -> None:
+    """
+    Create a backup of the queue database using either mongodump or a python implementation.
+    The mongodump version is faster and stores metadata, but requires the mongodump executable
+    and may not support all the connection options defined in the project configuration.
+    """
+    check_stopped_runner(error=True)
+
+    with loading_spinner(processing=False) as progress:
+        progress.add_task(description="Creating backup...", total=None)
+        jc = get_job_controller()
+        n_docs = jc.backup_dump(
+            dir_path=out_path,
+            mongo_bin_path=mongo_dir,
+            compress=compress,
+            python=python,
+        )
+
+    out_console.print("Backup created for ")
+    for collection in sorted(n_docs):
+        out_console.print(f"\t{collection} collection: {n_docs[collection]} documents")
+    out_console.print("Verify that these numbers fit the expected values.")
+
+
+@app_backup.command()
+def restore(
+    out_path: Annotated[
+        str,
+        typer.Argument(
+            help="The path of the folder where the backup files are located",
+            metavar="PATH",
+        ),
+    ] = ".",
+    compress: Annotated[
+        bool,
+        typer.Option(
+            "--compress",
+            "-c",
+            help="The backup files were generated with the --compress option and should be decompressed",
+        ),
+    ] = False,
+    mongo_dir: Annotated[
+        Optional[str],
+        typer.Option(
+            "--mongo-dir",
+            "-m",
+            help=(
+                "The path to a folder containing the mongorestore executable, if not present in the PATH"
+            ),
+        ),
+    ] = None,
+    python: Annotated[
+        bool,
+        typer.Option(
+            "--python",
+            "-p",
+            help="If selected a python implementation will be used to restore a backup. "
+            "WARNING: In this case metadata of the collections will not be restored",
+        ),
+    ] = False,
+) -> None:
+    """
+    Recreate the queue database from a previous backup using either mongorestore or a python implementation.
+    """
+    check_stopped_runner(error=True)
+
+    with loading_spinner(processing=False) as progress:
+        progress.add_task(description="Restoring backup...", total=None)
+        jc = get_job_controller()
+        jc.backup_restore(
+            dir_path=out_path,
+            mongo_bin_path=mongo_dir,
+            compress=compress,
+            python=python,
+        )
+
+    out_console.print("Backup restored")

--- a/src/jobflow_remote/cli/backup.py
+++ b/src/jobflow_remote/cli/backup.py
@@ -21,11 +21,11 @@ app.add_typer(app_backup)
 
 @app_backup.command()
 def create(
-    out_path: Annotated[
+    backup_dir: Annotated[
         str,
         typer.Argument(
-            help="The path of the folder where the output files will be saved",
-            metavar="PATH",
+            help="The path of the directory where the output files will be saved",
+            metavar="BACKUP_DIR",
         ),
     ] = ".",
     compress: Annotated[
@@ -67,7 +67,7 @@ def create(
         progress.add_task(description="Creating backup...", total=None)
         jc = get_job_controller()
         n_docs = jc.backup_dump(
-            dir_path=out_path,
+            dir_path=backup_dir,
             mongo_bin_path=mongo_dir,
             compress=compress,
             python=python,
@@ -81,25 +81,17 @@ def create(
 
 @app_backup.command()
 def restore(
-    out_path: Annotated[
+    backup_dir: Annotated[
         str,
         typer.Argument(
-            help="The path of the folder where the backup files are located",
-            metavar="PATH",
+            help="The path of the directory where the backup files are located",
+            metavar="BACKUP_DIR",
         ),
     ] = ".",
-    compress: Annotated[
-        bool,
-        typer.Option(
-            "--compress",
-            "-c",
-            help="The backup files were generated with the --compress option and should be decompressed",
-        ),
-    ] = False,
-    mongo_dir: Annotated[
+    mongo_path: Annotated[
         Optional[str],
         typer.Option(
-            "--mongo-dir",
+            "--mongo-path",
             "-m",
             help=(
                 "The path to a folder containing the mongorestore executable, if not present in the PATH"
@@ -125,9 +117,8 @@ def restore(
         progress.add_task(description="Restoring backup...", total=None)
         jc = get_job_controller()
         jc.backup_restore(
-            dir_path=out_path,
-            mongo_bin_path=mongo_dir,
-            compress=compress,
+            dir_path=backup_dir,
+            mongo_bin_path=mongo_path,
             python=python,
         )
 

--- a/src/jobflow_remote/cli/backup.py
+++ b/src/jobflow_remote/cli/backup.py
@@ -36,10 +36,10 @@ def create(
             help="Compress the output files",
         ),
     ] = False,
-    mongo_dir: Annotated[
+    mongo_path: Annotated[
         Optional[str],
         typer.Option(
-            "--mongo-dir",
+            "--mongo-path",
             "-m",
             help=(
                 "The path to a folder containing the mongodump executable, if not present in the PATH"
@@ -68,7 +68,7 @@ def create(
         jc = get_job_controller()
         n_docs = jc.backup_dump(
             dir_path=backup_dir,
-            mongo_bin_path=mongo_dir,
+            mongo_bin_path=mongo_path,
             compress=compress,
             python=python,
         )
@@ -123,3 +123,8 @@ def restore(
         )
 
     out_console.print("Backup restored")
+    if python:
+        out_console.print(
+            "Python version does not restore indexes in the DB. It is advisable to run "
+            "'jf admin index rebuild' to create them."
+        )

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -47,7 +47,15 @@ from jobflow_remote.jobs.state import (
 from jobflow_remote.remote.data import get_remote_store, update_store
 from jobflow_remote.remote.queue import QueueManager
 from jobflow_remote.utils.data import deep_merge_dict
-from jobflow_remote.utils.db import FlowLockedError, JobLockedError, MongoLock
+from jobflow_remote.utils.db import (
+    FlowLockedError,
+    JobLockedError,
+    MongoLock,
+    mongodump_from_store,
+    mongorestore_to_store,
+    pymongo_dump,
+    pymongo_restore,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -4117,6 +4125,163 @@ class JobController:
             delete_files=delete_files,
             max_limit=max_limit,
         )
+
+    def backup_dump(
+        self,
+        dir_path: str | Path = ".",
+        mongo_bin_path: str | None = None,
+        compress: bool = False,
+        python: bool = False,
+    ) -> dict[str, int]:
+        """
+        Create a backup of the queue database using either mongodump or a python implementation.
+        The mongodump version is faster and stores metadata, but requires the mongodump executable
+        and may not support all the connection options defined in the project configuration.
+        The python version is available if the mongodump executable is not available and may support
+        more connection options.
+
+        Parameters
+        ----------
+        dir_path
+            The path of the folder where the output files will be saved. Follows the mongodump
+            convention: a subfolder with the name of the DB will created inside this path.
+        mongo_bin_path
+            The path to a folder containing the mongodump executable, if not present in the PATH.
+        compress
+            If True, the output files will be compressed with gzip.
+        python
+            If True a python implementation will be used to create a backup. WARNING: In this case
+            metadata of the collections will not be saved.
+
+        Returns
+        -------
+        dict[str, int]
+            A dictionary containing the collection names as keys and the number of documents
+            saved for each collection as values.
+        """
+        dir_path = Path(dir_path)
+        doc_count = {}
+        collection_names = ["jobs", "flows", "jf_auxiliary"]
+        if python:
+            for name, collection in zip(
+                collection_names, [self.jobs, self.flows, self.auxiliary]
+            ):
+                doc_count[name] = pymongo_dump(
+                    collection=collection, output_path=dir_path, compress=compress
+                )
+        else:
+            for name, collection in zip(
+                collection_names,
+                [
+                    self.jobs_collection,
+                    self.flows_collection,
+                    self.auxiliary_collection,
+                ],
+            ):
+                doc_count[name] = mongodump_from_store(
+                    store=self.queue_store,
+                    collection=collection,
+                    output_path=dir_path,
+                    compress=compress,
+                    mongo_bin_path=mongo_bin_path,
+                )
+
+        # move the files produced to match the standard names
+        for name, collection in zip(
+            collection_names,
+            [self.jobs_collection, self.flows_collection, self.auxiliary_collection],
+        ):
+            if collection != name:
+                full_dir_path = dir_path / self.queue_store.database
+                data_file_name = f"{collection}.bson"
+                if compress:
+                    data_file_name += ".gz"
+                file_path = full_dir_path / data_file_name
+                if file_path.exists():
+                    new_file_name = f"{name}.bson"
+                    if compress:
+                        new_file_name += ".gz"
+                    file_path.rename(full_dir_path / new_file_name)
+                metadata_file_name = f"{collection}.metadata.json"
+                if compress:
+                    metadata_file_name += ".gz"
+                file_path = full_dir_path / metadata_file_name
+                if file_path.exists():
+                    new_file_name = f"{name}.metadata.json"
+                    if compress:
+                        new_file_name += ".gz"
+                    file_path.rename(full_dir_path / new_file_name)
+
+        return doc_count
+
+    def backup_restore(
+        self,
+        dir_path: str | Path = ".",
+        mongo_bin_path: str | None = None,
+        compress: bool = False,
+        python: bool = False,
+    ):
+        """
+        Restore the queue database from a backup.
+
+        It will restore the content of the collections jobs, flows and auxiliary
+        from the files '<name>.bson(.gz)' in the given directory. If `python` is not
+        selected, it will use the 'mongorestore' command with the specified 'mongo_bin_path'.
+        If `python` is selected it will use a pure python implementation.
+
+        Will allow to restore the backup with pristine collections.
+
+        Parameters
+        ----------
+        dir_path
+            The directory where to find the backup files.
+        mongo_bin_path
+            The path to a folder containing the mongodump executable, if not present in the PATH.
+        compress
+            If True the backup files are compressed.
+        python
+            If True, a pure python implementation will be used instead of the 'mongorestore'
+            command. WARNING: In this case metadata of the collections will not be restored.
+        """
+        dir_path = Path(dir_path)
+        collection_names = ["jobs", "flows", "jf_auxiliary"]
+        for name, db_name, collection in zip(
+            collection_names,
+            [self.jobs_collection, self.flows_collection],
+            [self.jobs, self.flows],
+        ):
+            count = collection.count_documents({})
+            if count > 0:
+                raise RuntimeError(
+                    f"The collection named {db_name} for {name} contains {count} documents."
+                    "Choose an empty collection."
+                )
+        next_id_doc = self.auxiliary.find_one({"next_id": {"$exists": True}})
+        if next_id_doc and next_id_doc["next_id"] != 1:
+            raise RuntimeError(
+                "next_id value is different from one in the auxiliary collection. "
+                "Choose an empty collection."
+            )
+        self.auxiliary.delete_many({})
+        for name, db_name, collection in zip(
+            collection_names,
+            [self.jobs_collection, self.flows_collection, self.auxiliary_collection],
+            [self.jobs, self.flows, self.auxiliary],
+        ):
+            file_name = f"{name}.bson"
+            if compress:
+                file_name += ".gz"
+            file_path = dir_path / file_name
+            if python:
+                pymongo_restore(collection=collection, input_file=file_path)
+            else:
+                mongorestore_to_store(
+                    store=self.queue_store,
+                    collection=db_name,
+                    input_file=file_path,
+                    compress=compress,
+                    mongo_bin_path=mongo_bin_path,
+                )
 
 
 def get_flow_leafs(job_docs: list[dict]) -> list[dict]:

--- a/src/jobflow_remote/utils/db.py
+++ b/src/jobflow_remote/utils/db.py
@@ -504,7 +504,7 @@ def mongo_operation(
         str_cmd, check=True, capture_output=True, text=True, shell=True
     )
     logger.debug(
-        f"output during execution of {str_cmd}. Stdout: {result.stdout}. Stderr: {result.stderr}"
+        f"output during execution of '{str_cmd}'. Stdout: {result.stdout}. Stderr: {result.stderr}"
     )
     return result.stdout, result.stderr
 

--- a/tests/db/cli/test_backup.py
+++ b/tests/db/cli/test_backup.py
@@ -65,8 +65,6 @@ def test_reset(job_controller, two_flows_four_jobs, python, compress) -> None:
         assert job_controller.count_jobs() == 0
 
         cmd = ["backup", "restore"]
-        if compress:
-            cmd.append("--compress")
         if python:
             cmd.append("--python")
         cmd.append(str(dir_path / db_name))

--- a/tests/db/cli/test_backup.py
+++ b/tests/db/cli/test_backup.py
@@ -1,4 +1,5 @@
 import tempfile
+from shutil import which
 
 import pytest
 
@@ -20,7 +21,15 @@ def check_files(files: list[str], meta: bool, compress: bool):
 
 @pytest.mark.parametrize(
     "python",
-    [True, False],
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.skipif(
+                not which("mongodump"), reason="mongodump missing"
+            ),
+        ),
+    ],
 )
 @pytest.mark.parametrize(
     "compress",

--- a/tests/db/cli/test_backup.py
+++ b/tests/db/cli/test_backup.py
@@ -1,0 +1,70 @@
+import tempfile
+
+import pytest
+
+
+def check_files(files: list[str], meta: bool, compress: bool):
+    ext = ".gz" if compress else ""
+    assert "flows.bson" + ext in files
+    assert "jf_auxiliary.bson" + ext in files
+    assert "jobs.bson" + ext in files
+    if meta:
+        assert "flows.metadata.json" + ext in files
+        assert "jf_auxiliary.metadata.json" + ext in files
+        assert "jobs.metadata.json" + ext in files
+
+        assert len(files) == 6
+    else:
+        assert len(files) == 3
+
+
+@pytest.mark.parametrize(
+    "python",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "compress",
+    [True, False],
+)
+def test_reset(job_controller, two_flows_four_jobs, python, compress) -> None:
+    from pathlib import Path
+
+    from jobflow_remote.testing.cli import run_check_cli
+
+    assert job_controller.count_jobs() == 4
+    db_name = job_controller.queue_store.database
+
+    with tempfile.TemporaryDirectory() as dir_name:
+        dir_path = Path(dir_name)
+        required_out = [
+            "Backup created",
+            "flows collection: 2 documents",
+            "jf_auxiliary collection: 1 documents",
+            "jobs collection: 4 documents",
+        ]
+        cmd = ["backup", "create"]
+        if compress:
+            cmd.append("--compress")
+        if python:
+            cmd.append("--python")
+        cmd.append(dir_name)
+        run_check_cli(cmd, required_out=required_out)
+        files = [str(p.name) for p in (dir_path / db_name).glob("*")]
+        check_files(files, meta=not python, compress=compress)
+        job_controller.reset(max_limit=0)
+
+        assert job_controller.count_jobs() == 0
+
+        cmd = ["backup", "restore"]
+        if compress:
+            cmd.append("--compress")
+        if python:
+            cmd.append("--python")
+        cmd.append(str(dir_path / db_name))
+        run_check_cli(cmd, required_out="Backup restored")
+
+        assert job_controller.count_jobs() == 4
+        assert job_controller.count_flows() == 2
+        aux_docs = list(job_controller.auxiliary.find({}))
+        assert len(aux_docs) == 1
+        assert aux_docs[0]["next_id"] == 5

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -169,6 +169,24 @@ def job_controller(random_project_name):
 
 
 @pytest.fixture()
+def job_controller_drop(random_project_name):
+    """Yields a jobcontroller instance for the test suite that also sets up the
+    jobstore. Drops the database at the end of the test.
+    Useful for tests that may leave entries in the DB that are not cleaned with
+    a reset.
+    """
+    from jobflow_remote.jobs.jobcontroller import JobController
+
+    jc = JobController.from_project_name(random_project_name)
+    assert jc.reset()
+    try:
+        yield jc
+    except:
+        jc.db.drop()
+        raise
+
+
+@pytest.fixture()
 def one_job(random_project_name):
     """Add one flow with one job to the DB."""
     from jobflow import Flow

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1,4 +1,5 @@
 import os.path
+from shutil import which
 from typing import NoReturn
 
 import pymongo
@@ -730,3 +731,122 @@ def test_indexes(job_controller, one_job):
 
     job_controller.build_indexes(background=False, drop=True)
     assert len(list(job_controller.jobs.list_indexes())) == 11
+
+
+@pytest.mark.parametrize(
+    "python",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.skipif(
+                not which("mongodump"), reason="mongodump missing"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "compress",
+    [True, False],
+)
+def test_backup(job_controller_drop, python, compress):
+    import tempfile
+    from pathlib import Path
+
+    from jobflow import Flow
+    from maggma.stores.mongolike import MemoryStore
+
+    from jobflow_remote.testing import add
+
+    # modify the jobcontroller so that the collections are not the standard ones
+    jobs_name = "test_jobs"
+    flows_name = "test_flows"
+    aux_name = "test_auxiliary"
+    job_controller_drop.jobs_collection = jobs_name
+    job_controller_drop.jobs = job_controller_drop.db[jobs_name]
+    job_controller_drop.queue_store.collection_name = jobs_name
+    job_controller_drop.queue_store._coll = job_controller_drop.jobs
+    job_controller_drop.flows_collection = flows_name
+    job_controller_drop.flows = job_controller_drop.db[flows_name]
+    job_controller_drop.auxiliary_collection = aux_name
+    job_controller_drop.auxiliary = job_controller_drop.db[aux_name]
+
+    job_controller_drop.reset()
+
+    j1 = add(1, 2)
+    j2 = add(j1.output, 2)
+    flow = Flow([j1, j2])
+
+    # do not use submit_flow, otherwise the original collections will be used.
+    job_controller_drop.add_flow(flow, worker="test_local_worker")
+
+    assert job_controller_drop.count_jobs() == 2
+
+    db_name = job_controller_drop.queue_store.database
+    with tempfile.TemporaryDirectory() as dir_name:
+        dir_path = Path(dir_name)
+
+        job_controller_drop.backup_dump(
+            dir_path=dir_name, compress=compress, python=python
+        )
+
+        files = [str(p.name) for p in (dir_path / db_name).glob("*")]
+
+        ext = ".gz" if compress else ""
+        assert "flows.bson" + ext in files
+        assert "jf_auxiliary.bson" + ext in files
+        assert "jobs.bson" + ext in files
+        if python:
+            assert len(files) == 3
+        else:
+            assert "flows.metadata.json" + ext in files
+            assert "jf_auxiliary.metadata.json" + ext in files
+            assert "jobs.metadata.json" + ext in files
+
+            assert len(files) == 6
+
+        with pytest.raises(
+            RuntimeError,
+            match=f"The collection named {jobs_name} for jobs contains 2 documents.*",
+        ):
+            job_controller_drop.backup_restore(
+                dir_path=dir_path / db_name, compress=compress, python=python
+            )
+
+        job_controller_drop.jobs.delete_many({})
+        with pytest.raises(
+            RuntimeError,
+            match=f"The collection named {flows_name} for flows contains 1 documents.*",
+        ):
+            job_controller_drop.backup_restore(
+                dir_path=dir_path / db_name, compress=compress, python=python
+            )
+
+        job_controller_drop.flows.delete_many({})
+        with pytest.raises(
+            RuntimeError,
+            match="next_id value is different from one in the auxiliary collection.*",
+        ):
+            job_controller_drop.backup_restore(
+                dir_path=dir_path / db_name, compress=compress, python=python
+            )
+
+        job_controller_drop.auxiliary.delete_many({})
+
+        job_controller_drop.backup_restore(
+            dir_path=dir_path / db_name, compress=compress, python=python
+        )
+
+        assert job_controller_drop.count_jobs() == 2
+        assert job_controller_drop.count_flows() == 1
+        assert job_controller_drop.auxiliary.find({})[0]["next_id"] == 3
+
+        # Other stores not supported for mongodump
+        if not python:
+            job_controller_drop.queue_store = MemoryStore()
+            with pytest.raises(
+                ValueError, match="Unsupported store type MemoryStore.*"
+            ):
+                job_controller_drop.backup_dump(
+                    dir_path=dir_name, compress=compress, python=python
+                )

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -833,9 +833,7 @@ def test_backup(job_controller_drop, python, compress):
 
         job_controller_drop.auxiliary.delete_many({})
 
-        job_controller_drop.backup_restore(
-            dir_path=dir_path / db_name, compress=compress, python=python
-        )
+        job_controller_drop.backup_restore(dir_path=dir_path / db_name, python=python)
 
         assert job_controller_drop.count_jobs() == 2
         assert job_controller_drop.count_flows() == 1


### PR DESCRIPTION
Initial implementation of a backup feature to create and restore a dump of the queue store. Closes #165.
Two options either based on the presence of the mongodump/mongorestore executable in the system, or a simple python dump to BSON files.
This may be important to have once we put in place the automatic update procedure (see  #150). It might be convenient to suggest the users to perform a backup before proceeding with the update of the DB.