### PR TITLE
Delete job files when rerunning; customizable execution command

### DIFF
--- a/doc/source/user/errors.rst
+++ b/doc/source/user/errors.rst
@@ -158,8 +158,10 @@ the ``READY`` state, this can be achieved by running::
     list of options available.
 
 .. warning::
-    Rerunning by default also deletes the folder on the worker where the Job was
-    executed. To avoid it use the ``--no-delete`` option.
+    Rerunning by default also marks the Job so that the folder on the worker where it
+    was executed will be deleted. The deletion is performed by the Runner before
+    reuploading the inputs, i.e. before the Job gets to the `UPLOADED` state.
+    To avoid it use the ``--no-delete`` option.
 
 .. warning::
     It is impossible to provide an exhaustive list of potential issues that could lead to
@@ -253,9 +255,11 @@ job with::
 will solve the issue.
 
 .. warning::
-    Rerunning by default also deletes the folder on the worker where the Job was
-    executed. If, as effect of a rerun children Jobs are also rerun, their folders
-    will be deleted as well. To avoid it use the ``--no-delete`` option.
+    Rerunning by default also marks the Job so that the folder on the worker where it
+    was executed will be deleted. The deletion is performed by the Runner before
+    reuploading the inputs, i.e. before the Job gets to the `UPLOADED` state. If, as effect
+    of a rerun children Jobs are also rerun, their folders will be marked for deletion as
+    well. To avoid it use the ``--no-delete`` option.
 
 .. note::
 

--- a/doc/source/user/errors.rst
+++ b/doc/source/user/errors.rst
@@ -158,6 +158,10 @@ the ``READY`` state, this can be achieved by running::
     list of options available.
 
 .. warning::
+    Rerunning by default also deletes the folder on the worker where the Job was
+    executed. To avoid it use the ``--no-delete`` option.
+
+.. warning::
     It is impossible to provide an exhaustive list of potential issues that could lead to
     a ``REMOTE_ERROR`` state. So except in some well defined cases, the error messages will be
     mainly given by the stack trace of the error.
@@ -247,6 +251,11 @@ job with::
     jf job rerun 5
 
 will solve the issue.
+
+.. warning::
+    Rerunning by default also deletes the folder on the worker where the Job was
+    executed. If, as effect of a rerun children Jobs are also rerun, their folders
+    will be deleted as well. To avoid it use the ``--no-delete`` option.
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,9 @@ filterwarnings = [
     "ignore:.*magmom.*:UserWarning",
     "ignore::DeprecationWarning",
 ]
+addopts = [
+    "--import-mode=importlib",
+]
 
 [tool.coverage.run]
 include = ["src/*"]

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1068,7 +1068,7 @@ def output(
         ),
     ] = False,
 ) -> None:
-    """Detailed information on a specific job."""
+    """Fetch the output of a Job from the output Store."""
     db_id, job_id = get_job_db_ids(job_db_id, job_index)
 
     with loading_spinner():

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -305,6 +305,14 @@ def rerun(
         ),
     ] = False,
     raise_on_error: raise_on_error_opt = False,
+    no_delete: Annotated[
+        bool,
+        typer.Option(
+            "--no-delete",
+            "-nd",
+            help=("Skip the delete of the files on the worker."),
+        ),
+    ] = False,
 ) -> None:
     """
     Rerun a Job. By default, this is limited to jobs that failed and children did
@@ -313,6 +321,8 @@ def rerun(
     will be cancelled. Most of the limitations can be overridden by the 'force'
     option. This could lead to inconsistencies in the overall state of the Jobs of
     the Flow.
+    All the folders of the Jobs whose state are modified will also be deleted on
+    the worker.
     """
     if force or break_lock:
         check_stopped_runner(error=False)
@@ -341,6 +351,8 @@ def rerun(
         break_lock=break_lock,
         force=force,
         raise_on_error=raise_on_error,
+        interactive=True,
+        delete_files=not no_delete,
     )
 
 
@@ -600,6 +612,7 @@ def delete(
         verbosity=verbosity,
         wait=wait,
         raise_on_error=raise_on_error,
+        interactive=True,
         delete_output=delete_output,
         delete_files=delete_files,
     )

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -215,6 +215,16 @@ class WorkerBase(BaseModel):
             raise ValueError("`work_dir` must be an absolute path")
         return v
 
