### PR TITLE
Option for stored data in `jf job list`

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -74,7 +74,7 @@ def flows_list(
     sort: sort_opt = SortOption.UPDATED_ON,
     reverse_sort: reverse_sort_flag_opt = False,
 ) -> None:
-    """Get the list of Jobs in the database."""
+    """Get the list of Flows in the database."""
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
     check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
 

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -105,6 +105,22 @@ def jobs_list(
             help="Select the jobs in FAILED and REMOTE_ERROR state. Incompatible with the --state option",
         ),
     ] = False,
+    stored_data_keys: Annotated[
+        Optional[list[str]],
+        typer.Option(
+            "--stored-data-key",
+            "-sdk",
+            help="Key to be shown from the stored_data field.",
+        ),
+    ] = None,
+    skip_job_id: Annotated[
+        bool,
+        typer.Option(
+            "--skip-job-id",
+            "-sji",
+            help="Skip the UUID field in the output table.",
+        ),
+    ] = False,
 ):
     """
     Get the list of Jobs in the database
@@ -163,7 +179,12 @@ def jobs_list(
                 sort=db_sort,
             )
 
-        table = get_job_info_table(jobs_info, verbosity=verbosity)
+        table = get_job_info_table(
+            jobs_info,
+            verbosity=verbosity,
+            stored_data_keys=stored_data_keys,
+            skip_job_id=skip_job_id,
+        )
 
     out_console.print(table)
     if SETTINGS.cli_suggestions:

--- a/src/jobflow_remote/config/settings.py
+++ b/src/jobflow_remote/config/settings.py
@@ -30,6 +30,10 @@ class JobflowRemoteSettings(BaseSettings):
     cli_log_level: LogLevel = Field(
         LogLevel.WARN, description="The level set for logging in the CLI"
     )
+    cli_job_list_columns: list[str] = Field(
+        default_factory=list,
+        description="The list of columns to show in the `jf job list` command.",
+    )
 
     model_config = SettingsConfigDict(env_prefix="jfremote_")
 

--- a/src/jobflow_remote/config/settings.py
+++ b/src/jobflow_remote/config/settings.py
@@ -31,7 +31,9 @@ class JobflowRemoteSettings(BaseSettings):
         LogLevel.WARN, description="The level set for logging in the CLI"
     )
     cli_job_list_columns: Optional[list[str]] = Field(
-        None, description="The list of columns to show in the `jf job list` command."
+        None,
+        description="The list of columns to show in the `jf job list` command. For available "
+        "options check the corresponding help: `jf job list -h`.",
     )
 
     model_config = SettingsConfigDict(env_prefix="jfremote_")

--- a/src/jobflow_remote/config/settings.py
+++ b/src/jobflow_remote/config/settings.py
@@ -30,9 +30,8 @@ class JobflowRemoteSettings(BaseSettings):
     cli_log_level: LogLevel = Field(
         LogLevel.WARN, description="The level set for logging in the CLI"
     )
-    cli_job_list_columns: list[str] = Field(
-        default_factory=list,
-        description="The list of columns to show in the `jf job list` command.",
+    cli_job_list_columns: Optional[list[str]] = Field(
+        None, description="The list of columns to show in the `jf job list` command."
     )
 
     model_config = SettingsConfigDict(env_prefix="jfremote_")

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -147,6 +147,7 @@ class JobInfo(BaseModel):
     end_time: Optional[datetime] = None
     priority: int = 0
     metadata: Optional[dict] = None
+    stored_data: Optional[dict] = None
 
     @property
     def is_locked(self) -> bool:

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -32,6 +32,14 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         ["job", "list"], required_out=["Get more information about the errors"]
     )
 
+    outputs = ["WAITING", "READY", "none", "State", "DB id", "whatever"]
+    excluded = ["add1", "add2", "Name", "Job id"]
+    run_check_cli(
+        ["job", "list", "-hk", "state", "-hk", "db_id", "-sdk", "whatever"],
+        required_out=outputs,
+        excluded_out=excluded,
+    )
+
 
 def test_job_info(job_controller, two_flows_four_jobs) -> None:
     from jobflow_remote.testing.cli import run_check_cli

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -32,12 +32,22 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         ["job", "list"], required_out=["Get more information about the errors"]
     )
 
-    outputs = ["WAITING", "READY", "none", "State", "DB id", "whatever"]
+    outputs = ["WAITING", "READY", "State", "DB id", "whatever"]
     excluded = ["add1", "add2", "Name", "Job id"]
     run_check_cli(
-        ["job", "list", "-hk", "state", "-hk", "db_id", "-sdk", "whatever"],
+        ["job", "list", "-o", "state,db_id", "-sdk", "whatever"],
         required_out=outputs,
         excluded_out=excluded,
+    )
+
+    output = "Header keys not supported: {'not_existing_key'}"
+    run_check_cli(
+        ["job", "list", "-o", "state,not_existing_key"], required_out=output, error=True
+    )
+
+    output = "Options output, verbosity are incompatible"
+    run_check_cli(
+        ["job", "list", "-o", "state,name", "-vv"], required_out=output, error=True
     )
 
 

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -51,6 +51,30 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
     )
 
 
+def test_jobs_list_settings(job_controller, two_flows_four_jobs, monkeypatch) -> None:
+    from jobflow_remote import SETTINGS
+    from jobflow_remote.testing.cli import run_check_cli
+
+    with monkeypatch.context() as m:
+        m.setattr(SETTINGS, "cli_job_list_columns", ["state", "db_id"])
+
+        outputs = ["WAITING", "READY", "State", "DB id"]
+        excluded = ["add1", "add2", "Name", "Job id"]
+        run_check_cli(
+            ["job", "list"],
+            required_out=outputs,
+            excluded_out=excluded,
+        )
+
+        # using -v will lead to a very large table which isn't fully displayed
+        columns = ["DB", "id", "Name", "Sta", "Job", "id", "Wor", "Last", "Loc"]
+        outputs = columns + [f"add{i}" for i in range(1, 5)] + ["REA", "WAI"]
+        run_check_cli(
+            ["job", "list", "-v"],
+            required_out=outputs,
+        )
+
+
 def test_job_info(job_controller, two_flows_four_jobs) -> None:
     from jobflow_remote.testing.cli import run_check_cli
 


### PR DESCRIPTION
Add the option to display data from the `stored_data` field in the `Response` object. A User can select a key or multiple keys to display those values.

On a sidenote, another option was added to not display the uuid of the jobs. I typically don't gain much from this information since the db_id already gives me the unique information I need to find the job in the database.

Things to discuss:

- Name of the cli options (including short-cuts)
- Name of the column in the output table: For now only the key. Should be sufficient since the user does know what fields he/she requested, right?
- Name of the default_value which is displayed once no data is available or the specified key is not present. For now a light grey italic `none`

Example:

See the attached screenshot.

<img width="1215" alt="Bildschirmfoto 2024-12-10 um 11 32 32" src="https://github.com/user-attachments/assets/98a6bba2-cf8b-4485-b61e-5e3c707deecf">

Maybe closes #227 