### PR TITLE
fix ignoring resolve_references in JobConfig

### DIFF
--- a/src/jobflow_remote/remote/data.py
+++ b/src/jobflow_remote/remote/data.py
@@ -239,6 +239,8 @@ def resolve_job_dict_args(job_dict: dict, store: JobStore) -> dict:
     Similar to Job.resolve_args, but without the need to deserialize the Job.
     The references are resolved inplace.
 
+    If resolve_references in job.config is False references are not resolved.
+
     Parameters
     ----------
     job_dict
@@ -251,6 +253,9 @@ def resolve_job_dict_args(job_dict: dict, store: JobStore) -> dict:
         The updated version of the input dictionary with references resolved.
     """
     from jobflow.core.reference import OnMissing, find_and_resolve_references
+
+    if not job_dict["config"]["resolve_references"]:
+        return job_dict
 
     on_missing = OnMissing(job_dict["config"]["on_missing_references"])
     cache: dict[str, Any] = {}

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -2,7 +2,7 @@
 
 from typing import Callable, NoReturn, Optional, Union
 
-from jobflow import Job, Response, job
+from jobflow import Job, JobConfig, OnMissing, Response, job
 
 
 @job
@@ -103,3 +103,11 @@ def current_jobdoc():
     from jobflow_remote.jobs.run import CURRENT_JOBDOC
 
     return CURRENT_JOBDOC.job_doc
+
+
+@job(config=JobConfig(resolve_references=False, on_missing_references=OnMissing.NONE))
+def no_resolve(ref):
+    """
+    A job that does not resolve the reference in input
+    """
+    return ref

--- a/tests/db/jobs/test_runner.py
+++ b/tests/db/jobs/test_runner.py
@@ -115,3 +115,29 @@ def test_ping_runner_runner(job_controller, runner, monkeypatch, caplog):
         abs((job_controller.get_running_runner()["last_pinged"] - t0).total_seconds())
         > 2
     )
+
+
+def test_resolve_references(job_controller, runner):
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.testing import add, no_resolve
+
+    j1 = add(1, 2)
+    j2 = no_resolve(j1.output)
+    flow = Flow([j1, j2])
+
+    submit_flow(flow, worker="test_local_worker")
+
+    runner.run_all_jobs(max_seconds=20)
+
+    # verify that the output is the output reference and not directly the output
+    # of the previous job. Since j2 has resolve_references=False in the JobConfig
+    # the reference should not be resolved.
+    job_controller.jobstore.connect()
+    out_docs = list(job_controller.jobstore.docs_store.query({"uuid": j2.uuid}))
+    assert len(out_docs) == 1
+    out_doc = out_docs[0]
+    assert isinstance(out_doc["output"], dict)
+    assert out_doc["output"]["@class"] == "OutputReference"
+    assert out_doc["output"]["uuid"] == j1.uuid


### PR DESCRIPTION
jobflow-remote, at variance with other jobflow mangers, does not take into account the `resolve_references` option in `JobConfig`. Currently references are always resolved by the runner without checking the job configuration.
This PR fixes the issue.
Thanks @VicTrqt and @emarazzi for pointing this out.