### PR TITLE
Hot fix to pin pymongo version to lower than 4.11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - how to limit number of jobs [\#195](https://github.com/Matgenix/jobflow-remote/issues/195)
 - non-unique uuids as a problem in jobflow-remote [\#193](https://github.com/Matgenix/jobflow-remote/issues/193)
 - Set `projects_folder` via env var [\#188](https://github.com/Matgenix/jobflow-remote/issues/188)
-- Support for heterogenous computing resources? [\#184](https://github.com/Matgenix/jobflow-remote/issues/184)
+- Support for heterogeneous computing resources? [\#184](https://github.com/Matgenix/jobflow-remote/issues/184)
 - Jobflow remote logo [\#178](https://github.com/Matgenix/jobflow-remote/issues/178)
 - How could I use SGE for job submission?  [\#159](https://github.com/Matgenix/jobflow-remote/issues/159)
 - Check there is not already a runner running [\#140](https://github.com/Matgenix/jobflow-remote/issues/140)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "jobflow >= 0.1.19",
     "psutil >= 5.9,< 7.0",
     "pydantic ~= 2.4",
+    "pymongo < 4.11",
     "python-dateutil>=2.8.2",
     "qtoolkit >= 0.1.6",
     "rich ~= 13.7",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 jobflow==0.1.19
 pydantic==2.10.5
+pymongo==4.10.1
 fabric==3.2.2
 tomlkit==0.13.2
 qtoolkit==0.1.6


### PR DESCRIPTION
Pymongo added a sort argument to some of its methods in version 4.11. Down the road, this has impacts on maggma (through mongomock) that is used in jobflow remote for the remote JSONStore. Currently fixed by pinning pymongo to a previous version (lower than 4.11).
Fixed typo in changelog.