### PR TITLE
Add --count option in CLI

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -17,6 +17,7 @@ from jobflow_remote.cli.formatting import (
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
+    count_opt,
     days_opt,
     db_ids_opt,
     delete_all_opt,
@@ -74,6 +75,7 @@ def flows_list(
     metadata: metadata_opt = None,
     locked: locked_flow_opt = False,
     verbosity: verbosity_opt = 0,
+    count: count_opt = False,
     max_results: max_results_opt = 100,
     sort: sort_opt = SortOption.UPDATED_ON,
     reverse_sort: reverse_sort_flag_opt = False,
@@ -88,31 +90,46 @@ def flows_list(
 
     db_sort: list[tuple[str, int]] = [(sort.value, 1 if reverse_sort else -1)]
 
-    with loading_spinner():
-        flows_info = jc.get_flows_info(
-            job_ids=job_id,
-            db_ids=db_id,
-            flow_ids=flow_id,
-            states=state,
-            start_date=start_date,
-            end_date=end_date,
-            name=name,
-            metadata=metadata,
-            locked=locked,
-            limit=max_results,
-            sort=db_sort,
-            full=verbosity > 0,
-        )
+    if count:
+        with loading_spinner():
+            n_flows = jc.count_flows(
+                job_ids=job_id,
+                db_ids=db_id,
+                flow_ids=flow_id,
+                states=state,
+                start_date=start_date,
+                end_date=end_date,
+                name=name,
+                metadata=metadata,
+                locked=locked,
+            )
+        out_console.print(f"Selected Flows: {n_flows}")
+    else:
+        with loading_spinner():
+            flows_info = jc.get_flows_info(
+                job_ids=job_id,
+                db_ids=db_id,
+                flow_ids=flow_id,
+                states=state,
+                start_date=start_date,
+                end_date=end_date,
+                name=name,
+                metadata=metadata,
+                locked=locked,
+                limit=max_results,
+                sort=db_sort,
+                full=verbosity > 0,
+            )
 
-        table = get_flow_info_table(flows_info, verbosity=verbosity)
+            table = get_flow_info_table(flows_info, verbosity=verbosity)
 
-    if SETTINGS.cli_suggestions and max_results and len(flows_info) == max_results:
-        out_console.print(
-            f"The number of Flows printed is limited by the maximum selected: {max_results}",
-            style="yellow",
-        )
+        if SETTINGS.cli_suggestions and max_results and len(flows_info) == max_results:
+            out_console.print(
+                f"The number of Flows printed is limited by the maximum selected: {max_results}",
+                style="yellow",
+            )
 
-    out_console.print(table)
+        out_console.print(table)
 
 
 @app_flow.command()

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -103,7 +103,7 @@ def flows_list(
                 metadata=metadata,
                 locked=locked,
             )
-        out_console.print(f"Selected Flows: {n_flows}")
+        out_console.print(f"Number of Flows: {n_flows}")
     else:
         with loading_spinner():
             flows_info = jc.get_flows_info(

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -209,7 +209,7 @@ def jobs_list(
                 metadata=metadata,
                 workers=worker_name,
             )
-        out_console.print(f"Selected jobs: {n_jobs}")
+        out_console.print(f"Number of jobs: {n_jobs}")
     else:
         with loading_spinner():
             if custom_query:

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -22,6 +22,7 @@ from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
     OptionalStr,
     break_lock_opt,
+    count_opt,
     days_opt,
     db_ids_opt,
     delete_all_opt,
@@ -115,6 +116,7 @@ def jobs_list(
             "Compatible with other state filtering options",
         ),
     ] = False,
+    count: count_opt = False,
     stored_data_keys: Annotated[
         Optional[list[str]],
         typer.Option(
@@ -192,15 +194,10 @@ def jobs_list(
         else:
             state = RUNNING_STATES
 
-    with loading_spinner():
-        if custom_query:
-            jobs_info = jc.get_jobs_info_query(
+    if count:
+        with loading_spinner():
+            n_jobs = jc.count_jobs(
                 query=custom_query,
-                limit=max_results,
-                sort=db_sort,
-            )
-        else:
-            jobs_info = jc.get_jobs_info(
                 job_ids=job_ids_indexes,
                 db_ids=db_id,
                 flow_ids=flow_id,
@@ -211,40 +208,63 @@ def jobs_list(
                 name=name,
                 metadata=metadata,
                 workers=worker_name,
-                limit=max_results,
-                sort=db_sort,
+            )
+        out_console.print(f"Selected jobs: {n_jobs}")
+    else:
+        with loading_spinner():
+            if custom_query:
+                jobs_info = jc.get_jobs_info_query(
+                    query=custom_query,
+                    limit=max_results,
+                    sort=db_sort,
+                )
+            else:
+                jobs_info = jc.get_jobs_info(
+                    job_ids=job_ids_indexes,
+                    db_ids=db_id,
+                    flow_ids=flow_id,
+                    states=state,
+                    start_date=start_date,
+                    locked=locked,
+                    end_date=end_date,
+                    name=name,
+                    metadata=metadata,
+                    workers=worker_name,
+                    limit=max_results,
+                    sort=db_sort,
+                )
+
+            table = get_job_info_table(
+                jobs_info,
+                verbosity=verbosity,
+                output_keys=output_keys,
+                stored_data_keys=stored_data_keys,
             )
 
-        table = get_job_info_table(
-            jobs_info,
-            verbosity=verbosity,
-            output_keys=output_keys,
-            stored_data_keys=stored_data_keys,
-        )
-
-    out_console.print(table)
-    if SETTINGS.cli_suggestions:
-        if max_results and len(jobs_info) == max_results:
-            out_console.print(
-                f"The number of Jobs printed may be limited by the maximum selected: {max_results}",
-                style="yellow",
-            )
-        remote_errors = False
-        if any(
-            ji.remote.retry_time_limit is not None and ji.state != JobState.REMOTE_ERROR
-            for ji in jobs_info
-        ):
-            text = (
-                "Some jobs (state in orange) have failed while interacting with"
-                " the worker, but will be retried."
-            )
-            out_console.print(text, style="yellow")
-            remote_errors = True
-        if remote_errors or any(
-            ji.state in (JobState.REMOTE_ERROR, JobState.FAILED) for ji in jobs_info
-        ):
-            text = "Get more information about the errors with 'jf job info JOB_ID'"
-            out_console.print(text, style="yellow")
+        out_console.print(table)
+        if SETTINGS.cli_suggestions:
+            if max_results and len(jobs_info) == max_results:
+                out_console.print(
+                    f"The number of Jobs printed may be limited by the maximum selected: {max_results}",
+                    style="yellow",
+                )
+            remote_errors = False
+            if any(
+                ji.remote.retry_time_limit is not None
+                and ji.state != JobState.REMOTE_ERROR
+                for ji in jobs_info
+            ):
+                text = (
+                    "Some jobs (state in orange) have failed while interacting with"
+                    " the worker, but will be retried."
+                )
+                out_console.print(text, style="yellow")
+                remote_errors = True
+            if remote_errors or any(
+                ji.state in (JobState.REMOTE_ERROR, JobState.FAILED) for ji in jobs_info
+            ):
+                text = "Get more information about the errors with 'jf job info JOB_ID'"
+                out_console.print(text, style="yellow")
 
 
 @app_job.command(name="info")

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -383,6 +383,14 @@ index_direction_arg = Annotated[
     ),
 ]
 
+count_opt = Annotated[
+    bool,
+    typer.Option(
+        "--count",
+        help="Just return the count of the selected elements",
+    ),
+]
+
 
 # as of typer version 0.9.0 the dict is not a supported type. Define a custom one
 class DictType(dict):

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -198,16 +198,16 @@ class JobController:
 
     def _build_query_job(
         self,
-        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
-        db_ids: str | list[str] | None = None,
-        flow_ids: str | list[str] | None = None,
-        states: JobState | list[JobState] | None = None,
-        locked: bool = False,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        name: str | None = None,
-        metadata: dict | None = None,
-        workers: str | list[str] | None = None,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None,
+        db_ids: str | list[str] | None,
+        flow_ids: str | list[str] | None,
+        states: JobState | list[JobState] | None,
+        locked: bool,
+        start_date: datetime | None,
+        end_date: datetime | None,
+        name: str | None,
+        metadata: dict | None,
+        workers: str | list[str] | None,
     ) -> dict:
         """
         Build a query to search for Jobs, based on standard parameters.
@@ -303,15 +303,15 @@ class JobController:
 
     def _build_query_flow(
         self,
-        job_ids: str | list[str] | None = None,
-        db_ids: str | list[str] | None = None,
-        flow_ids: str | list[str] | None = None,
-        states: FlowState | list[FlowState] | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        name: str | None = None,
-        metadata: dict | None = None,
-        locked: bool = False,
+        job_ids: str | list[str] | None,
+        db_ids: str | list[str] | None,
+        flow_ids: str | list[str] | None,
+        states: FlowState | list[FlowState] | None,
+        start_date: datetime | None,
+        end_date: datetime | None,
+        name: str | None,
+        metadata: dict | None,
+        locked: bool,
     ) -> dict:
         """
         Build a query to search for Flows, based on standard parameters.
@@ -757,6 +757,7 @@ class JobController:
                 name=name,
                 metadata=metadata,
                 workers=workers,
+                locked=False,
             )
         result = self.jobs.find(query, projection=["db_id"])
 
@@ -2579,6 +2580,7 @@ class JobController:
             end_date=end_date,
             locked=True,
             name=name,
+            metadata=None,
         )
 
         result = self.flows.update_many(
@@ -2981,7 +2983,7 @@ class JobController:
             A dictionary of the values of the metadata to match. Should be an
             exact match for all the values provided.
         locked
-            If True only locked Flows will be selected.
+            If True only locked Flows will be counted.
 
         Returns
         -------

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2950,6 +2950,8 @@ class JobController:
         start_date: datetime | None = None,
         end_date: datetime | None = None,
         name: str | None = None,
+        metadata: dict | None = None,
+        locked: bool = False,
     ) -> int:
         """
         Count flows based on filter parameters.
@@ -2975,6 +2977,11 @@ class JobController:
         name
             Pattern matching the name of Flow. Default is an exact match, but all
             conventions from python fnmatch can be used (e.g. *test*)
+        metadata
+            A dictionary of the values of the metadata to match. Should be an
+            exact match for all the values provided.
+        locked
+            If True only locked Flows will be selected.
 
         Returns
         -------
@@ -2990,6 +2997,8 @@ class JobController:
                 start_date=start_date,
                 end_date=end_date,
                 name=name,
+                metadata=metadata,
+                locked=locked,
             )
         return self.flows.count_documents(query)
 

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -14,6 +14,7 @@ def test_flows_list(job_controller, two_flows_four_jobs) -> None:
     outputs = columns + [f"f{i}" for i in range(1, 3)] + ["READY"]
 
     run_check_cli(["flow", "list"], required_out=outputs)
+    run_check_cli(["flow", "list", "--count"], required_out="Selected Flows: 2")
 
     # the output table is squeezed. Hard to check stdout. Just check that runs correctly
     run_check_cli(["flow", "list", "-v"])
@@ -25,6 +26,10 @@ def test_flows_list(job_controller, two_flows_four_jobs) -> None:
     outputs = ["READY"]
     run_check_cli(
         ["flow", "list", "-fid", two_flows_four_jobs[0].uuid], required_out=outputs
+    )
+    run_check_cli(
+        ["flow", "list", "-fid", two_flows_four_jobs[0].uuid, "--count"],
+        required_out="Selected Flows: 1",
     )
 
     # test metadata query
@@ -39,6 +44,10 @@ def test_flows_list(job_controller, two_flows_four_jobs) -> None:
         ["flow", "list", "--metadata", "test=x"],
         required_out=outputs,
         excluded_out=excluded,
+    )
+    run_check_cli(
+        ["flow", "list", "--metadata", "test=x", "--count"],
+        required_out="Selected Flows: 1",
     )
 
 

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -14,7 +14,7 @@ def test_flows_list(job_controller, two_flows_four_jobs) -> None:
     outputs = columns + [f"f{i}" for i in range(1, 3)] + ["READY"]
 
     run_check_cli(["flow", "list"], required_out=outputs)
-    run_check_cli(["flow", "list", "--count"], required_out="Selected Flows: 2")
+    run_check_cli(["flow", "list", "--count"], required_out="Number of Flows: 2")
 
     # the output table is squeezed. Hard to check stdout. Just check that runs correctly
     run_check_cli(["flow", "list", "-v"])
@@ -29,7 +29,7 @@ def test_flows_list(job_controller, two_flows_four_jobs) -> None:
     )
     run_check_cli(
         ["flow", "list", "-fid", two_flows_four_jobs[0].uuid, "--count"],
-        required_out="Selected Flows: 1",
+        required_out="Number of Flows: 1",
     )
 
     # test metadata query
@@ -47,7 +47,7 @@ def test_flows_list(job_controller, two_flows_four_jobs) -> None:
     )
     run_check_cli(
         ["flow", "list", "--metadata", "test=x", "--count"],
-        required_out="Selected Flows: 1",
+        required_out="Number of Flows: 1",
     )
 
 

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -10,6 +10,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
     outputs = columns + [f"add{i}" for i in range(1, 5)] + ["READY", "WAITING"]
 
     run_check_cli(["job", "list"], required_out=outputs)
+    run_check_cli(["job", "list", "--count"], required_out="Selected jobs: 4")
 
     # the output table is squeezed. Hard to check stdout. Just check that runs correctly
     run_check_cli(["job", "list", "-v"])
@@ -24,6 +25,10 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         ["job", "list", "-q", '{"db_id": "1"}'],
         required_out=outputs,
         excluded_out=excluded,
+    )
+    run_check_cli(
+        ["job", "list", "-q", '{"db_id": "1"}', "--count"],
+        required_out="Selected jobs: 1",
     )
 
     # trigger the additional information
@@ -58,6 +63,9 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         required_out=outputs,
         excluded_out=excluded,
     )
+    run_check_cli(
+        ["job", "list", "-s", "READY", "--count"], required_out="Selected jobs: 1"
+    )
 
     outputs = ["READY", "REMOTE_ERROR"]
     excluded = ["WAITING"]
@@ -91,6 +99,9 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         ["job", "list", "--running"],
         required_out=outputs,
         excluded_out=excluded,
+    )
+    run_check_cli(
+        ["job", "list", "--running", "--count"], required_out="Selected jobs: 1"
     )
 
 

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -10,7 +10,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
     outputs = columns + [f"add{i}" for i in range(1, 5)] + ["READY", "WAITING"]
 
     run_check_cli(["job", "list"], required_out=outputs)
-    run_check_cli(["job", "list", "--count"], required_out="Selected jobs: 4")
+    run_check_cli(["job", "list", "--count"], required_out="Number of jobs: 4")
 
     # the output table is squeezed. Hard to check stdout. Just check that runs correctly
     run_check_cli(["job", "list", "-v"])
@@ -28,7 +28,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
     )
     run_check_cli(
         ["job", "list", "-q", '{"db_id": "1"}', "--count"],
-        required_out="Selected jobs: 1",
+        required_out="Number of jobs: 1",
     )
 
     # trigger the additional information
@@ -64,7 +64,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         excluded_out=excluded,
     )
     run_check_cli(
-        ["job", "list", "-s", "READY", "--count"], required_out="Selected jobs: 1"
+        ["job", "list", "-s", "READY", "--count"], required_out="Number of jobs: 1"
     )
 
     outputs = ["READY", "REMOTE_ERROR"]
@@ -101,7 +101,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         excluded_out=excluded,
     )
     run_check_cli(
-        ["job", "list", "--running", "--count"], required_out="Selected jobs: 1"
+        ["job", "list", "--running", "--count"], required_out="Number of jobs: 1"
     )
 
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -878,6 +878,10 @@ def test_backup(job_controller_drop, python, compress):
         )
 
         files = [str(p.name) for p in (dir_path / db_name).glob("*")]
+        ext = ".gz" if compress else ""
+        if "prelude.json" + ext in files:
+            files = list(files)
+            files.remove("prelude.json" + ext)
 
         ext = ".gz" if compress else ""
         assert "flows.bson" + ext in files


### PR DESCRIPTION
Adding a `--count` option for `jf job list` and `jf flow list`, printing just the number of jobs/flows matching the query.