+    @field_validator("execution_cmd")
+    @classmethod
+    def check_execution_cmd(cls, v) -> Optional[str]:
+        if v is not None and "{}" not in v:
+            raise ValueError(
+                "`execution_cmd` must contain a '{}' part to allow setting "
+                "the execution folder at runtime"
+            )
+        return v
+
     def get_scheduler_io(self) -> BaseSchedulerIO:
         """
         Get the BaseSchedulerIO from QToolKit depending on scheduler_type.

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -166,6 +166,13 @@ class WorkerBase(BaseModel):
         None,
         description="String with commands that will be executed after the execution of the Job",
     )
+    execution_cmd: Optional[str] = Field(
+        None,
+        description="String with commands to execute the Job on the worker. By default will be "
+        "set to `jf -fe execution run {}`. The `{}` part will be used to insert the path to "
+        "the execution directory and it is mandatory. Change only for specific needs (e.g. the"
+        "jf command needs to be executed in a container).",
+    )
     timeout_execute: int = Field(
         60,
         description="Timeout for the execution of the commands in the worker "
@@ -637,6 +644,16 @@ class Project(BaseModel):
                     f"error while converting jobstore to JobStore. Error: {traceback.format_exc()}"
                 ) from e
         return jobstore
+
+    @property
+    def has_interactive_workers(self) -> bool:
+        """
+        True if any of the workers have interactive_login set to True.
+        """
+        for worker in self.workers.values():
+            if isinstance(worker, RemoteWorker) and worker.interactive_login:
+                return True
+        return False
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -119,6 +119,7 @@ class RemoteInfo(BaseModel):
     process_id: Optional[str] = None
     retry_time_limit: Optional[datetime] = None
     error: Optional[str] = None
+    cleanup: bool = False
 
 
 class JobInfo(BaseModel):

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -119,7 +119,7 @@ class RemoteInfo(BaseModel):
     process_id: Optional[str] = None
     retry_time_limit: Optional[datetime] = None
     error: Optional[str] = None
-    cleanup: bool = False
+    prerun_cleanup: bool = False
 
 
 class JobInfo(BaseModel):

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2467,7 +2467,7 @@ class JobController:
         return result.modified_count
 
     def _safe_delete_files(
-        self, jobs_info: list[JobInfo | dict]
+        self, jobs_info: Sequence[JobInfo | dict]
     ) -> list[JobInfo | dict]:
         """
         Delete the files associated to the selected Jobs.

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1128,7 +1128,7 @@ class JobController:
                     if child_doc["state"] != JobState.WAITING.value:
                         modified_jobs.append(child_doc["db_id"])
                         if delete_files:
