### PR TITLE
bugfix and test release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     if: github.repository == 'matgenix/jobflow-remote' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
+      issues: read
+      pull-requests: read
 
     steps:
     - name: Checkout repository

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -221,6 +221,9 @@ def format_job_info(
         if queue_err:
             d["remote"]["queue_err"] = ReprStr(queue_err)
 
+    if verbosity < 2 and d.get("parents") and len(d.get("parents", [])) > 5:
+        d["parents"] = d["parents"][:2] + ["..."] + d["parents"][-2:]
+
     # reorder the keys
     # Do not check here that all the keys in JobInfo are in JOB_INFO_ORDER. Check in the tests
     sorted_d = {}

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -272,12 +272,18 @@ class JobDoc(BaseModel):
         dict
             The dict representing the JobDoc.
         """
+        # split the serialization of the job since Enums should stay enums
+        # in the job inputs and they are not pydantic models that reconstructs
+        # them during deserialization.
+        dump = self.model_dump(mode="python")
+        job = dump.pop("job")
         d = jsanitize(
-            self.model_dump(mode="python"),
+            dump,
             strict=True,
             allow_bson=True,
             enum_values=True,
         )
+        d["job"] = jsanitize(job, strict=True, allow_bson=True)
         # required since the resources are not serialized otherwise
         if isinstance(self.resources, QResources):
             d["resources"] = self.resources.as_dict()

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -50,7 +50,6 @@ def get_initial_job_doc_dict(
     JobDoc
         A new JobDoc.
     """
-    from monty.json import jsanitize
 
     # take the resources either from the job, if they are defined
     # (they can be defined dynamically by the update_config) or the
@@ -64,7 +63,7 @@ def get_initial_job_doc_dict(
     priority = job.config.manager_config.get("priority") or priority
 
     job_doc = JobDoc(
-        job=jsanitize(job, strict=True, enum_values=True),
+        job=job,
         uuid=job.uuid,
         index=job.index,
         db_id=db_id,

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -275,15 +275,9 @@ class Runner:
                 self.checkout
             )
 
-        if transfer or queue or complete:
-            try:
-                self.advance_state(states)
-            except Exception:
-                logger.exception("Error during initial advance_state")
-            scheduler.every(self.runner_options.delay_advance_status).seconds.do(
-                self.advance_state, states=states
-            )
-
+        # first perform this step with check run status and update the status of
+        # the limited workers (if any). Otherwise, upon start of the runner the initial
+        # count of the currently submitted jobs is 0.
         if queue:
             try:
                 self.check_run_status()
@@ -315,6 +309,15 @@ class Runner:
                 scheduler.every(self.runner_options.delay_update_batch).seconds.do(
                     self.update_batch_jobs
                 )
+
+        if transfer or queue or complete:
+            try:
+                self.advance_state(states)
+            except Exception:
+                logger.exception("Error during initial advance_state")
+            scheduler.every(self.runner_options.delay_advance_status).seconds.do(
+                self.advance_state, states=states
+            )
 
         # all the processes will ping the running_runner document to signal
         # that at least one is still active.
@@ -359,11 +362,6 @@ class Runner:
         self.checkout()
         scheduler.every(self.runner_options.delay_checkout).seconds.do(self.checkout)
 
-        self.advance_state(states)
-        scheduler.every(self.runner_options.delay_advance_status).seconds.do(
-            self.advance_state, states=states
-        )
-
         self.check_run_status()
         scheduler.every(self.runner_options.delay_check_run_status).seconds.do(
             self.check_run_status
@@ -386,6 +384,11 @@ class Runner:
             scheduler.every(self.runner_options.delay_update_batch).seconds.do(
                 self.update_batch_jobs
             )
+
+        self.advance_state(states)
+        scheduler.every(self.runner_options.delay_advance_status).seconds.do(
+            self.advance_state, states=states
+        )
 
         running_states = [
             JobState.READY.value,

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -1,8 +1,10 @@
 """A series of toy workflows that can be used for testing."""
 
+from dataclasses import dataclass
+from enum import Enum
 from typing import Callable, NoReturn, Optional, Union
 
-from jobflow import Job, JobConfig, OnMissing, Response, job
+from jobflow import Job, JobConfig, Maker, OnMissing, Response, job
 
 
 @job
@@ -111,3 +113,18 @@ def no_resolve(ref):
     A job that does not resolve the reference in input
     """
     return ref
+
+
+class TestEnum(Enum):
+    A = "A"
+    B = "B"
+
+
+@dataclass
+class EnumMaker(Maker):
+    e: TestEnum = TestEnum.A
+    name: str = "enum maker"
+
+    @job
+    def make(self):
+        assert isinstance(self.e, TestEnum)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import logging.config
 import random
 import time
 import warnings
+from functools import partial
 from pathlib import Path
 
 import pytest
@@ -239,3 +240,73 @@ def job_controller_drop(random_project_name, job_controller):
         yield job_controller
     finally:
         job_controller.db.client.drop_database(job_controller.db)
+
+
+def wait_daemon_status(
+    daemon_manager, target_status, acceptable_states=None, max_wait: int = 10
+) -> bool:
+    from jobflow_remote.jobs.daemon import DaemonError
+
+    if not acceptable_states:
+        acceptable_states = [target_status]
+
+    state = None
+    for _i in range(max_wait):
+        time.sleep(1)
+        # if the state cannot be determined keep waiting
+        try:
+            state = daemon_manager.check_status()
+        except DaemonError:
+            continue
+        assert state in acceptable_states
+        if state == target_status:
+            return True
+    raise RuntimeError(
+        f"The daemon did not reach {target_status.value} within the expected time ({max_wait}). Last state: {state}"
+    )
+
+
+@pytest.fixture(scope="session")
+def wait_daemon_started():
+    from jobflow_remote.jobs.daemon import DaemonStatus
+
+    return partial(
+        wait_daemon_status,
+        target_status=DaemonStatus.RUNNING,
+        acceptable_states=[DaemonStatus.STARTING, DaemonStatus.RUNNING],
+    )
+
+
+@pytest.fixture(scope="session")
+def wait_daemon_stopped():
+    from jobflow_remote.jobs.daemon import DaemonStatus
+
+    return partial(
+        wait_daemon_status,
+        target_status=DaemonStatus.STOPPED,
+        acceptable_states=[
+            DaemonStatus.STOPPING,
+            DaemonStatus.STOPPED,
+            DaemonStatus.RUNNING,
+            DaemonStatus.PARTIALLY_RUNNING,
+        ],
+    )
+
+
+@pytest.fixture(scope="session")
+def wait_daemon_shutdown():
+    from jobflow_remote.jobs.daemon import DaemonStatus
+
+    acceptable_states = [
+        DaemonStatus.STOPPING,
+        DaemonStatus.STOPPED,
+        DaemonStatus.RUNNING,
+        DaemonStatus.PARTIALLY_RUNNING,
+        DaemonStatus.SHUT_DOWN,
+    ]
+
+    return partial(
+        wait_daemon_status,
+        target_status=DaemonStatus.SHUT_DOWN,
+        acceptable_states=acceptable_states,
+    )

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -130,6 +130,10 @@ def test_jobs_list_settings(job_controller, two_flows_four_jobs, monkeypatch) ->
 
 
 def test_job_info(job_controller, two_flows_four_jobs) -> None:
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.testing import add
     from jobflow_remote.testing.cli import run_check_cli
 
     outputs = ["name = 'add1'", "state = 'READY'"]
@@ -147,6 +151,26 @@ def test_job_info(job_controller, two_flows_four_jobs) -> None:
 
     run_check_cli(
         ["job", "info", "10"], error=True, required_out="No data matching the request"
+    )
+
+    # test job with many parents. The job is wrong, as it does not take a list, but
+    # it is not going to be executed.
+    parents = [add(1, 5) for _ in range(10)]
+    child = add([p.output for p in parents], 2)
+
+    flow = Flow([child, *parents])
+    submit_flow(flow, worker="test_local_worker")
+    # get the list of parent ids from the DB to be sure to get the correct list ordering
+    pids = job_controller.get_job_info(child.uuid).parents
+    run_check_cli(
+        ["job", "info", child.uuid],
+        required_out=[pids[0], pids[-1], "..."],
+        excluded_out=[pids[5]],
+    )
+    run_check_cli(
+        ["job", "info", child.uuid, "-vv"],
+        required_out=pids,
+        excluded_out=["..."],
     )
 
 

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -2,9 +2,7 @@ import os
 import random
 import shutil
 import tempfile
-import time
 import warnings
-from functools import partial
 from pathlib import Path
 
 import pytest
@@ -202,73 +200,3 @@ def two_flows_four_jobs(random_project_name):
     submit_flow(flow2, worker="test_local_worker")
 
     return [flow, flow2]
-
-
-def wait_daemon_status(
-    daemon_manager, target_status, acceptable_states=None, max_wait: int = 10
-) -> bool:
-    from jobflow_remote.jobs.daemon import DaemonError
-
-    if not acceptable_states:
-        acceptable_states = [target_status]
-
-    state = None
-    for _i in range(max_wait):
-        time.sleep(1)
-        # if the state cannot be determined keep waiting
-        try:
-            state = daemon_manager.check_status()
-        except DaemonError:
-            continue
-        assert state in acceptable_states
-        if state == target_status:
-            return True
-    raise RuntimeError(
-        f"The daemon did not reach {target_status.value} within the expected time ({max_wait}). Last state: {state}"
-    )
-
-
-@pytest.fixture(scope="session")
-def wait_daemon_started():
-    from jobflow_remote.jobs.daemon import DaemonStatus
-
-    return partial(
-        wait_daemon_status,
-        target_status=DaemonStatus.RUNNING,
-        acceptable_states=[DaemonStatus.STARTING, DaemonStatus.RUNNING],
-    )
-
-
-@pytest.fixture(scope="session")
-def wait_daemon_stopped():
-    from jobflow_remote.jobs.daemon import DaemonStatus
-
-    return partial(
-        wait_daemon_status,
-        target_status=DaemonStatus.STOPPED,
-        acceptable_states=[
-            DaemonStatus.STOPPING,
-            DaemonStatus.STOPPED,
-            DaemonStatus.RUNNING,
-            DaemonStatus.PARTIALLY_RUNNING,
-        ],
-    )
-
-
-@pytest.fixture(scope="session")
-def wait_daemon_shutdown():
-    from jobflow_remote.jobs.daemon import DaemonStatus
-
-    acceptable_states = [
-        DaemonStatus.STOPPING,
-        DaemonStatus.STOPPED,
-        DaemonStatus.RUNNING,
-        DaemonStatus.PARTIALLY_RUNNING,
-        DaemonStatus.SHUT_DOWN,
-    ]
-
-    return partial(
-        wait_daemon_status,
-        target_status=DaemonStatus.SHUT_DOWN,
-        acceptable_states=acceptable_states,
-    )

--- a/tests/db/jobs/test_data.py
+++ b/tests/db/jobs/test_data.py
@@ -1,0 +1,16 @@
+def test_jobdoc_serialization(job_controller, runner) -> None:
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.testing import EnumMaker, TestEnum
+
+    job = EnumMaker().make()
+    assert isinstance(job.maker.e, TestEnum)
+    submit_flow(job, worker="test_local_worker")
+
+    jobdoc_from_db = job_controller.get_jobs_doc()[0]
+    assert isinstance(jobdoc_from_db.job.maker.e, TestEnum)
+
+    runner.run_all_jobs(max_seconds=10)
+
+    jobdoc_from_db = job_controller.get_jobs_doc()[0]
+    assert jobdoc_from_db.state == JobState.COMPLETED

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -78,7 +78,9 @@ def test_run_batch_multi(job_controller, monkeypatch) -> None:
             assert ji1.start_time < ji2.end_time
 
 
-def test_max_jobs_worker(job_controller, daemon_manager) -> None:
+def test_max_jobs_worker(
+    job_controller, daemon_manager, wait_daemon_started, wait_daemon_shutdown
+) -> None:
     import time
 
     from jobflow import Flow
@@ -90,30 +92,59 @@ def test_max_jobs_worker(job_controller, daemon_manager) -> None:
     # run the daemon in background to check what happens to the
     # jobs during the execution
     daemon_manager.start(raise_on_error=True)
+    wait_daemon_started(daemon_manager)
 
     job_ids = []
     for _ in range(4):
-        j = add_sleep(2, 5)
+        j = add_sleep(2, 20)
         job_ids.append((j.uuid, 1))
         flow = Flow([j])
         submit_flow(flow, worker="test_max_jobs_worker")
 
-    finished_states = (JobState.REMOTE_ERROR, JobState.FAILED, JobState.COMPLETED)
-    running_states = (JobState.RUNNING, JobState.SUBMITTED)
+    t0 = time.time()
 
-    max_running_jobs = 0
-    for _ in range(30):
-        time.sleep(1)
-        jobs_info = job_controller.get_jobs_info(job_ids=job_ids)
-        if all(ji.state in finished_states for ji in jobs_info):
-            break
-        current_running = sum(ji.state in running_states for ji in jobs_info)
-        max_running_jobs = max(max_running_jobs, current_running)
+    def check_running_jobs(seconds):
+        finished_states = (JobState.REMOTE_ERROR, JobState.FAILED, JobState.COMPLETED)
+        running_states = (JobState.RUNNING, JobState.SUBMITTED)
 
-    jobs_info = job_controller.get_jobs_info(job_ids=job_ids)
-    assert all(ji.state == JobState.COMPLETED for ji in jobs_info)
+        max_running_jobs = 0
+        for _ in range(seconds):
+            time.sleep(1)
+            jobs_info = job_controller.get_jobs_info(job_ids=job_ids)
+            if all(ji.state in finished_states for ji in jobs_info):
+                break
+            current_running = sum(ji.state in running_states for ji in jobs_info)
+            max_running_jobs = max(max_running_jobs, current_running)
+        return max_running_jobs
+
+    max_running_jobs = check_running_jobs(4)
+
+    assert job_controller.count_jobs(states=JobState.RUNNING) == 2
+    assert job_controller.count_jobs(states=JobState.UPLOADED) == 2
 
     # the max running jobs should be two, meaning that it was reached and cannot
     # be larger. The check could be <= 2, but if it does not reach two it will
     # not be testing some parts of the code and the test is not complete.
     assert max_running_jobs == 2
+
+    # now stop the runner and restart it, so it can check that upon restart the current
+    # running jobs are correctly taken into account
+    daemon_manager.shut_down(raise_on_error=True)
+    wait_daemon_shutdown(daemon_manager)
+    daemon_manager.start(raise_on_error=True)
+    wait_daemon_started(daemon_manager)
+
+    if time.time() - t0 > 15:
+        raise RuntimeError(
+            "The execution of the first part of the test took too long (probably "
+            "the restart of the runner) and the test will not be reliable. "
+            "Consider repeating it or increasing the job sleep time"
+        )
+
+    max_running_jobs = check_running_jobs(60)
+    assert max_running_jobs == 2
+
+    jobs_info = job_controller.get_jobs_info(job_ids=job_ids)
+    for ji in jobs_info:
+        print(ji.db_id, ji.state)
+    assert job_controller.count_jobs(states=JobState.COMPLETED) == 4


### PR DESCRIPTION
Two bugfixes: 
* In case of limited workers, when starting the runner the order of operations was such that the currently active jobs were not taken into account.
* The serialization of the JobDoc was using `enum_values=True` to also serialize the `Job` object. While this is fine for the rest of the document, where pydantic converts the value back to an Enum during deserialization, this is not the case for example for attributes of a Maker. While this may still be working in some cases, the Enum object should likely be preserved. This could be a potentially breaking change, if anything relied on the old serialization or if for some specific job the serialization becomes unrelieable, but I consider the previous implementation incorrect.

Test changing the permissions in the release workflow.