### PR TITLE
CLI and other small updates

### DIFF
--- a/doc/source/user/additional_material.rst
+++ b/doc/source/user/additional_material.rst
@@ -1,0 +1,18 @@
+.. _additional_material:
+
+*******************
+Additional material
+*******************
+
+Here is a collection of links to external references and tutorials that may be helpful
+in understanding, setting up and testing jobflow-remote
+
+Atomate2 CECAM school (Lausanne, March 2025)
+============================================
+
+The website of the CECAM school `Automated ab initio workflows with Jobflow and Atomate2 <https://www.cecam.org/workshop-details/automated-ab-initio-workflows-with-jobflow-and-atomate2-1276>`_
+held in Lausanne from March 17, 2025 to March 20, 2025 contains some extensive presentations
+and tutorials on jobflow and jobflow-remote. In particular:
+
+* Introduction to jobflow remote [`SLIDES <https://members.cecam.org/storage/presentation/jobflow_remote-1742222756.pdf>`_] [`VIDEO <https://kdrive.infomaniak.com/app/share/818045/8adfa398-ddb1-4add-bedc-ecadda711432/preview/video/149790>`_]
+* `Docker container to test jobflow-remote <https://github.com/Matgenix/atomate2_cecam_school>`_

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -28,5 +28,6 @@ details are found in :ref:`reference`.
    :hidden:
    :caption: Extras
 
+   additional_material
    ../glossary
    ../license

--- a/doc/source/user/projectconf.rst
+++ b/doc/source/user/projectconf.rst
@@ -56,7 +56,16 @@ For all these folders the paths are set with defaults, but can be customised set
 
 .. warning::
   The project name does not take into consideration the configuration file name.
-  For coherence it would be better to give use the project name as file name.
+  For coherence it would be better to use the project name as file name.
+
+.. dropdown:: Example
+
+    Standard usage will not require filling in all directories path and usually
+    just the name can be provided in the configuration:
+
+    .. code-block:: yaml
+
+        name: my_project
 
 .. _projectconf worker:
 
@@ -111,6 +120,68 @@ configurations. Those can better be set with the :ref:`projectconf execconfig`.
     through the ``scheduler_username`` option. Jobflow-remote will use that as a filter,
     instead of the list of ids.
 
+.. dropdown:: Example
+
+    Several workers of different kinds can be defined:
+
+    .. code-block:: yaml
+
+        workers:
+          my_cluster_front_end: # A worker on the front end of the cluster
+            scheduler_type: shell
+            work_dir: /path/to/run/dir
+            # Activate the conda environment on the worker
+            pre_run: "\neval \"$(conda shell.bash hook)\"\nconda activate jfr\n"
+            type: remote
+            # No connection details if they are defined in the ~/.ssh/config file
+            host: my_cluster
+          my_cluster: # same cluter, a worker using the SLURM queue
+            scheduler_type: slurm
+            work_dir: /path/to/run/dir
+            resources:
+            pre_run: "\neval \"$(conda shell.bash hook)\"\nconda activate jfr\n"
+            type: remote
+            host: my_cluster
+          another_cluster: # A remote worker on another cluster
+            scheduler_type: slurm
+            work_dir: /path/to/another/run/dir
+            pre_run: source /data/venv/jobflow/bin/activate
+            type: remote
+            # also possible to define connection details here
+            host: another.cluster.host.net
+            user: username
+            key_filename: /path/to/ssh/private/key
+          another_cluster_batch: # A batch worker on the second cluster
+            scheduler_type: slurm
+            work_dir: /path/to/another/run/dir
+            # Each batch job will run on two nodes with 24 cores each
+            resources:
+              nodes: 2
+              ntasks_per_node: 24
+              mem: 95000
+              partition: xxx
+            pre_run: source /data/venv/jobflow/bin/activate
+            type: remote
+            host: another.cluster.host.net
+            user: username
+            key_filename: /path/to/ssh/private/key
+            # maximum 5 batch Slurm jobs in the queue at the same time
+            max_jobs: 5
+            # This will determine that the worker is a "batch" worker
+            batch:
+              jobs_handle_dir: /some/remote/path/run/batch_handle_slurm
+              work_dir: /some/remote/path/run/batch_work_slurm
+              # two jobflow Job executed in parallel in a single SLURM submission
+              parallel_jobs: 2
+          local_shell: # A local worker running in the shell
+            scheduler_type: shell
+            work_dir: /local/path/to/run/jobs
+            pre_run: "\neval \"$(conda shell.bash hook)\"\nconda activate atomate2_pyd2\n"
+            type: local
+            # Limit the number of local jobs. Since there is no queue they can all
+            # start simultaneously otherwise
+            max_jobs: 3
+
 .. _projectconf jobstore:
 
 JobStore
@@ -128,6 +199,28 @@ in this project.
 
     The ``JobStore`` should be defined in jobflow-remote's configuration file.
     The content of the standard jobflow configuration file will be ignored.
+
+.. warning::
+
+    If you have been using jobflow without jobflow-remote and you have a
+    ``JobStore`` defined in a ``jobflow.yaml`` it will be ignored. Only the
+    definition in the jobflow-remote configuration file will be considered
+
+.. dropdown:: Example
+
+    Define a ``JobStore`` similarly to standard jobflow
+
+    .. code-block:: yaml
+
+        jobstore:
+          docs_store:
+            type: MongoStore
+            host: <host name>
+            port: 27017
+            username: <username>
+            password: <password>
+            database: <database name>
+            collection_name: outputs
 
 .. _projectconf queuestore:
 
@@ -151,6 +244,34 @@ of these two collections can also be customized.
     Some key operations required by jobflow-remote on the collections are not
     supported by any file based MongoDB implementation at the moment.
 
+.. warning::
+
+    If the ``JobStore`` is also based on a MongoDB, it is often convenient to have
+    its main ``docs_store`` in the same database as the ``queue`` store, in that
+    case it is important that the two do **not point to the same collection**.
+    Unexpected errors may happen otherwise.
+
+.. dropdown:: Example
+
+    Define a queue store as maggma store. It is possible to use the same syntax
+    as for the ``JobStore``. Customizing the names of the additional collections
+    is also possible but not necessary
+
+    .. code-block:: yaml
+
+        queue:
+          store:
+            type: MongoStore
+            host: <host name>
+            port: 27017
+            username: <username>
+            password: <password>
+            database: <database name>
+            collection_name: jobs
+          flows_collection: flows
+          auxiliary_collection: jf_auxiliary
+
+
 .. _projectconf execconfig:
 
 Execution configurations
@@ -160,6 +281,35 @@ It is possible to define a set of ``ExecutionConfig`` objects to quickly set up
 configurations for different kind of Jobs and Flow. The ``exec_config`` key
 contains a dictionary where the keys are the names associated to the configurations
 and for each a set of instruction to be set before and after the execution of the Job.
+See the :ref:`tuning exec_config` section for more details and a usage examples.
+
+.. dropdown:: Example
+
+    Multiple configurations can be defined, for example one for each version of an
+    external code or for different software requirements. If multiple workers
+    are present, different ``exec_config`` will need to be defined for each of them.
+
+    .. code-block:: yaml
+
+        exec_config:
+          xxx_v1_1_my_cluster:
+            modules:
+            - releases/2021b
+            - intel/2021b
+            export:
+              PATH: /path/to/executable/v1.1:$PATH
+            pre_run:
+            post_run:
+          xxx_v3_2_my_cluster:
+            modules:
+            - releases/2023b
+            - intel/2023b
+            export:
+              PATH: /path/to/executable/v3.2:$PATH
+          yyy_local:
+            export:
+              PATH: /path/to/local/executable:$PATH
+            pre_run: "echo 'test'\necho 'test2'"
 
 Runner options
 --------------