-                            child_doc_update["remote.cleanup"] = True
+                            child_doc_update["remote.prerun_cleanup"] = True
                     child_lock.update_on_release = {"$set": child_doc_update}
                     updated_states[child_doc["uuid"]][child_doc["index"]] = (
                         JobState.WAITING
@@ -1146,7 +1146,7 @@ class JobController:
             job_doc_update = get_reset_job_base_dict()
             job_doc_update["state"] = JobState.READY.value
             if delete_files:
-                job_doc_update["remote.cleanup"] = True
+                job_doc_update["remote.prerun_cleanup"] = True
 
         return job_doc_update, modified_jobs
 
@@ -1181,7 +1181,7 @@ class JobController:
         job_doc_update = get_reset_job_base_dict()
         job_doc_update["state"] = JobState.CHECKED_OUT.value
         if delete_files:
-            job_doc_update["remote.cleanup"] = True
+            job_doc_update["remote.prerun_cleanup"] = True
 
         return job_doc_update
 

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -3881,8 +3881,14 @@ class JobController:
                 no_retry = True
             except RemoteError as e:
                 error = f"Remote error: {e.msg}"
-                if e.__cause__:
-                    trace = traceback.format_exception(e.__cause__)
+                cause = e.__cause__
+                if cause:
+                    # this is required for support of python 3.9. In 3.10 the API
+                    # changed and format_exception(e) could be used instead.
+                    # Do that if/when support for 3.9 is dropped.
+                    trace = traceback.format_exception(
+                        type(cause), cause, cause.__traceback__
+                    )
                     error += "\ncaused by:\n" + "".join(trace)
                 no_retry = e.no_retry
             except Exception:

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -910,6 +910,7 @@ class JobController:
             anymore. Doing otherwise will likely lead to inconsistencies in the DB.
         delete_files
             Delete all the files in the worker folder of the rerun Job.
+            Note that the deletion will not be performed directly but only when the job effectively restarts.
 
         Returns
         -------

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -637,7 +637,8 @@ class Runner:
 
         remote_path = Path(doc["run_dir"])
 
-        script_commands = [f"jf -fe execution run {remote_path}"]
+        execution_cmd = worker.execution_cmd or "jf -fe execution run {}"
+        script_commands = [execution_cmd.format(remote_path)]
 
         queue_manager = self.get_queue_manager(worker_name)
         qout_fpath = remote_path / OUT_FNAME

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -576,10 +576,10 @@ class Runner:
         worker = self.get_worker(doc["worker"])
         host = self.get_host(doc["worker"])
 
-        # if cleanup is specified (job was likely rerun) delete the folder before
+        # if prerun_cleanup is specified (job was likely rerun) delete the folder before
         # reuploading the data
         run_dir = doc["run_dir"]
-        if doc.get("remote", {}).get("cleanup", False):
+        if doc.get("remote", {}).get("prerun_cleanup", False):
             try:
                 deleted = safe_remove_job_files(
                     host=host, run_dir=run_dir, raise_on_error=True
@@ -639,7 +639,7 @@ class Runner:
             "$set": {
                 "run_dir": remote_path,
                 "state": JobState.UPLOADED.value,
-                "remote.cleanup": False,
+                "remote.prerun_cleanup": False,
             }
         }
         lock.update_on_release = set_output

--- a/src/jobflow_remote/utils/remote.py
+++ b/src/jobflow_remote/utils/remote.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from jobflow_remote import ConfigManager
+
+if TYPE_CHECKING:
+    from jobflow_remote.config.base import Project
+    from jobflow_remote.remote.host.base import BaseHost
+
+logger = logging.getLogger(__name__)
+
+
+class SharedHosts:
+    """
+    A singleton context manager to allow sharing the same host objects.
+
+    Hosts are stored internally, associated to the worker name
+    Being a singleton, opening the context manager multiple times allows
+    to share the hosts across different sections of the code, if needed.
+    Hosts connections are all closed only when leaving the last context
+    manager.
+
+    Examples
+    --------
+
+    >>> with SharedHosts(project) as shared_hosts:
+    ...     host = shared_hosts.get_host("worker_name")
+    ...     # Use host as required
+    """
+
+    _instance: SharedHosts = None
+    _ref_count: int = 0
+    _hosts: ClassVar[dict[str, BaseHost]] = {}
+    _project: Project | None = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, project: Project | None = None):
+        """
+        Parameters
+        ----------
+        project
+            The project configuration.
+        """
+        if self._project is None:
+            if project is None:
+                config_manager: ConfigManager = ConfigManager()
+                project = config_manager.get_project(None)
+            self._project = project
+
+    def get_host(self, worker: str) -> BaseHost:
+        """
+        Return the shared host, if already defined, otherwise retrieve
+        the host from the project and connect it.
+
+        Parameters
+        ----------
+        worker
+            The name of a worker defined in the project
+        Returns
+        -------
+        BaseHost
+            The shared host.
+        """
+        if worker not in self._project.workers:
+            raise ValueError(f"Worker {worker} not defined in {self._project.name}")
+        if worker in self._hosts:
+            return self._hosts[worker]
+
+        host = self._project.workers[worker].get_host()
+        host.connect()
+        self._hosts[worker] = host
+        return host
+
+    def close_hosts(self) -> None:
+        """Close the connection to all the connected hosts"""
+        for worker in list(self._hosts):
+            try:
+                self._hosts[worker].close()
+            except Exception:
+                logger.exception(
+                    f"Error while closing the connection to the {worker} worker"
+                )
+            finally:
+                self._hosts.pop(worker)
+
+    def __enter__(self):
+        # Increment reference count
+        self.__class__._ref_count += 1
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Decrement reference count
+        self.__class__._ref_count -= 1
+
+        # Cleanup only when the last context exits
+        if self.__class__._ref_count == 0:
+            self.close_hosts()

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -134,18 +134,20 @@ def test_rerun(job_controller, two_flows_four_jobs) -> None:
     assert os.path.isdir(job_info.run_dir)
     ji = job_controller.get_job_info(db_id="1")
     assert ji.state == JobState.READY
