### PR TITLE
Allow switching off daemon if no running runner doc

### DIFF
--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -42,6 +42,10 @@ class RunnerOptions(BaseModel):
         description="Delay between subsequent refresh from the DB of the number of submitted "
         "and running jobs (seconds). Only used if a batch worker is present",
     )
+    delay_ping_db: int = Field(
+        7200,
+        description="Delay between subsequent pings to the running runner document.",
+    )
     lock_timeout: Optional[int] = Field(
         86400,
         description="Time to consider the lock on a document expired and can be overridden (seconds)",

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -697,13 +697,17 @@ class DaemonManager:
         bool
             True if the daemon was stopped successfully, False otherwise.
         """
-        with self.lock_runner_doc() as lock:
-            doc_error = self._check_running_runner(
-                lock.locked_document, raise_on_error=raise_on_error
-            )
-            if doc_error:
-                logger.error(doc_error)
-                return False
+        with self.lock_runner_doc(allow_missing=True) as lock:
+            # This check is done to allow users to switch off the runner
+            # even if the running_runner document is not present.
+            # If the document is locked the error will be raised by lock_runner_doc
+            if lock.locked_document:
+                doc_error = self._check_running_runner(
+                    lock.locked_document, raise_on_error=raise_on_error
+                )
+                if doc_error:
+                    logger.error(doc_error)
+                    return False
             status = self.check_status()
             if status in (
                 DaemonStatus.STOPPED,
@@ -826,13 +830,17 @@ class DaemonManager:
         bool
             True if the daemon is shut down correctly, False otherwise.
         """
-        with self.lock_runner_doc() as lock:
-            doc_error = self._check_running_runner(
-                lock.locked_document, raise_on_error=raise_on_error
-            )
-            if doc_error:
-                logger.error(doc_error)
-                return False
+        with self.lock_runner_doc(allow_missing=True) as lock:
+            # This check is done to allow users to switch off the runner
+            # even if the running_runner document is not present.
+            # If the document is locked the error will be raised by lock_runner_doc
+            if lock.locked_document:
+                doc_error = self._check_running_runner(
+                    lock.locked_document, raise_on_error=raise_on_error
+                )
+                if doc_error:
+                    logger.error(doc_error)
+                    return False
             status = self.check_status()
             if status == DaemonStatus.SHUT_DOWN:
                 logger.info("supervisord is already shut down.")

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -3819,6 +3819,23 @@ class JobController:
                 )
             lock.update_on_release = {"$set": {"running_runner": None}}
 
+    def ping_running_runner(self) -> bool:
+        """
+        Ping the running_runner document, if exists and has been activated as a daemon.
+
+        Returns
+        -------
+        bool
+            True if the ping was successful.
+        """
+        ping_result = self.auxiliary.find_one_and_update(
+            {"running_runner.last_pinged": {"$exists": True}},
+            {"$set": {"running_runner.last_pinged": datetime.utcnow()}},
+            upsert=False,
+        )
+
+        return ping_result is not None
+
     def update_flow_state(
         self,
         flow_uuid: str,

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -54,9 +54,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-PING_RUNNER_DELAY = 7200
-
-
 class Runner:
     """
     Object orchestrating the execution of all the Jobs.
@@ -321,7 +318,9 @@ class Runner:
 
         # all the processes will ping the running_runner document to signal
         # that at least one is still active.
-        scheduler.every(PING_RUNNER_DELAY).seconds.do(self.ping_running_runner)
+        scheduler.every(self.project.runner.delay_ping_db).seconds.do(
+            self.ping_running_runner
+        )
 
         ticks_remaining: int | bool = True
         if ticks is not None:

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -45,6 +45,12 @@ def test_std_operations(
     run_check_cli(
         ["runner", "info"],
         required_out=[*info_required, "hostname", "last_pinged"],
+        excluded_out="processes_info",
+    )
+
+    run_check_cli(
+        ["runner", "info", "-v"],
+        required_out=[*info_required, "hostname", "last_pinged", "processes_info"],
     )
 
     run_check_cli(

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -242,6 +242,7 @@ def wait_daemon_status(
     if not acceptable_states:
         acceptable_states = [target_status]
 
+    state = None
     for _i in range(max_wait):
         time.sleep(1)
         # if the state cannot be determined keep waiting
@@ -253,7 +254,7 @@ def wait_daemon_status(
         if state == target_status:
             return True
     raise RuntimeError(
-        f"The daemon did not start {target_status.value} within the expected time ({max_wait})"
+        f"The daemon did not reach {target_status.value} within the expected time ({max_wait}). Last state: {state}"
     )
 
 
@@ -288,4 +289,16 @@ def wait_daemon_stopped():
 def wait_daemon_shutdown():
     from jobflow_remote.jobs.daemon import DaemonStatus
 
-    return partial(wait_daemon_status, target_status=DaemonStatus.SHUT_DOWN)
+    acceptable_states = [
+        DaemonStatus.STOPPING,
+        DaemonStatus.STOPPED,
+        DaemonStatus.RUNNING,
+        DaemonStatus.PARTIALLY_RUNNING,
+        DaemonStatus.SHUT_DOWN,
+    ]
+
+    return partial(
+        wait_daemon_status,
+        target_status=DaemonStatus.SHUT_DOWN,
+        acceptable_states=acceptable_states,
+    )

--- a/tests/db/jobs/test_daemon.py
+++ b/tests/db/jobs/test_daemon.py
@@ -283,7 +283,7 @@ def test_missing_running_runner_doc(
 ):
     from jobflow_remote.jobs.daemon import DaemonStatus
 
-    # remote the running_runner document
+    # remove the running_runner document
     assert (
         job_controller.auxiliary.delete_one(
             {"running_runner": {"$exists": True}}
@@ -310,7 +310,7 @@ def test_missing_running_runner_doc(
     assert daemon_manager.start(raise_on_error=True, single=False)
     wait_daemon_started(daemon_manager)
 
-    # remote the running_runner document
+    # remove the running_runner document
     assert (
         job_controller.auxiliary.delete_one(
             {"running_runner": {"$exists": True}}

--- a/tests/db/jobs/test_runner.py
+++ b/tests/db/jobs/test_runner.py
@@ -91,8 +91,6 @@ def test_delay_download(job_controller, runner, monkeypatch, one_job):
 def test_ping_runner_runner(job_controller, runner, monkeypatch, caplog):
     from datetime import datetime
 
-    from jobflow_remote.jobs import runner as runner_module
-
     assert not job_controller.ping_running_runner()
     runner.ping_running_runner()
     # check that the ping does not create the document
@@ -110,7 +108,7 @@ def test_ping_runner_runner(job_controller, runner, monkeypatch, caplog):
         < 0.1
     )
     with monkeypatch.context() as m:
-        m.setattr(runner_module, "PING_RUNNER_DELAY", 3)
+        m.setattr(runner.runner_options, "delay_ping_db", 3)
         runner.run(ticks=5)
 
     assert (


### PR DESCRIPTION
Fixing a potential issue for the upgrade procedure, signaled in https://github.com/Matgenix/jobflow-remote/issues/211#issuecomment-2564361222
Now it is possible to stop the runner even if there is no running_runner document.