### PR TITLE
Reset stored data field on rerun

### DIFF
--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -517,4 +517,5 @@ def get_reset_job_base_dict() -> dict:
         "updated_on": datetime.utcnow(),
         "start_time": None,
         "end_time": None,
+        "stored_data": None,
     }


### PR DESCRIPTION
I've added a line of code which should ensure that the stored_data field is also reset when calling `jf job rerun`. To be honest I've not tested it so far.

I am not sure how this field is intended to be used, but in the way I am it makes sense to reset it also on rerun.

What is your opinion?