-    assert ji.remote.cleanup
+    assert ji.remote.prerun_cleanup
 
     # set the job back to completed and set remote.cleanup=False. rerun with --no-delete
     assert job_controller.set_job_state(JobState.COMPLETED, db_id="1")
-    assert job_controller.set_job_doc_properties({"remote.cleanup": False}, db_id="1")
+    assert job_controller.set_job_doc_properties(
+        {"remote.prerun_cleanup": False}, db_id="1"
+    )
     run_check_cli(
         ["job", "rerun", "-did", "1", "-f", "-nd"],
     )
 
     ji = job_controller.get_job_info(db_id="1")
     assert ji.state == JobState.READY
-    assert not ji.remote.cleanup
+    assert not ji.remote.prerun_cleanup
 
 
 def test_retry(job_controller, two_flows_four_jobs) -> None:

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -330,8 +330,8 @@ def test_rerun_failed(job_controller, runner) -> None:
     j3_info = job_controller.get_job_info(job_id=j3.uuid, job_index=j3.index)
     assert j1_path.exists()
     assert j3_path.exists()
-    assert j1_info.remote.cleanup
-    assert j3_info.remote.cleanup
+    assert j1_info.remote.prerun_cleanup
+    assert j3_info.remote.prerun_cleanup
 
     # create a file in the folders, to be sure that in the meanwhile the folders have been removed
     # during the upload phase
@@ -355,8 +355,8 @@ def test_rerun_failed(job_controller, runner) -> None:
     j3_info = job_controller.get_job_info(job_id=j3.uuid, job_index=j3.index)
 
     # also check that the cleanup has be set to False
-    assert not j1_info.remote.cleanup
-    assert not j3_info.remote.cleanup
+    assert not j1_info.remote.prerun_cleanup
+    assert not j3_info.remote.prerun_cleanup
 
     assert job_controller.count_jobs(job_ids=(j4.uuid, 2)) == 1
 
@@ -431,7 +431,7 @@ def test_rerun_remote_error(job_controller, monkeypatch, runner) -> None:
     # do not run the job explicitly, as it is already checked in other tests
     j1_info = job_controller.get_job_info(job_id=j1.uuid, job_index=j1.index)
     assert Path(j1_info.run_dir).exists()
-    assert j1_info.remote.cleanup
+    assert j1_info.remote.prerun_cleanup
 
 
 def test_retry(job_controller, monkeypatch, runner) -> None:

--- a/tests/db/jobs/test_runner.py
+++ b/tests/db/jobs/test_runner.py
@@ -1,0 +1,68 @@
+def test_upload_cleanup_error(job_controller, runner, monkeypatch):
+    from pathlib import Path
+
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.remote.host.local import LocalHost
+    from jobflow_remote.testing import add
+
+    j1 = add(1, 2)
+    flow = Flow([j1])
+
+    submit_flow(flow, worker="test_local_worker")
+
+    assert runner.run_one_job(max_seconds=10, job_id=[j1.uuid, j1.index])
+    j1_info = job_controller.get_job_info(job_id=j1.uuid, job_index=j1.index)
+    j1_path = Path(j1_info.run_dir)
+    assert j1_info.state == JobState.COMPLETED
+
+    assert set(job_controller.rerun_jobs(job_ids=(j1.uuid, j1.index), force=True)) == {
+        j1_info.db_id
+    }
+    assert j1_path.exists()
+
+    check_file_j1 = j1_path / "test_test.json"
+    check_file_j1.touch(exist_ok=True)
+    assert check_file_j1.exists()
+
+    # remove the jfremote_in.json and check that the remove fails
+    jfremote_in = j1_path / "jfremote_in.json"
+    jfremote_in.unlink(missing_ok=True)
+
+    assert runner.run_one_job(max_seconds=10, job_id=[j1.uuid, j1.index])
+    j1_info = job_controller.get_job_info(job_id=j1.uuid, job_index=j1.index)
+    assert j1_info.state == JobState.REMOTE_ERROR
+
+    # since it fails immediately, step attempts is left to zero
+    assert j1_info.remote.step_attempts == 0
+    assert (
+        "Error while performing cleanup of the run_dir folder for job 1"
+        in j1_info.remote.error
+    )
+    assert (
+        f"Could not delete folder {j1_info.run_dir} since it may not contain a jobflow-remote execution."
+        in j1_info.remote.error
+    )
+
+    # rerun the job create again the file and mock to have it failed in a different way
+    job_controller.rerun_job(db_id="1")
+    jfremote_in.touch(exist_ok=True)
+
+    def raise_rmtree(*args, **kwargs):
+        raise RuntimeError("FAKE ERROR")
+
+    with monkeypatch.context() as m:
+        m.setattr(LocalHost, "rmtree", raise_rmtree)
+        m.setattr(runner.runner_options, "max_step_attempts", 2)
+        assert runner.run_one_job(max_seconds=20, job_id=[j1.uuid, j1.index])
+
+    j1_info = job_controller.get_job_info(job_id=j1.uuid, job_index=j1.index)
+    assert j1_info.state == JobState.REMOTE_ERROR
+    assert j1_info.remote.step_attempts == 2
+    assert (
+        "Error while performing cleanup of the run_dir folder for job 1"
+        in j1_info.remote.error
+    )
+    assert "FAKE ERROR" in j1_info.remote.error