@@ -172,6 +322,26 @@ reasonable values are set for the delay between each check of the database for
 different kind of actions performed by the ``Runner``. These intervals can be
 changed to better fit your needs. Remind that reducing these intervals too much
 may put unnecessary strain on the database.
+
+.. dropdown:: Example
+
+    Most of the times default values should be fine. Here is how to customize
+    the Runner execution
+
+    .. code-block:: yaml
+
+        runner:
+          delay_checkout: 10
+          delay_check_run_status: 10
+          delay_advance_status: 10
+          delay_update_batch: 10
+          lock_timeout: 86400
+          delete_tmp_folder: true
+          max_step_attempts: 3
+          delta_retry:
+          - 30
+          - 300
+          - 1200
 
 Metadata
 --------

--- a/doc/source/user/tuning.rst
+++ b/doc/source/user/tuning.rst
@@ -29,6 +29,8 @@ should always be defined for each Job when adding a Flow to the database.
     to the same HPC center, but with different configurations can be created.
     The ``Runner`` will still open a single connection if the host is the same.
 
+.. _tuning exec_config:
+
 Execution configuration
 -----------------------
 
@@ -36,12 +38,66 @@ An execution configuration, represented as an ``ExecutionConfig`` object in
 the code, contains information to run additional commands before and after
 the execution of a Job.
 
-These can be typically used to define the modules to load on an HPC center,
+This can be typically used to define the modules to load on an HPC center,
 specific python environment to load or setting the ``PATH`` for some executable
-needed by the Job.
+needed by the Job. In an ``ExecutionConfig`` different elements can be defined:
 
-They can be usually given as a string referring to the setting defined in the
-project configuration file, or as an instance of ``ExecutionConfig``.
+* ``modules``: a list of strings representing the modules that will be loaded in the
+  submission script (e.g. the string ``OpenMPI`` will be applied by running ``module load OpenMPI``).
+* ``export``: a dictionary with names and values of variable that will be exported
+  in the submission script (e.g. ``{"X": 1}`` will be translated to ``export X=1``)
+* ``pre_run``: a string that will be included in the submission script before starting
+  the Job.
+* ``post_run``: a string that will be included in the submission script after the Job
+  has been executed.
+
+To customize the job an execution configuration can be selected setting the
+``exec_config`` argument of ``submit_flow`` or ``set_run_config``, where the values can be:
+
+1) a string pointing to an ``exec_config`` defined in the Project configuration
+2) an instance of ``ExecutionConfig``
+
+An example of ``exec_config`` in the configuration file is
+
+.. code-block:: yaml
+
+    exec_config:
+      example_config:
+        modules:
+        - releases/2021b
+        - intel/2021b
+        export:
+          PATH: /path/to/your/code/bin:$PATH
+        pre_run: "echo 'test'\necho 'test2'"
+        post_run:
+
+where ``example_config`` is a custom name. This can be used when submitting a Job as
+
+.. code-block:: python
+
+    submit_flow(flow, exec_config="example_config", worker="worker_1")
+
+and will result in the following lines being added to the submission script
+
+.. code-block:: bash
+
+    echo 'test'
+    echo 'test2'
+    export PATH=/path/to/your/code/bin:$PATH
+    module load releases/2021b
+    module load intel/2021b
+
+The same can be achieved by defining an instance of ``ExecutionConfig`` in the submission
+script and passing it to ``submit_flow``.
+
+.. note::
+
+    These lines will be added **after** the worker ``pre_run`` in the submission script.
+
+.. note::
+
+    Multiple ``exec_config`` can be defined in the Project configuration, but only one
+    can be passed to an ``exec_config`` argument.
 
 Resources
 ---------

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -12,7 +12,7 @@ from rich.scope import render_scope
 from rich.table import Table
 from rich.text import Text
 
-from jobflow_remote.cli.utils import ReprStr, fmt_datetime
+from jobflow_remote.cli.utils import ReprStr, fmt_datetime, render_scope_jfr
 from jobflow_remote.jobs.state import FlowState, JobState
 from jobflow_remote.remote.data import get_job_path
 from jobflow_remote.utils.data import convert_utc_time