--- a/tests/db/utils/test_data.py
+++ b/tests/db/utils/test_data.py
@@ -56,7 +56,7 @@ def test_get_utc_offset():
     from jobflow_remote.utils.data import get_utc_offset
 
     assert get_utc_offset("America/Los_Angeles") == "-07:00"
-    assert get_utc_offset("Europe/Paris") == "+02:00"
+    assert get_utc_offset("Europe/Moscow") == "+03:00"
     assert get_utc_offset("UTC") == "+00:00"
     assert get_utc_offset("Asia/Shanghai") == "+08:00"
     with pytest.raises(ValueError, match="Could not determine the timezone for XXX"):

--- a/tests/db/utils/test_data.py
+++ b/tests/db/utils/test_data.py
@@ -55,7 +55,7 @@ def test_get_past_time_rounded():
 def test_get_utc_offset():
     from jobflow_remote.utils.data import get_utc_offset
 
-    assert get_utc_offset("America/Los_Angeles") == "-07:00"
+    assert get_utc_offset("America/Buenos_Aires") == "-03:00"
     assert get_utc_offset("Europe/Moscow") == "+03:00"
     assert get_utc_offset("UTC") == "+00:00"
     assert get_utc_offset("Asia/Shanghai") == "+08:00"

--- a/tests/db/utils/test_remote.py
+++ b/tests/db/utils/test_remote.py
@@ -1,0 +1,21 @@
+def test_share_hosts(mocker):
+    import jobflow_remote
+    from jobflow_remote.utils.remote import SharedHosts
+
+    mocker.patch("jobflow_remote.remote.host.local.LocalHost.close")
+
+    with SharedHosts() as shared_hosts1:
+        host1 = shared_hosts1.get_host("test_local_worker")
+        assert len(shared_hosts1._hosts) == 1
+        with SharedHosts() as shared_hosts2:
+            assert len(shared_hosts2._hosts) == 1
+            host2 = shared_hosts2.get_host("test_local_worker")
+            # hosts should be the same instance
+            assert shared_hosts1 is shared_hosts2
+            assert host1 is host2
+
+        # after leaving the first context manager the close should not be called
+        jobflow_remote.remote.host.local.LocalHost.close.assert_not_called()
+
+    # close() called only once after leaving the outermost context manager
+    jobflow_remote.remote.host.local.LocalHost.close.assert_called_once()


### PR DESCRIPTION
Closing #197 and #196.

### Delete files on rerun
As discussed in #197, this will remove the files from the worker when a Job is rerun. 
1) The removal is applied by default, but can be deactivated
2) If an error happens while removing the files, the Job will not be rerun
3) If failing to remove files due to the fact that the `jfremote_in.json` is missing a warning will be printed, but Job will be rerun

Note that this functionality might have a direct impact for @JaGeo: now if a worker has a MFA when rerunning a job it will ask to insert the OTP. 

Also I am not 100% convinced about point 2, if it instead should print a warning and still rerun the Job. 

Also pinging @QuantumChemist @utf. 

### Customizable execution command

As discussed in #196 added a new option to customize the `jf -fe execution run`: `execution_cmd`

@yw-fang would this be fine?