@@ -228,7 +228,7 @@ def format_job_info(
         if k in d:
             sorted_d[k] = d[k]
 
-    return render_scope(sorted_d, sort_keys=False)
+    return render_scope_jfr(sorted_d, sort_keys=False, overflow="fold")
 
 
 def format_flow_info(flow_info: FlowInfo) -> Table:

--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -13,12 +13,10 @@ from jobflow_remote.cli.utils import (
     out_console,
     start_profiling,
 )
-from jobflow_remote.config import ConfigError
-from jobflow_remote.utils.log import initialize_cli_logger
 
 app = JFRTyper(
     name="jf",
-    add_completion=False,
+    add_completion=True,
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help"]},
     epilog=None,  # to remove the default message in JFRTyper
@@ -70,6 +68,8 @@ def main(
 ) -> None:
     """The controller CLI for jobflow-remote."""
     from jobflow_remote import SETTINGS
+    from jobflow_remote.config import ConfigError
+    from jobflow_remote.utils.log import initialize_cli_logger
 
     if full_exc:
         SETTINGS.cli_full_exc = True

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1,6 +1,4 @@
 import io
-import os
-import shlex
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Optional
@@ -105,7 +103,7 @@ def jobs_list(
         typer.Option(
             "--error",
             "-e",
-            help="Select the jobs in FAILED and REMOTE_ERROR state",
+            help="Select the jobs in FAILED and REMOTE_ERROR state. Compatible with other state filtering options",
         ),
     ] = False,
     running: Annotated[
@@ -113,7 +111,8 @@ def jobs_list(
         typer.Option(
             "--running",
             "-run",
-            help="Select the jobs in one of the running states (from CHECKED_OUT to DOWNLOADED)",
+            help="Select the jobs in one of the running states (from CHECKED_OUT to DOWNLOADED). "
+            "Compatible with other state filtering options",
         ),
     ] = False,
     stored_data_keys: Annotated[
@@ -802,30 +801,12 @@ def todir(
         typer.Option(
             "--shell",
             "-s",
-            help="A shell to be used locally when executing the command to connect",
+            help="A shell to be used in the opened terminal",
         ),
     ] = "bash",
-    remote_shell: Annotated[
-        Optional[str],
-        typer.Option(
-            "--remote-shell",
-            "-rs",
-            help="A shell to be used on the worker to give access to the terminal",
-        ),
-    ] = "bash",
-    command: Annotated[
-        bool,
-        typer.Option(
-            "--command",
-            "-c",
-            help="Only print the ssh command that will be used to connect",
-        ),
-    ] = False,
 ):
     """
     Connect to the worker and go to the job run_dir.
-    For remote workers and explicit ssh command is generated, so only a subset
-    of the connection definition are supported.
     """
 
     # NOTE this function uses system commands to connect to the remote host and
@@ -842,23 +823,16 @@ def todir(
         job_index=job_index,
         db_id=db_id,
     )
+    if not job_data:
+        exit_with_error_msg("No job matching the critiria")
     if not job_data.run_dir:
         exit_with_error_msg("The selected Job does not have a run_dir defined yet")
     worker = cm.get_worker(job_data.worker)
     host = worker.get_host()
-    cmd = host.to_dir_cmd(job_data.run_dir, target_shell=remote_shell)
-    if shell:
-        cmd = f"{shell} -c {shlex.quote(cmd)}"
-
-    if command:
-        out_console.print("Connection command:")
-        out_console.print(cmd)
-        return
-
     out_console.print(
         f"Connecting to worker {job_data.worker} and moving to {job_data.run_dir}"
     )
-    os.system(cmd)  # noqa: S605
+    host.shell(pre_cmd=f"cd {job_data.run_dir}", shell=shell)
 
 
 app_job_set = JFRTyper(

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1,4 +1,6 @@
 import io
+import os
+import shlex
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated, Optional
@@ -70,7 +72,7 @@ from jobflow_remote.cli.utils import (
     str_to_dict,
 )
 from jobflow_remote.jobs.report import JobsReport
-from jobflow_remote.jobs.state import JobState
+from jobflow_remote.jobs.state import ERROR_STATES, RUNNING_STATES, JobState
 from jobflow_remote.remote.queue import ERR_FNAME, OUT_FNAME
 
 app_job = JFRTyper(
@@ -103,7 +105,15 @@ def jobs_list(
         typer.Option(
             "--error",
             "-e",
-            help="Select the jobs in FAILED and REMOTE_ERROR state. Incompatible with the --state option",
+            help="Select the jobs in FAILED and REMOTE_ERROR state",
+        ),
+    ] = False,
+    running: Annotated[
+        bool,
+        typer.Option(
+            "--running",
+            "-run",
+            help="Select the jobs in one of the running states (from CHECKED_OUT to DOWNLOADED)",
         ),
     ] = False,
     stored_data_keys: Annotated[
@@ -130,7 +140,8 @@ def jobs_list(
     """
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
     check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
-    check_incompatible_opt({"state": state, "error": error})
+    # check_incompatible_opt({"state": state, "error": error})
+    # check_incompatible_opt({"state": state, "running": running})
     check_incompatible_opt({"output": cli_output_keys, "verbosity": verbosity})
     check_query_incompatibility(
         custom_query,
@@ -171,7 +182,16 @@ def jobs_list(
     db_sort: list[tuple[str, int]] = [(sort.value, 1 if reverse_sort else -1)]
 
     if error:
-        state = [JobState.REMOTE_ERROR, JobState.FAILED]
+        if state:
+            state.extend(ERROR_STATES)
+        else:
+            state = ERROR_STATES
+
+    if running:
+        if state:
+            state.extend(RUNNING_STATES)
+        else:
+            state = RUNNING_STATES
 
     with loading_spinner():
         if custom_query:
@@ -280,7 +300,9 @@ def job_info(
     if not job_data:
         exit_with_error_msg("No data matching the request")
 
-    out_console.print(format_job_info(job_data, verbosity, show_none=show_none))
+    out_console.print(
+        format_job_info(job_data, verbosity, show_none=show_none), overflow="crop"
+    )
 
 
 @app_job.command()
@@ -769,6 +791,74 @@ def report(
         timezone=timezone,
     )
     out_console.print(*get_job_report_components(jobs_report))
+
+
+@app_job.command()
+def todir(
+    job_db_id: job_db_id_arg = None,
+    job_index: job_index_arg = None,
+    shell: Annotated[
+        Optional[str],
+        typer.Option(
+            "--shell",
+            "-s",
+            help="A shell to be used locally when executing the command to connect",
+        ),
+    ] = "bash",
+    remote_shell: Annotated[
+        Optional[str],
+        typer.Option(
+            "--remote-shell",
+            "-rs",
+            help="A shell to be used on the worker to give access to the terminal",
+        ),
+    ] = "bash",
+    command: Annotated[
+        bool,
+        typer.Option(
+            "--command",
+            "-c",
+            help="Only print the ssh command that will be used to connect",
+        ),
+    ] = False,
+):
+    """
+    Connect to the worker and go to the job run_dir.
+    For remote workers and explicit ssh command is generated, so only a subset
+    of the connection definition are supported.
+    """
+
+    # NOTE this function uses system commands to connect to the remote host and
+    # local host. The shell name is also potentially passed by the user, so
+    # it is potentially dangerous if the user does not have direct access to
+    # the machines involved, but this should not be the case for the CLI of JFR.
+    cm = get_config_manager()
+    jc = get_job_controller()
+
+    db_id, job_id = get_job_db_ids(job_db_id, job_index)
+
+    job_data = jc.get_job_info(
+        job_id=job_id,
+        job_index=job_index,
+        db_id=db_id,
+    )
+    if not job_data.run_dir:
+        exit_with_error_msg("The selected Job does not have a run_dir defined yet")
+    worker = cm.get_worker(job_data.worker)
+    host = worker.get_host()
+    cmd = host.to_dir_cmd(job_data.run_dir, target_shell=remote_shell)
+    if shell:
+        cmd = f"{shell} -c {shlex.quote(cmd)}"
+
+    if command:
+        out_console.print("Connection command:")
+        out_console.print(cmd)
+        return
+
+    out_console.print(
+        f"Connecting to worker {job_data.worker} and moving to {job_data.run_dir}"
+    )
+    os.system(cmd)  # noqa: S605
 
 
 app_job_set = JFRTyper(

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -190,6 +190,17 @@ def check(
             )
         workers_to_test = [worker]
 
+    # check that jobstore main Store and the queue Store do not share the same collection
+    if (check_all or (jobstore and queue)) and (
+        project.get_jobstore().docs_store == project.get_queue_store()
+    ):
+        msg_duplicated_stores = (
+            "It seems that the main docs_store of the JobStore and the queue store point to the "
+            "same database and collection. This will lead to errors. Choose different collection names."
+        )
+
+        out_console.print(msg_duplicated_stores, style="red bold")
+
     tick = "[bold green]✓[/] "
     tick_warn = "[bold yellow]✓[/] "
     cross = "[bold red]x[/] "

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -279,6 +279,28 @@ def shutdown() -> None:
 
 
 @app_runner.command()
+def restart() -> None:
+    """
+    Restart the runner. Send a stop signal, wait for the runner to stop and
+    restart it with the same configuration.
+    """
+    cm = get_config_manager()
+    dm = DaemonManager.from_project(cm.get_project())
+    with loading_spinner(processing=False) as progress:
+        progress.add_task(description="Restarting the daemon...", total=None)
+        try:
+            dm.restart(raise_on_error=True)
+        except RunningDaemonError as e:
+            exit_with_error_msg(
+                f"Error while restarting the daemon: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
+            )
+        except DaemonError as e:
+            exit_with_error_msg(
+                f"Error while restaring the daemon: {getattr(e, 'message', e)}"
+            )
+
+
+@app_runner.command()
 def status() -> None:
     """Fetch the status of the daemon runner."""
     from jobflow_remote import SETTINGS

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -10,7 +10,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, Callable, NoReturn
 
 import typer
 from click import ClickException
@@ -26,7 +26,10 @@ from jobflow_remote.config.base import ProjectUndefinedError
 from jobflow_remote.jobs.daemon import DaemonError, DaemonManager, DaemonStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from cProfile import Profile
+
+    from rich.console import ConsoleRenderable
 
     from jobflow_remote.jobs.state import JobState
 
@@ -714,3 +717,70 @@ def confirm_project_name(style: str | None = "red", exit_on_error: bool = True) 
             exit_with_error_msg("The input does not match the current project name")
         return False
     return True
+
+
+def render_scope_jfr(
+    scope: Mapping[str, Any],
+    *,
+    title: TextType | None = None,
+    sort_keys: bool = True,
+    indent_guides: bool = False,
+    max_length: int | None = None,
+    max_string: int | None = None,
+    overflow: str | None = None,
+) -> ConsoleRenderable:
+    """
+    Render python variables in a given scope.
+    From original rich.scope.render_scope. Customized to fit jfr needs:
+    * allows overflow explicitly
+
+    Args:
+        scope (Mapping): A mapping containing variable names and values.
+        title (str, optional): Optional title. Defaults to None.
+        sort_keys (bool, optional): Enable sorting of items. Defaults to True.
+        indent_guides (bool, optional): Enable indentation guides. Defaults to False.
+        max_length (int, optional): Maximum length of containers before abbreviating, or None for no abbreviation.
+            Defaults to None.
+        max_string (int, optional): Maximum length of string before truncating, or None to disable. Defaults to None.
+        overflow (str):
+            Overflow method: "crop", "fold", or "ellipsis". Defaults to ``None``.
+    Returns:
+        ConsoleRenderable: A renderable object.
+    """
+    from rich.highlighter import ReprHighlighter
+    from rich.panel import Panel
+    from rich.pretty import Pretty
+    from rich.table import Table
+
+    highlighter = ReprHighlighter()
+    items_table = Table.grid(padding=(0, 1), expand=False)
+    items_table.add_column(justify="right")
+
+    def sort_items(item: tuple[str, Any]) -> tuple[bool, str]:
+        """Sort special variables first, then alphabetically."""
+        key, _ = item
+        return (not key.startswith("__"), key.lower())
+
+    items = sorted(scope.items(), key=sort_items) if sort_keys else scope.items()
+    for key, value in items:
+        key_text = Text.assemble(
+            (key, "scope.key.special" if key.startswith("__") else "scope.key"),
+            (" =", "scope.equals"),
+        )
+        items_table.add_row(
+            key_text,
+            Pretty(
+                value,
+                highlighter=highlighter,
+                indent_guides=indent_guides,
+                max_length=max_length,
+                max_string=max_string,
+                overflow=overflow,
+            ),
+        )
+    return Panel.fit(
+        items_table,
+        title=title,
+        border_style="scope.border",
+        padding=(0, 1),
+    )

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -856,6 +856,47 @@ class DaemonManager:
             lock.update_on_release = {"$set": {"running_runner": None}}
             return True
 
+    def restart(self, raise_on_error: bool = False) -> bool:
+        """
+        Restart the daemon by stopping and waiting then starting it with the same options.
+
+        Parameters
+        ----------
+        raise_on_error
+            If True, raise an exception if an error occurs.
+
+        Returns
+        -------
+        bool
+            True if the daemon is restarted correctly, False otherwise.
+        """
+        with self.lock_runner_doc(allow_missing=True) as lock:
+            doc = lock.locked_document
+            doc_error = self._check_running_runner(doc, raise_on_error=raise_on_error)
+            if doc_error:
+                logger.error(doc_error)
+                return False
+            status = self.check_status()
+            if status not in (
+                DaemonStatus.RUNNING,
+                DaemonStatus.PARTIALLY_RUNNING,
+            ):
+                logger.warning(f"Status of the runner {status.value}. Cannot restart")
+                return False
+        stop_out = self.stop(wait=True, raise_on_error=raise_on_error)
+        if not stop_out:
+            logger.warning("Could not stop the runner")
+            return False
+        old_config = self.parse_config_file()
+        return self.start(
+            num_procs_transfer=old_config["num_procs_transfer"],
+            num_procs_complete=old_config["num_procs_complete"],
+            single=old_config["single"],
+            log_level=old_config["log_level"],
+            raise_on_error=raise_on_error,
+            connect_interactive=old_config["connect_interactive"],
+        )
+
     def wait_start(self, timeout: int = 30) -> None:
         """
         Wait for all processes of the daemon to start.

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1201,7 +1201,7 @@ class JobController:
                 )
 
         job_doc_update = get_reset_job_base_dict()
-        job_doc_update["state"] = JobState.CHECKED_OUT.value
+        job_doc_update["state"] = JobState.READY.value
         if delete_files:
             job_doc_update["remote.prerun_cleanup"] = True
 
@@ -4039,7 +4039,14 @@ class JobController:
                 else:
                     step_attempts = doc["remote"]["step_attempts"]
                     no_retry = no_retry or step_attempts >= max_step_attempts
-                    queue_out, queue_err = self._get_downloaded_queue_files(doc)
+                    try:
+                        # prevent errors from handling queue files breaking the lock release
+                        queue_out, queue_err = self._get_downloaded_queue_files(doc)
+                    except Exception:
+                        logger.warning(
+                            "Error while trying to retrieve queue output", exc_info=True
+                        )
+                        queue_out, queue_err = None, None
                     if no_retry:
                         update_on_release = {
                             "$set": {
@@ -4438,7 +4445,9 @@ class JobController:
                 flow_doc.parents.pop(job_uuid, None)
 
             # Update flow state if necessary
-            updated_states = {job_uuid: {job_index: None}}  # None indicates job removal
+            updated_states: dict[str, dict[int, Any]] = {
+                job_uuid: {job_index: None}
+            }  # None indicates job removal
             self.update_flow_state(
                 flow_uuid=flow_doc.uuid, updated_states=updated_states
             )

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2736,6 +2736,32 @@ class JobController:
             for idx in flow_custom_indexes:
                 self.flows.create_index(idx, background=background)
 
+        # if the docs_store is a MongoStore with a collection, create a proper composed
+        # index that is the most effective for retrieving outputs. Otherwise create a simple
+        # index based on the maggma interface for the two indexes separately.
+        # In any case trap all exceptions, as this should not be a blocking point
+        try:
+            docs_store = self.jobstore.docs_store
+            if hasattr(docs_store, "_collection"):
+                if drop:
+                    docs_store._collection.drop_indexes()
+                docs_store._collection.create_index(
+                    [("uuid", 1), ("index", -1)], background=background
+                )
+            else:
+                docs_store.ensure_index("uuid")
+                docs_store.ensure_index("index")
+        except Exception:
+            logger.warning("Could not create the index for the JobStore", exc_info=True)
+        # Use the standard interface to create an index for the additional stores
+        for store_name, additional_store in self.jobstore.additional_stores.items():
+            try:
+                additional_store.ensure_index("blob_uuid")
+            except Exception:
+                logger.warning(
+                    f"Could not create the blob_uuid index for additional store {store_name}"
+                )
+
     def create_indexes(
         self,
         indexes: list[str | list],

--- a/src/jobflow_remote/jobs/run.py
+++ b/src/jobflow_remote/jobs/run.py
@@ -58,6 +58,11 @@ def run_remote_job(run_dir: str | Path = ".") -> None:
             job: Job = in_data["job"]
             store = in_data["store"]
             job_doc_dict = in_data.get("job_doc", None)
+            if isinstance(job.function, dict):
+                raise RuntimeError(  # noqa: TRY004,TRY301
+                    f"The function in the Job could not be deserialized: {job.function}.\n"
+                    "Check if this function is actually available in the worker's python environment"
+                )
             if job_doc_dict:
                 job_doc_dict["job"] = job
                 JfrState().job_doc = JobDoc.model_validate(job_doc_dict)

--- a/src/jobflow_remote/jobs/state.py
+++ b/src/jobflow_remote/jobs/state.py
@@ -74,6 +74,8 @@ DELETABLE_STATES = [
     s for s in JobState if s not in [JobState.BATCH_SUBMITTED, JobState.BATCH_RUNNING]
 ]
 
+ERROR_STATES = [JobState.REMOTE_ERROR, JobState.FAILED]
+
 
 class FlowState(Enum):
     """States of a Flow."""

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -148,21 +148,16 @@ class BaseHost(MSONable):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def to_dir_cmd(self, dir_path: str | Path, target_shell: str = "bash") -> str:
+    def shell(self, pre_cmd: str | None = None, shell: str = "bash"):
         """
-        Command that can be used in a unix shell to reach a directory in the host.
+        Open a connection to the host and starts the selected shell
 
         Parameters
         ----------
-        dir_path
-            The directory to reach
-        target_shell
-            Shell command to be used to start the shell on the worker to access the
-            target directory
-
-        Returns
-        -------
-            The string to be used to reach the chose directory.
+        pre_cmd
+            Any command to be executed before starting the shell
+        shell
+            The name of the shell to start
         """
         raise NotImplementedError
 

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -147,6 +147,25 @@ class BaseHost(MSONable):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def to_dir_cmd(self, dir_path: str | Path, target_shell: str = "bash") -> str:
+        """
+        Command that can be used in a unix shell to reach a directory in the host.
+
+        Parameters
+        ----------
+        dir_path
+            The directory to reach
+        target_shell
+            Shell command to be used to start the shell on the worker to access the
+            target directory
+
+        Returns
+        -------
+            The string to be used to reach the chose directory.
+        """
+        raise NotImplementedError
+
     @property
     def interactive_login(self) -> bool:
         """

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -157,21 +157,21 @@ class LocalHost(BaseHost):
 
         return removed
 
-    def to_dir_cmd(self, dir_path: str | Path, target_shell: str = "bash") -> str:
+    def shell(self, pre_cmd: str | None = None, shell: str = "bash"):
         """
-        Command that can be used in a unix shell to reach a directory in the host.
-        A simple cd for local host.
+        Open a connection to the host and starts the selected shell
 
         Parameters
         ----------
-        dir_path
-            The directory to reach
-        target_shell
-            Shell command to be used to start the shell on the worker to access the
-            target directory
-
-        Returns
-        -------
-            The string to be used to reach the chose directory.
+        pre_cmd
+            Any command to be executed before starting the shell
+        shell
+            The name of the shell to start
         """
-        return f"cd {dir_path}; {target_shell}"
+
+        from invoke import Context
+
+        cmd = shell
+        if pre_cmd:
+            cmd = f"{pre_cmd}; {shell}"
+        Context().run(cmd, pty=True)

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -156,3 +156,22 @@ class LocalHost(BaseHost):
         shutil.rmtree(path, onerror=onerror if not raise_on_error else None)
 
         return removed
+
+    def to_dir_cmd(self, dir_path: str | Path, target_shell: str = "bash") -> str:
+        """
+        Command that can be used in a unix shell to reach a directory in the host.
+        A simple cd for local host.
+
+        Parameters
+        ----------
+        dir_path
+            The directory to reach
+        target_shell
+            Shell command to be used to start the shell on the worker to access the
+            target directory
+
+        Returns
+        -------
+            The string to be used to reach the chose directory.
+        """
+        return f"cd {dir_path}; {target_shell}"

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -430,6 +430,27 @@ class RemoteHost(BaseHost):
     def interactive_login(self) -> bool:
         return self._interactive_login
 
+    def to_dir_cmd(self, dir_path: str | Path, target_shell: str = "bash") -> str:
+        """
+        Command that can be used in a unix shell to reach a directory in the host.
+        Generates an ssh command from the Connection object. If password is defined
+        in the connection will use sshpass.
+
+        Parameters
+        ----------
+        dir_path
+            The directory to reach
+        target_shell
+            Shell command to be used to start the shell on the worker to access the
+            target directory
+
+        Returns
+        -------
+            The string to be used to reach the chose directory.
+        """
+        ssh_cmd = build_ssh_command(self.connection)
+        return f'{ssh_cmd} "cd {dir_path}; {target_shell}"'
+
 
 def inter_handler(title, instructions, prompt_list):
     """
@@ -492,3 +513,107 @@ class InteractiveAuthStrategy(OpenSSHAuthStrategy):
         #     )
 
         yield Interactive(username=self.username)
+
+
+def build_ssh_command(connection: fabric.Connection) -> str:
+    """
+    Given a fabric Connection generate the ssh command replicating
+    that same connection.
+
+    Only a subset of the cases are implemented and several involved
+    connections will probably not be handled properly.
+
+    Parameters
+    ----------
+    connection
+        The fabric connection used to generate the command
+    Returns
+    -------
+        A string representing the ssh connection
+    """
+    cmd_parts = []
+
+    connect_kwargs = connection.connect_kwargs or {}
+    password = connect_kwargs.get("password")
+    if password:
+        cmd_parts += ["sshpass", "-p", shlex.quote(password)]
+
+    cmd_parts.append("ssh")
+    cmd_parts.append("-t")
+
+    # Forward agent
+    if connection.forward_agent:
+        cmd_parts.append("-A")
+
+    # handle gateway. Only one nested gateway Connection allowed
+    gateway = connection.gateway
+    if gateway:
+        if isinstance(gateway, str):
+            # If the string contains an "ssh" command it should be used as a ProxyCommand
+            # otherwise consider it like a ProxyJump
+            if "ssh " in gateway:
+                cmd_parts += ["-o", f"ProxyCommand={shlex.quote(gateway)}"]
+            else:
+                cmd_parts += ["-J", gateway]
+
+        elif isinstance(gateway, fabric.Connection):
+            # if gateway is another connection create a ProxyCommand using this same
+            # function, but don't do it recursively if there is more than one nested gateway
+            if getattr(gateway, "gateway", None):
+                raise NotImplementedError(
+                    "Nested gateways beyond one level are not supported."
+                )
+            proxy_cmd = build_ssh_command(gateway)
+            cmd_parts += ["-o", f"ProxyCommand={shlex.quote(proxy_cmd + ' -W %h:%p')}"]
+
+    # Port
+    if connection.port:
+        cmd_parts += ["-p", str(connection.port)]
+
+    # Timeout
+    if connection.connect_timeout:
+        cmd_parts += ["-o", f"ConnectTimeout={connection.connect_timeout}"]
+
+    # Identity file
+    if "key_filename" in connect_kwargs:
+        key = connect_kwargs["key_filename"]
+        if isinstance(key, (list, tuple)):
+            for k in key:
+                cmd_parts += ["-i", shlex.quote(k)]
+        else:
+            cmd_parts += ["-i", shlex.quote(key)]
+
+    # Private key passphrase
+    if "passphrase" in connect_kwargs:
+        warnings.warn(
+            "passphrase argument from the configuration will be ignored", stacklevel=2
+        )
+
+    # in paramiko this results in not checking for keys in ~/.ssh, but there seems to
+    # be no equivalent in the ssh command. At this stage this is used in the tests.
+    # With this option, if the key is explicitly set but look_for_keys=False, the connection
+    # will work for paramiko, but not with this ssh command. Assume that if a key is passed
+    # it should not be necessary to also set look_for_keys=False. This may instead be useful
+    # to force the use of the password when many keys are available in ~/.ssh or in the agent.
+    if "look_for_keys" in connect_kwargs:
+        look = "yes" if connect_kwargs["look_for_keys"] else "no"
+        cmd_parts += ["-o", f"PubkeyAuthentication={look}"]
+
+    # Allow agent
+    if "allow_agent" in connect_kwargs:
+        agent = "yes" if connect_kwargs["allow_agent"] else "no"
+        cmd_parts += ["-o", f"IdentityAgent={agent}"]
+
+    if connect_kwargs.get("compress", False):
+        cmd_parts.append("-C")
+
+    # KeepAlive settings if present
+    if "keepalive" in connect_kwargs:
+        interval = connect_kwargs["keepalive"]
+        cmd_parts += ["-o", f"ServerAliveInterval={interval}"]
+
+    # User@host
+    user_prefix = f"{connection.user}@" if connection.user else ""
+    destination = f"{user_prefix}{connection.host}"
+
+    return " ".join([*cmd_parts, destination])

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -430,26 +430,21 @@ class RemoteHost(BaseHost):
     def interactive_login(self) -> bool:
         return self._interactive_login
 
-    def to_dir_cmd(self, dir_path: str | Path, target_shell: str = "bash") -> str:
+    def shell(self, pre_cmd: str | None = None, shell: str = "bash"):
         """
-        Command that can be used in a unix shell to reach a directory in the host.
-        Generates an ssh command from the Connection object. If password is defined
-        in the connection will use sshpass.
+        Open a connection to the host and starts the selected shell
 
         Parameters
         ----------
-        dir_path
-            The directory to reach
-        target_shell
-            Shell command to be used to start the shell on the worker to access the
-            target directory
-
-        Returns
-        -------
-            The string to be used to reach the chose directory.
+        pre_cmd
+            Any command to be executed before starting the shell
+        shell
+            The name of the shell to start
         """
-        ssh_cmd = build_ssh_command(self.connection)
-        return f'{ssh_cmd} "cd {dir_path}; {target_shell}"'
+        cmd = shell
+        if pre_cmd:
+            cmd = f"{pre_cmd}; {shell}"
+        self.connection.run(cmd, pty=True)
 
 
 def inter_handler(title, instructions, prompt_list):
@@ -513,107 +508,3 @@ class InteractiveAuthStrategy(OpenSSHAuthStrategy):
         #     )
 
         yield Interactive(username=self.username)
-
-
-def build_ssh_command(connection: fabric.Connection) -> str:
-    """
-    Given a fabric Connection generate the ssh command replicating
-    that same connection.
-
-    Only a subset of the cases are implemented and several involved
-    connections will probably not be handled properly.
-
-    Parameters
-    ----------
-    connection
-        The fabric connection used to generate the command
-    Returns
-    -------
-        A string representing the ssh connection
-    """
-    cmd_parts = []
-
-    connect_kwargs = connection.connect_kwargs or {}
-    password = connect_kwargs.get("password")
-    if password:
-        cmd_parts += ["sshpass", "-p", shlex.quote(password)]
-
-    cmd_parts.append("ssh")
-    cmd_parts.append("-t")
-
-    # Forward agent
-    if connection.forward_agent:
-        cmd_parts.append("-A")
-
-    # handle gateway. Only one nested gateway Connection allowed
-    gateway = connection.gateway
-    if gateway:
-        if isinstance(gateway, str):
-            # If the string contains an "ssh" command it should be used as a ProxyCommand
-            # otherwise consider it like a ProxyJump
-            if "ssh " in gateway:
-                cmd_parts += ["-o", f"ProxyCommand={shlex.quote(gateway)}"]
-            else:
-                cmd_parts += ["-J", gateway]
-
-        elif isinstance(gateway, fabric.Connection):
-            # if gateway is another connection create a ProxyCommand using this same
-            # function, but don't do it recursively if there is more than one nested gateway
-            if getattr(gateway, "gateway", None):
-                raise NotImplementedError(
-                    "Nested gateways beyond one level are not supported."
-                )
-            proxy_cmd = build_ssh_command(gateway)
-            cmd_parts += ["-o", f"ProxyCommand={shlex.quote(proxy_cmd + ' -W %h:%p')}"]
-
-    # Port
-    if connection.port:
-        cmd_parts += ["-p", str(connection.port)]
-
-    # Timeout
-    if connection.connect_timeout:
-        cmd_parts += ["-o", f"ConnectTimeout={connection.connect_timeout}"]
-
-    # Identity file
-    if "key_filename" in connect_kwargs:
-        key = connect_kwargs["key_filename"]
-        if isinstance(key, (list, tuple)):
-            for k in key:
-                cmd_parts += ["-i", shlex.quote(k)]
-        else:
-            cmd_parts += ["-i", shlex.quote(key)]
-
-    # Private key passphrase
-    if "passphrase" in connect_kwargs:
-        warnings.warn(
-            "passphrase argument from the configuration will be ignored", stacklevel=2
-        )
-
-    # in paramiko this results in not checking for keys in ~/.ssh, but there seems to
-    # be no equivalent in the ssh command. At this stage this is used in the tests.
-    # With this option, if the key is explicitly set but look_for_keys=False, the connection
-    # will work for paramiko, but not with this ssh command. Assume that if a key is passed
-    # it should not be necessary to also set look_for_keys=False. This may instead be useful
-    # to force the use of the password when many keys are available in ~/.ssh or in the agent.
-    if "look_for_keys" in connect_kwargs:
-        look = "yes" if connect_kwargs["look_for_keys"] else "no"
-        cmd_parts += ["-o", f"PubkeyAuthentication={look}"]
-
-    # Allow agent
-    if "allow_agent" in connect_kwargs:
-        agent = "yes" if connect_kwargs["allow_agent"] else "no"
-        cmd_parts += ["-o", f"IdentityAgent={agent}"]
-
-    if connect_kwargs.get("compress", False):
-        cmd_parts.append("-C")
-
-    # KeepAlive settings if present
-    if "keepalive" in connect_kwargs:
-        interval = connect_kwargs["keepalive"]
-        cmd_parts += ["-o", f"ServerAliveInterval={interval}"]
-
-    # User@host
-    user_prefix = f"{connection.user}@" if connection.user else ""
-    destination = f"{user_prefix}{connection.host}"
-
-    return " ".join([*cmd_parts, destination])

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -50,6 +50,49 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         ["job", "list", "-o", "state,name", "-vv"], required_out=output, error=True
     )
 
+    # test state filtering
+    outputs = ["READY"]
+    excluded = ["WAITING", "REMOTE_ERROR"]
+    run_check_cli(
+        ["job", "list", "-s", "READY"],
+        required_out=outputs,
+        excluded_out=excluded,
+    )
+
+    outputs = ["READY", "REMOTE_ERROR"]
+    excluded = ["WAITING"]
+    run_check_cli(
+        ["job", "list", "-s", "READY", "--error"],
+        required_out=outputs,
+        excluded_out=excluded,
+    )
+
+    outputs = ["REMOTE_ERROR"]
+    excluded = ["READY", "WAITING"]
+    run_check_cli(
+        ["job", "list", "--error"],
+        required_out=outputs,
+        excluded_out=excluded,
+    )
+
+    assert job_controller.set_job_state(JobState.DOWNLOADED, db_id="3")
+    outputs = ["REMOTE_ERROR", "DOWNLOADED"]
+    excluded = ["READY", "WAITING"]
+    run_check_cli(
+        ["job", "list", "--error", "--running"],
+        required_out=outputs,
+        excluded_out=excluded,
+    )
+
+    assert job_controller.set_job_state(JobState.DOWNLOADED, db_id="3")
+    outputs = ["DOWNLOADED"]
+    excluded = ["READY", "WAITING", "REMOTE_ERROR"]
+    run_check_cli(
+        ["job", "list", "--running"],
+        required_out=outputs,
+        excluded_out=excluded,
+    )
+
 
 def test_jobs_list_settings(job_controller, two_flows_four_jobs, monkeypatch) -> None:
     from jobflow_remote import SETTINGS
@@ -517,4 +560,32 @@ def test_report(job_controller) -> None:
     run_check_cli(
         ["job", "report", "days", "2"],
         required_out=output + excluded + ["Running Jobs │   1"],
+    )
+
+
+def test_todir(job_controller, one_job):
+    from jobflow_remote.jobs.runner import Runner
+    from jobflow_remote.testing.cli import run_check_cli
+
+    run_check_cli(
+        ["job", "todir", "1"],
+        required_out="The selected Job does not have a run_dir defined yet",
+        error=True,
+    )
+
+    runner = Runner()
+    runner.run_one_job()
+
+    # outputs from the connected shell are not either not executed properly
+    # or not captured from run_check_cli.
+    # Matching the run_dir seems to have problems due to the newlines present in the
+    # captured output that can split the path over multiple lines
+    run_check_cli(
+        ["job", "todir", "1"],
+        cli_input="exit",
+        required_out=["Connecting to worker test_local_worker"],
+    )
+
+    run_check_cli(
+        ["job", "todir", "1", "--command"], required_out=["Connection command:", "cd "]
     )

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -576,7 +576,7 @@ def test_todir(job_controller, one_job):
     runner = Runner()
     runner.run_one_job()
 
-    # outputs from the connected shell are not either not executed properly
+    # outputs from the connected shell are either not executed properly
     # or not captured from run_check_cli.
     # Matching the run_dir seems to have problems due to the newlines present in the
     # captured output that can split the path over multiple lines
@@ -584,8 +584,4 @@ def test_todir(job_controller, one_job):
         ["job", "todir", "1"],
         cli_input="exit",
         required_out=["Connecting to worker test_local_worker"],
-    )
-
-    run_check_cli(
-        ["job", "todir", "1", "--command"], required_out=["Connection command:", "cd "]
     )

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -59,7 +59,11 @@ def test_generate(job_controller, random_project_name, monkeypatch, tmp_dir) -> 
         )
 
 
-def test_check(job_controller) -> None:
+def test_check(job_controller, monkeypatch, tmp_dir) -> None:
+    import os
+
+    from jobflow_remote import SETTINGS
+    from jobflow_remote.config.manager import ConfigManager
     from jobflow_remote.testing.cli import run_check_cli
 
     output = [
@@ -69,6 +73,18 @@ def test_check(job_controller) -> None:
         "✓ Queue store",
     ]
     run_check_cli(["project", "check"], required_out=output)
+
+    # create a copy of the project and it so that the jobstore and queue
+    # store have the same db and collection
+    project = ConfigManager().get_project()
+    with monkeypatch.context() as m:
+        m.setattr(SETTINGS, "projects_folder", os.getcwd())
+        project.jobstore["docs_store"]["collection_name"] = "same_collection"
+        project.queue.store["collection_name"] = "same_collection"
+        ConfigManager().create_project(project)
+
+        duplicated_msg = "It seems that the main docs_store of the JobStore and the queue store point to the same database and collection"
+        run_check_cli(["project", "check"], required_out=[*output, duplicated_msg])
 
 
 def test_check_fail(job_controller, monkeypatch, tmp_dir) -> None:

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -54,6 +54,10 @@ def test_std_operations(
     )
 
     run_check_cli(
+        ["runner", "restart"],
+    )
+
+    run_check_cli(
         ["runner", "stop"],
         required_out="The stop signal has been sent to the Runner",
     )

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -53,9 +53,13 @@ def test_std_operations(
         required_out=[*info_required, "hostname", "last_pinged", "processes_info"],
     )
 
+    rr_before = job_controller.get_running_runner()
     run_check_cli(
         ["runner", "restart"],
     )
+    wait_daemon_started(daemon_manager)
+    rr_after = job_controller.get_running_runner()
+    assert rr_after["start_time"] > rr_before["start_time"]
 
     run_check_cli(
         ["runner", "stop"],

--- a/tests/db/jobs/test_daemon.py
+++ b/tests/db/jobs/test_daemon.py
@@ -333,3 +333,14 @@ def test_missing_running_runner_doc(
     # still cannot start
     with pytest.raises(ValueError, match=error):
         daemon_manager.start(raise_on_error=True, single=False)
+
+
+def test_restart(job_controller, daemon_manager, wait_daemon_started):
+    from jobflow_remote.jobs.daemon import DaemonStatus
+
+    assert not daemon_manager.restart(raise_on_error=False)
+    assert daemon_manager.start()
+    wait_daemon_started(daemon_manager)
+    assert daemon_manager.restart(raise_on_error=True)
+
+    assert daemon_manager.check_status() == DaemonStatus.RUNNING

--- a/tests/db/remote/host/test_remote.py
+++ b/tests/db/remote/host/test_remote.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 @patch("fabric.Connection.run")
 @patch("fabric.Connection.cd")
@@ -38,3 +40,65 @@ def test_sanitize(mock_cd, mock_run):
     # Assert on the result of your function
     assert stdout == "test"
     assert stderr == ""
+
+
+def test_build_ssh_command():
+    from fabric import Connection
+
+    from jobflow_remote.remote.host.remote import build_ssh_command
+
+    c = Connection("a", gateway=Connection("b", gateway=Connection("c")))
+    with pytest.raises(NotImplementedError):
+        build_ssh_command(c)
+
+    c = Connection(host="host", user="name")
+    assert build_ssh_command(c) == "ssh -t -p 22 name@host"
+
+    c = Connection(host="host", user="name", connect_kwargs={"password": "test"})
+    assert build_ssh_command(c) == "sshpass -p test ssh -t -p 22 name@host"
+
+    c = Connection(host="host", user="name", forward_agent=True, connect_timeout=30)
+    assert build_ssh_command(c) == "ssh -t -A -p 22 -o ConnectTimeout=30 name@host"
+
+    c = Connection(host="host", user="name", gateway=Connection("host2", user="name2"))
+    assert (
+        build_ssh_command(c)
+        == "ssh -t -o ProxyCommand='ssh -t -p 22 name2@host2 -W %h:%p' -p 22 name@host"
+    )
+
+    c = Connection(host="host", user="name", gateway="ssh name2@host2")
+    assert (
+        build_ssh_command(c)
+        == "ssh -t -o ProxyCommand='ssh name2@host2' -p 22 name@host"
+    )
+
+    c = Connection(host="host", user="name", gateway="host2")
+    assert build_ssh_command(c) == "ssh -t -J host2 -p 22 name@host"
+
+    c = Connection(
+        host="host", user="name", connect_kwargs={"key_filename": "/path/to/key"}
+    )
+    assert build_ssh_command(c) == "ssh -t -p 22 -i /path/to/key name@host"
+
+    c = Connection(
+        host="host",
+        user="name",
+        connect_kwargs={"look_for_keys": False, "allow_agent": True},
+    )
+    assert (
+        build_ssh_command(c)
+        == "ssh -t -p 22 -o PubkeyAuthentication=no -o IdentityAgent=yes name@host"
+    )
+
+    c = Connection(
+        host="host", user="name", connect_kwargs={"compress": True, "keepalive": True}
+    )
+    assert (
+        build_ssh_command(c) == "ssh -t -p 22 -C -o ServerAliveInterval=True name@host"
+    )
+
+    c = Connection(host="host", user="name", connect_kwargs={"passphrase": "pass"})
+    with pytest.warns(
+        match="passphrase argument from the configuration will be ignored"
+    ):
+        assert build_ssh_command(c) == "ssh -t -p 22 name@host"

--- a/tests/db/remote/host/test_remote.py
+++ b/tests/db/remote/host/test_remote.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 @patch("fabric.Connection.run")
 @patch("fabric.Connection.cd")
@@ -40,65 +38,3 @@ def test_sanitize(mock_cd, mock_run):
     # Assert on the result of your function
     assert stdout == "test"
     assert stderr == ""
-
-
-def test_build_ssh_command():
-    from fabric import Connection
-
-    from jobflow_remote.remote.host.remote import build_ssh_command
-
-    c = Connection("a", gateway=Connection("b", gateway=Connection("c")))
-    with pytest.raises(NotImplementedError):
-        build_ssh_command(c)
-
-    c = Connection(host="host", user="name")
-    assert build_ssh_command(c) == "ssh -t -p 22 name@host"
-
-    c = Connection(host="host", user="name", connect_kwargs={"password": "test"})
-    assert build_ssh_command(c) == "sshpass -p test ssh -t -p 22 name@host"
-
-    c = Connection(host="host", user="name", forward_agent=True, connect_timeout=30)
-    assert build_ssh_command(c) == "ssh -t -A -p 22 -o ConnectTimeout=30 name@host"
-
-    c = Connection(host="host", user="name", gateway=Connection("host2", user="name2"))
-    assert (
-        build_ssh_command(c)
-        == "ssh -t -o ProxyCommand='ssh -t -p 22 name2@host2 -W %h:%p' -p 22 name@host"
-    )
-
-    c = Connection(host="host", user="name", gateway="ssh name2@host2")
-    assert (
-        build_ssh_command(c)
-        == "ssh -t -o ProxyCommand='ssh name2@host2' -p 22 name@host"
-    )
-
-    c = Connection(host="host", user="name", gateway="host2")
-    assert build_ssh_command(c) == "ssh -t -J host2 -p 22 name@host"
-
-    c = Connection(
-        host="host", user="name", connect_kwargs={"key_filename": "/path/to/key"}
-    )
-    assert build_ssh_command(c) == "ssh -t -p 22 -i /path/to/key name@host"
-
-    c = Connection(
-        host="host",
-        user="name",
-        connect_kwargs={"look_for_keys": False, "allow_agent": True},
-    )
-    assert (
-        build_ssh_command(c)
-        == "ssh -t -p 22 -o PubkeyAuthentication=no -o IdentityAgent=yes name@host"
-    )
-
-    c = Connection(
-        host="host", user="name", connect_kwargs={"compress": True, "keepalive": True}
-    )
-    assert (
-        build_ssh_command(c) == "ssh -t -p 22 -C -o ServerAliveInterval=True name@host"
-    )
-
-    c = Connection(host="host", user="name", connect_kwargs={"passphrase": "pass"})
-    with pytest.warns(
-        match="passphrase argument from the configuration will be ignored"
-    ):
-        assert build_ssh_command(c) == "ssh -t -p 22 name@host"

--- a/tests/integration/test_workers.py
+++ b/tests/integration/test_workers.py
@@ -464,6 +464,9 @@ def test_sanitize(worker, job_controller):
     ["test_local_worker", "test_remote_slurm_worker"],
 )
 def test_todir(job_controller, worker):
+    import subprocess
+    import time
+
     from jobflow_remote import submit_flow
     from jobflow_remote.jobs.runner import Runner
     from jobflow_remote.testing import add
@@ -481,16 +484,28 @@ def test_todir(job_controller, worker):
     runner = Runner()
     runner.run_all_jobs(max_seconds=MAX_TRY_SECONDS)
 
-    # outputs from the connected shell are not either not executed properly
-    # or not captured from run_check_cli.
-    # Matching the run_dir seems to have problems due to the newlines present in the
-    # captured output that can split the path over multiple lines
-    run_check_cli(
-        ["job", "todir", "1"],
-        cli_input="exit",
-        required_out=[f"Connecting to worker {worker}"],
+    # Run the CLI command as a subprocess to avoid getting stuck in the remote shell
+    # without the option to pass the "exit" command. It seems that the "input" option
+    # for the CliRunner does not work in this case.
+    process = subprocess.Popen(
+        ["jf", "job", "todir", "1"],  # noqa: S603, S607
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
 
-    run_check_cli(
-        ["job", "todir", "1", "--command"], required_out=["Connection command:", "cd "]
-    )
+    try:
+        # short wait to be sure that the shell is loaded
+        time.sleep(0.5)
+
+        stdout, stderr = process.communicate(input="ls; exit\n", timeout=5)
+
+        # should be there for the "ls" command
+        assert "jfremote_out.json" in stdout
+
+        assert process.returncode is not None
+
+    except subprocess.TimeoutExpired:
+        process.kill()
+        pytest.fail("CLI todir test timed out")

--- a/tests/integration/test_workers.py
+++ b/tests/integration/test_workers.py
@@ -457,3 +457,40 @@ def test_sanitize(worker, job_controller):
     runner.run_one_job()
 
     assert job_controller.count_jobs(states=JobState.COMPLETED) == 1
+
+
+@pytest.mark.parametrize(
+    "worker",
+    ["test_local_worker", "test_remote_slurm_worker"],
+)
+def test_todir(job_controller, worker):
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.runner import Runner
+    from jobflow_remote.testing import add
+    from jobflow_remote.testing.cli import run_check_cli
+
+    j = add(1, 5)
+    submit_flow(j, worker=worker)
+
+    run_check_cli(
+        ["job", "todir", j.uuid],
+        required_out="The selected Job does not have a run_dir defined yet",
+        error=True,
+    )
+
+    runner = Runner()
+    runner.run_all_jobs(max_seconds=MAX_TRY_SECONDS)
+
+    # outputs from the connected shell are not either not executed properly
+    # or not captured from run_check_cli.
+    # Matching the run_dir seems to have problems due to the newlines present in the
+    # captured output that can split the path over multiple lines
+    run_check_cli(
+        ["job", "todir", "1"],
+        cli_input="exit",
+        required_out=[f"Connecting to worker {worker}"],
+    )
+
+    run_check_cli(
+        ["job", "todir", "1", "--command"], required_out=["Connection command:", "cd "]
+    )


### PR DESCRIPTION
Some small fixes and new functionalities:

* Avoid truncation of text in `jf job info` #266
  After some tests it seems that while it is possible to pass `overflow="fold"` to the `print` method of `Console` in rich, the value gets reset to `ellipsis` somewhere during the visualization. Unfortunately I don't have the time to dig more into rich, so for the moment I created our custom version of `render_scope` that prevents the issue.
* Better error message if the Job cannot be deserialized by the worker: #263
* Test implementation of a `jf job todir` option in the CLI, that opens a shell directly on the worker and moves to the job directory. Since this runs directly an ssh command I have implemented a converter from `Connection` to the string to be executed, but this of course cannot cover all possible use cases. At least it works for the workers that I have defined in my project.
* "rerun" for certain states switched the state to `CHECKED_OUT` supposedly to save some time to the runner, but this could cause problems since some actions cannot be performed if the job is not `READY`. Now it brings back the Job to `READY`. 
* `jf runner restart`, equivalent to stop+start. To smooth the restart when updating the project configuration. Partially addressing #155
* If possible create indexes in the JobStore collection as resolving references may be slow for large databases otherwise. See https://github.com/materialsproject/jobflow/issues/627