### PR TITLE
Minor updates: color job list, allow resuming STOPPED jobs

### DIFF
--- a/doc/source/user/states.rst
+++ b/doc/source/user/states.rst
@@ -113,12 +113,12 @@ STOPPED
 
 Error state. The Job was stopped by another Job as a consequence of a
 ``stop_jobflow`` or ``stop_children`` actions in the Job's response.
-This state cannot be modified.
+A Job in this state can be resumed.
 
 USER_STOPPED
 ------------
 
-Error state. A Job stopped by the user. This state cannot be modified.
+Error state. A Job stopped by the user. A Job in this state can be resumed.
 
 BATCH_SUBMITTED
 ---------------

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -380,3 +380,29 @@ def report(
         timezone=timezone,
     )
     out_console.print(*get_flow_report_components(jobs_report))
+
+
+@app_flow.command()
+def resume(
+    flow_db_id: flow_db_id_arg,
+    job_id_flag: job_flow_id_flag_opt = False,
+) -> None:
+    """Resume a STOPPED or PAUSED Flow."""
+    job_id = flow_id = None
+    db_id, jf_id = get_job_db_ids(flow_db_id, None)
+    if db_id is None:
+        if job_id_flag:
+            job_id = jf_id
+        else:
+            flow_id = jf_id
+
+    with loading_spinner():
+        jc = get_job_controller()
+
+        n_jobs = jc.resume_flow(
+            job_id=job_id,
+            db_id=db_id,
+            flow_id=flow_id,
+        )
+
+    out_console.print(f"{n_jobs} Job(s) resumed")

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import copy
 import datetime
 import io
 import time
+from itertools import cycle
 from typing import TYPE_CHECKING
 
 from monty.json import jsanitize
@@ -24,6 +26,44 @@ if TYPE_CHECKING:
     from jobflow_remote.jobs.data import FlowInfo, JobDoc, JobInfo
     from jobflow_remote.jobs.report import FlowsReport, JobsReport
     from jobflow_remote.jobs.upgrade import UpgradeAction
+
+
+colors_list = [
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "bright_red",
+    "bright_green",
+    "bright_yellow",
+    "bright_blue",
+    "bright_magenta",
+    "bright_cyan",
+    "dark_blue",
+    "salmon1",
+    "dodger_blue1",
+    "spring_green4",
+    "dark_green",
+    "cyan1",
+    "purple4",
+    "royal_blue1",
+    "dark_red",
+    "orange4",
+    "green3",
+    "deep_sky_blue1",
+    "deep_pink1",
+    "orange1",
+    "deep_sky_blue4",
+    "yellow3",
+    "violet",
+    "deep_pink3",
+    "spring_green1",
+    "steel_blue",
+    "green_yellow",
+    "blue3",
+]
 
 
 def format_state(ji: JobInfo) -> Text:
@@ -88,6 +128,7 @@ def get_job_info_table(
     verbosity: int,
     output_keys: list[str] | None = None,
     stored_data_keys: list[str] | None = None,
+    color: bool = False,
 ) -> Table:
     stored_data_keys = stored_data_keys or []
     if not output_keys or verbosity > 0:
@@ -101,6 +142,9 @@ def get_job_info_table(
             output_keys += all_output_keys[11:13]
     all_display_keys = output_keys + stored_data_keys
 
+    # Use a dictionary to determine how to extract the value to print from each
+    # JobInfo object. Main reference is header_name_data_getter_map and gets
+    # updated with additional required values.
     sdk_map = {
         k: (k, lambda x, k=k: x.stored_data.get(k) if x.stored_data else None)
         for k in stored_data_keys
@@ -110,6 +154,22 @@ def get_job_info_table(
     table = Table(title="Jobs info")
     for key in all_display_keys:
         table.add_column(full_map[key][0])
+
+    if color and "name" in all_display_keys:
+        # color the name of the Job by replacing the function that gets the
+        # value of the cell in header_name_data_getter_map.
+        # make a copy to avoid modifying the original object.
+        main_hosts = {ji.hosts[-1] for ji in jobs_info if ji.hosts}
+        hosts_color_map = dict(zip(main_hosts, cycle(colors_list)))
+
+        def get_colored_name(ji):
+            if ji.hosts:
+                return Text(ji.name, style=hosts_color_map.get(ji.hosts[-1], None))
+            # this should likely never happen, but leave to avoid hard failures
+            return ji.name
+
+        full_map = copy.deepcopy(full_map)
+        full_map["name"] = (full_map["name"][0], get_colored_name)
 
     for ji in jobs_info:
         table.add_row(*(full_map[key][1](ji) for key in all_display_keys))
@@ -181,6 +241,7 @@ JOB_INFO_ORDER = [
     "lock_id",
     "lock_time",
     "stored_data",
+    "hosts",
 ]
 
 
@@ -223,6 +284,9 @@ def format_job_info(
 
     if verbosity < 2 and d.get("parents") and len(d.get("parents", [])) > 5:
         d["parents"] = d["parents"][:2] + ["..."] + d["parents"][-2:]
+
+    if verbosity < 2 and d.get("hosts") and len(d.get("hosts", [])) > 5:
+        d["hosts"] = d["hosts"][:2] + ["..."] + d["hosts"][-2:]
 
     # reorder the keys
     # Do not check here that all the keys in JobInfo are in JOB_INFO_ORDER. Check in the tests

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -159,7 +159,7 @@ def get_job_info_table(
         # color the name of the Job by replacing the function that gets the
         # value of the cell in header_name_data_getter_map.
         # make a copy to avoid modifying the original object.
-        main_hosts = {ji.hosts[-1] for ji in jobs_info if ji.hosts}
+        main_hosts = list(dict.fromkeys(ji.hosts[-1] for ji in jobs_info if ji.hosts))
         hosts_color_map = dict(zip(main_hosts, cycle(colors_list)))
 
         def get_colored_name(ji):

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -135,6 +135,14 @@ def jobs_list(
             f"Available options are: {', '.join(header_name_data_getter_map)}",
         ),
     ] = None,
+    color: Annotated[
+        bool,
+        typer.Option(
+            "--color",
+            "-c",
+            help="Color the job names with same colors for Jobs belonging to the same Flow",
+        ),
+    ] = False,
 ):
     """
     Get the list of Jobs in the database.
@@ -239,6 +247,7 @@ def jobs_list(
                 verbosity=verbosity,
                 output_keys=output_keys,
                 stored_data_keys=stored_data_keys,
+                color=color,
             )
 
         out_console.print(table)
@@ -537,6 +546,52 @@ def pause(
 
 
 @app_job.command()
+def resume(
+    job_db_id: job_db_id_arg = None,
+    job_index: job_index_arg = None,
+    job_id: job_ids_indexes_opt = None,
+    db_id: db_ids_opt = None,
+    flow_id: flow_ids_opt = None,
+    state: job_state_opt = None,
+    start_date: start_date_opt = None,
+    end_date: end_date_opt = None,
+    name: name_opt = None,
+    metadata: metadata_opt = None,
+    worker_name: worker_name_opt = None,
+    custom_query: query_opt = None,
+    days: days_opt = None,
+    hours: hours_opt = None,
+    verbosity: verbosity_opt = 0,
+    wait: wait_lock_opt = None,
+    raise_on_error: raise_on_error_opt = False,
+) -> None:
+    """Resume a Job that was previously PAUSED or STOPPED."""
+    jc = get_job_controller()
+
+    execute_multi_jobs_cmd(
+        single_cmd=jc.resume_job,
+        multi_cmd=jc.resume_jobs,
+        job_db_id=job_db_id,
+        job_index=job_index,
+        job_ids=job_id,
+        db_ids=db_id,
+        flow_ids=flow_id,
+        states=state,
+        start_date=start_date,
+        end_date=end_date,
+        name=name,
+        metadata=metadata,
+        days=days,
+        hours=hours,
+        workers=worker_name,
+        custom_query=custom_query,
+        verbosity=verbosity,
+        wait=wait,
+        raise_on_error=raise_on_error,
+    )
+
+
+@app_job.command(hidden=True)
 def play(
     job_db_id: job_db_id_arg = None,
     job_index: job_index_arg = None,
@@ -556,12 +611,16 @@ def play(
     wait: wait_lock_opt = None,
     raise_on_error: raise_on_error_opt = False,
 ) -> None:
-    """Resume a Job that was previously PAUSED."""
+    """Resume a Job that was previously PAUSED or STOPPED. DEPRECATED: use resume instead"""
+    out_console.print(
+        "The 'jf job play' command is deprecated. Use 'jf job resume' instead",
+        style="gold1",
+    )
     jc = get_job_controller()
 
     execute_multi_jobs_cmd(
-        single_cmd=jc.play_job,
-        multi_cmd=jc.play_jobs,
+        single_cmd=jc.resume_job,
+        multi_cmd=jc.resume_jobs,
         job_db_id=job_db_id,
         job_index=job_index,
         job_ids=job_id,

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -139,7 +139,7 @@ def jobs_list(
         bool,
         typer.Option(
             "--color",
-            "-c",
+            "-col",
             help="Color the job names with same colors for Jobs belonging to the same Flow",
         ),
     ] = False,

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -150,6 +150,7 @@ class JobInfo(BaseModel):
     priority: int = 0
     metadata: Optional[dict] = None
     stored_data: Optional[dict] = None
+    hosts: Optional[list[str]] = None
 
     @property
     def is_locked(self) -> bool:
@@ -201,7 +202,7 @@ class JobInfo(BaseModel):
             The instance of JobInfo based on the data
         """
         job = d.pop("job")
-        for k in ["name", "metadata"]:
+        for k in ["name", "metadata", "hosts"]:
             d[k] = job[k]
         return cls.model_validate(d)
 
@@ -219,6 +220,7 @@ def _projection_db_info() -> list[str]:
     projection.remove("name")
     projection.append("job.name")
     projection.append("job.metadata")
+    projection.append("job.hosts")
     return projection
 
 

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1871,7 +1871,7 @@ class JobController:
 
             return return_doc["db_id"]
 
-    def play_jobs(
+    def resume_jobs(
         self,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: str | list[str] | None = None,
@@ -1888,7 +1888,7 @@ class JobController:
         break_lock: bool = False,
     ) -> list[str]:
         """
-        Restart selected Jobs that were previously paused.
+        Restart selected Jobs that were previously paused or stopped.
 
         Parameters
         ----------
@@ -1935,8 +1935,8 @@ class JobController:
             List of db_ids of the updated Jobs.
         """
         return self._many_jobs_action(
-            method=self.play_job,
-            action_description="playing",
+            method=self.resume_job,
+            action_description="resuming",
             job_ids=job_ids,
             db_ids=db_ids,
             flow_ids=flow_ids,
@@ -1952,7 +1952,7 @@ class JobController:
             break_lock=break_lock,
         )
 
-    def play_job(
+    def resume_job(
         self,
         job_id: str | None = None,
         db_id: str | None = None,
@@ -1961,7 +1961,7 @@ class JobController:
         break_lock: bool = False,
     ) -> str:
         """
-        Restart a single Jobs that was previously paused.
+        Restart a single Jobs that was previously paused or stopped.
         Selected by db_id or uuid+index. Only one among db_id
         and job_id should be defined.
 
@@ -1992,7 +1992,11 @@ class JobController:
         )
         flow_lock_kwargs = dict(projection=["uuid"])
         with self.lock_job_flow(
-            acceptable_states=[JobState.PAUSED],
+            acceptable_states=[
+                JobState.PAUSED,
+                JobState.STOPPED,
+                JobState.USER_STOPPED,
+            ],
             job_id=job_id,
             db_id=db_id,
             job_index=job_index,
@@ -3276,7 +3280,36 @@ class JobController:
         exec_config: ExecutionConfig | None = None,
         resources: QResources | None = None,
         priority: int = 0,
+        stopped: bool = False,
     ) -> None:
+        """
+        Append a new Flow to an existing one as a child of a specific Job.
+
+        Parameters
+        ----------
+        job_doc
+            The dictionary representation of the JobDoc of the Job to which
+             the new Flow will be appended.
+        flow_dict
+            The dictionary of the original Flow.
+        new_flow_dict
+            The dictionary of the new Flow.
+        worker
+            The default worker applied to the newly created Jobs, if not
+            overridden by specific Job configurations.
+        response_type
+            Type or response.
+        exec_config
+            ExecConfig inherited from the generating Job, if not overridden
+            by specific Job updates.
+        resources
+            Resources inherited from the generating Job, if not overridden
+            by specific Job updates.
+        priority
+            Priority inherited from the generating Job.
+        stopped
+            If True the generated Jobs will be set in the STOPPED state.
+        """
         from jobflow import Flow, Job
 
         decoder = MontyDecoder()
@@ -3340,17 +3373,18 @@ class JobController:
             db_id = f"{prefix}{db_id_int}"
             # inherit the parents of the job to which we are appending
             parents = parents if parents else job_parents  # noqa: PLW2901
-            job_dicts.append(
-                get_initial_job_doc_dict(
-                    job,
-                    parents,
-                    db_id,
-                    worker=worker,
-                    exec_config=exec_config,
-                    resources=resources,
-                    priority=priority,
-                )
+            init_job_doc = get_initial_job_doc_dict(
+                job,
+                parents,
+                db_id,
+                worker=worker,
+                exec_config=exec_config,
+                resources=resources,
+                priority=priority,
             )
+            if stopped:
+                init_job_doc["state"] = JobState.STOPPED.value
+            job_dicts.append(init_job_doc)
             flow_updates["$set"][f"parents.{job.uuid}.{job.index}"] = parents
             ids_to_push.append((job_dicts[-1]["db_id"], job.uuid, job.index))
         flow_updates["$push"]["ids"] = {"$each": ids_to_push}
@@ -3587,6 +3621,7 @@ class JobController:
         # handle response
         else:
             new_state = JobState.COMPLETED.value
+            stop_generated = response["stop_children"] or response["stop_jobflow"]
             if response["replace"] is not None:
                 self._append_flow(
                     job_doc,
@@ -3597,6 +3632,7 @@ class JobController:
                     exec_config=job_doc["exec_config"],
                     resources=job_doc["resources"],
                     priority=job_doc["priority"],
+                    stopped=stop_generated,
                 )
 
             if response["addition"] is not None:
@@ -3609,6 +3645,7 @@ class JobController:
                     exec_config=job_doc["exec_config"],
                     resources=job_doc["resources"],
                     priority=job_doc["priority"],
+                    stopped=stop_generated,
                 )
 
             if response["detour"] is not None:
@@ -3621,6 +3658,7 @@ class JobController:
                     exec_config=job_doc["exec_config"],
                     resources=job_doc["resources"],
                     priority=job_doc["priority"],
+                    stopped=stop_generated,
                 )
 
             if response["stored_data"] is not None:
@@ -3726,7 +3764,11 @@ class JobController:
             The number of modified Jobs.
         """
         result = self.jobs.update_many(
-            {"parents": job_uuid, "state": JobState.WAITING.value},
+            {
+                "parents": job_uuid,
+                "state": {"$in": [JobState.WAITING.value, JobState.READY.value]},
+                "lock_id": None,
+            },
             {"$set": {"state": JobState.STOPPED.value}},
         )
         return result.modified_count
@@ -3761,7 +3803,11 @@ class JobController:
         job_uuids = flow_dict["jobs"]
 
         result = self.jobs.update_many(
-            {"uuid": {"$in": job_uuids}, "state": JobState.WAITING.value},
+            {
+                "uuid": {"$in": job_uuids},
+                "state": {"$in": [JobState.WAITING.value, JobState.READY.value]},
+                "lock_id": None,
+            },
             {"$set": {"state": JobState.STOPPED.value}},
         )
         return result.modified_count

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -597,7 +597,7 @@ class JobController:
         Returns
         -------
         dict, list
-            A dict and an optional list to be used as query and sort,
+            A dict and an optional list to be used as filter and sort,
             respectively, in a query for a single Job.
         """
         query: dict = {}
@@ -621,6 +621,45 @@ class JobController:
         if not query:
             raise ValueError("At least one among db_id and job_id should be specified")
         return query, sort
+
+    @staticmethod
+    def generate_flow_id_query(
+        db_id: str | None = None,
+        job_id: str | None = None,
+        flow_id: str | None = None,
+    ) -> dict:
+        """
+        Generate a query for a single Flow based on the ids.
+        Only one among the input options should be defined.
+
+        Parameters
+        ----------
+        db_id
+            The db_id of one Job belonging to the Flow.
+        job_id
+            The uuid of one Job belonging to the Flow.
+        flow_id
+            The uuid of the Flow.
+
+        Returns
+        -------
+        dict
+            A dict to be used as filter in a query for a single Job.
+        """
+
+        if sum((job_id is None, db_id is None, flow_id is None)) != 2:
+            raise ValueError(
+                "One and only one among job_id, db_id and flow_id should be defined"
+            )
+
+        if db_id:
+            # the "0" refers to the index in the ids list.
+            # needs to be a string, but is correctly recognized by MongoDB
+            return {"ids": {"$elemMatch": {"0": db_id}}}
+        if job_id:
+            return {"jobs": job_id}
+
+        return {"uuid": flow_id}
 
     def get_job_info(
         self,
@@ -2010,23 +2049,7 @@ class JobController:
                 raise RuntimeError("No job document found in lock")
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
-            on_missing = job_doc["job"]["config"]["on_missing_references"]
-            allow_failed = on_missing != OnMissing.ERROR.value
-
-            # in principle the lock on each of the parent jobs is not needed
-            # since a parent Job cannot change to COMPLETED or FAILED while
-            # the flow is locked
-            for parent in self.jobs.find(
-                {"uuid": {"$in": job_doc["parents"]}}, projection=["state"]
-            ):
-                parent_state = JobState(parent["state"])
-                if parent_state != JobState.COMPLETED:
-                    if parent_state == JobState.FAILED and allow_failed:
-                        continue
-                    final_state = JobState.WAITING
-                    break
-            else:
-                final_state = JobState.READY
+            final_state = self._resume_job_locked(job_doc)
 
             updated_states = {job_id: {job_index: final_state}}
             self.update_flow_state(
@@ -2035,6 +2058,157 @@ class JobController:
             )
             job_lock.update_on_release = {"$set": {"state": final_state.value}}
             return job_lock.locked_document["db_id"]
+
+    def _resume_job_locked(self, job_doc) -> JobState:
+        """
+        Helper method for the logic of resuming a Job.
+        Assumes the input is the dictionary representation of a JobDoc and that
+        the Flow and Job has been locked.
+
+        Parameters
+        ----------
+        job_doc
+            Dictionary representing the JobDoc with the required elements presents.
+
+        Returns
+        -------
+        JobState
+            The final state that should be set to a Job.
+        """
+        on_missing = job_doc["job"]["config"]["on_missing_references"]
+        allow_failed = on_missing != OnMissing.ERROR.value
+        # in principle the lock on each of the parent jobs is not needed
+        # since a parent Job cannot change to COMPLETED or FAILED while
+        # the flow is locked
+        for parent in self.jobs.find(
+            {"uuid": {"$in": job_doc["parents"]}}, projection=["state"]
+        ):
+            parent_state = JobState(parent["state"])
+            if parent_state != JobState.COMPLETED:
+                if parent_state == JobState.FAILED and allow_failed:
+                    continue
+                final_state = JobState.WAITING
+                break
+        else:
+            final_state = JobState.READY
+        return final_state
+
+    def resume_flow(
+        self,
+        job_id: str | None = None,
+        db_id: str | None = None,
+        flow_id: str | None = None,
+        wait: int | None = None,
+        break_lock: bool = False,
+    ) -> int:
+        """
+        Resume a Flow by resuming all the STOPPED, USER_STOPPED and PAUSED Jobs
+        in the Flow.
+
+        Parameters
+        ----------
+        job_id
+            The uuid of one of the Jobs of the Flow.
+        db_id
+            The db_id of one of the Jobs of the Flow.
+        flow_id
+            The uuid of the Flow.
+        wait
+            In case the Flow or Jobs that need to be updated are locked,
+            wait this time (in seconds) for the lock to be released.
+            Raise an error if lock is not released.
+        break_lock
+            Forcibly break the lock on locked documents. Use with care and
+            verify that the lock has been set by a process that is not running
+            anymore. Doing otherwise will likely lead to inconsistencies in the DB.
+
+        Returns
+        -------
+        int
+            The number of Jobs modified.
+        """
+        sleep = None
+        if wait:
+            sleep = 10
+        flow_filter = self.generate_flow_id_query(
+            job_id=job_id, db_id=db_id, flow_id=flow_id
+        )
+        with self.lock_flow(
+            filter=flow_filter,
+            sleep=sleep,
+            max_wait=wait,
+            get_locked_doc=True,
+            break_lock=break_lock,
+        ) as flow_lock:
+            if not flow_lock.locked_document:
+                if flow_lock.unavailable_document:
+                    raise FlowLockedError.from_flow_doc(flow_lock.unavailable_document)
+                raise ValueError(f"No Flow document matching criteria {flow_filter}")
+            flow_doc = FlowDoc.model_validate(flow_lock.locked_document)
+            if flow_doc.state not in [FlowState.STOPPED, FlowState.PAUSED]:
+                raise ValueError(f"Cannot resume a Flow in state {flow_doc.state}")
+            # loop over the STOPPED, USER_STOPPED and PAUSED jobs.
+            # In principle there should be no ambiguity since in all the cases the Flow should be
+            # locked. Still do not assume that at the end all the Jobs will not be stopped.
+            jobs_filter = self._build_query_job(
+                flow_ids=[flow_doc.uuid],
+                states=[JobState.STOPPED, JobState.USER_STOPPED, JobState.PAUSED],
+                job_ids=None,
+                db_ids=None,
+                locked=False,
+                start_date=None,
+                end_date=None,
+                name=None,
+                metadata=None,
+                workers=None,
+            )
+            job_db_ids_to_resume = [
+                d["db_id"] for d in self.jobs.find(jobs_filter, projection=["db_id"])
+            ]
+
+            job_lock_kwargs = dict(
+                projection=["uuid", "index", "db_id", "state", "job.config", "parents"]
+            )
+            n_updated_jobs = 0
+            for job_db_id in job_db_ids_to_resume:
+                job_lock_filter = {"db_id": job_db_id}
+                with self.lock_job(
+                    filter=job_lock_filter,
+                    break_lock=break_lock,
+                    projection=job_lock_kwargs,
+                    sleep=sleep,
+                    max_wait=wait,
+                    get_locked_doc=True,
+                ) as job_lock:
+                    job_doc_dict = job_lock.locked_document
+                    if not job_doc_dict:
+                        if job_lock.unavailable_document:
+                            raise JobLockedError.from_job_doc(
+                                job_lock.unavailable_document
+                            )
+                        raise ValueError(
+                            f"No Job document matching criteria {job_lock_filter}"
+                        )
+                    # this should not happen, but handle the case to avoid inconsistencies
+                    # no error is raised as the job should already be in the correct state
+                    if JobState(job_doc_dict["state"]) not in [
+                        JobState.STOPPED,
+                        JobState.USER_STOPPED,
+                        JobState.PAUSED,
+                    ]:
+                        continue
+                    final_state = self._resume_job_locked(job_doc_dict)
+                    job_lock.update_on_release = {"$set": {"state": final_state.value}}
+                    n_updated_jobs += 1
+
+            # no need for updated states, since all the Jobs have been already updated separately
+            final_state = self.update_flow_state(flow_uuid=flow_doc.uuid)
+            if final_state in [FlowState.PAUSED, FlowState.STOPPED]:
+                logger.warning(
+                    "The Flow was not fully resumed. Consider running resume again"
+                )
+
+            return n_updated_jobs
 
     def set_job_run_properties(
         self,
@@ -3927,7 +4101,7 @@ class JobController:
         self,
         flow_uuid: str,
         updated_states: dict[str, dict[int, JobState | None]] | None = None,
-    ) -> None:
+    ) -> FlowState:
         """
         Update the state of a Flow in the DB based on the Job's states.
 
@@ -3943,6 +4117,11 @@ class JobController:
             If the value is None the Job is considered deleted and the state
             of that Job will be ignored while determining the state of the
             whole Flow.
+
+        Returns
+        -------
+        FlowState
+            The state set for the Flow.
         """
         updated_states = updated_states or {}
         projection = ["uuid", "index", "parents", "state"]
@@ -3982,6 +4161,7 @@ class JobController:
             {"uuid": flow_uuid},
             [{"$set": {"state": flow_state.value, "updated_on": updated_cond}}],
         )
+        return flow_state
 
     @contextlib.contextmanager
     def lock_job(self, **lock_kwargs) -> Generator[MongoLock, None, None]:

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -115,6 +115,32 @@ def no_resolve(ref):
     return ref
 
 
+@job
+def replace_and_stop_jobflow(a=1, b=1) -> Response[None]:
+    from jobflow import Flow
+
+    j1 = add(a, b)
+    j2 = add(j1.output, 1)
+    flow = Flow([j1, j2], output=j2.output)
+    return Response(replace=flow, stop_jobflow=True)
+    # return Response(replace=flow)
+
+
+@job
+def replace_and_stop_children(a: int = 1, b: int = 1) -> Response[None]:
+    from jobflow import Flow
+
+    j1 = add(a, b)
+    j2 = add(j1.output, 1)
+    flow = Flow([j1, j2], output=j2.output)
+    return Response(replace=flow, stop_children=True)
+
+
+@job
+def stop_jobflow(x=None) -> Response[None]:
+    return Response(stop_jobflow=True)
+
+
 class TestEnum(Enum):
     A = "A"
     B = "B"

--- a/src/jobflow_remote/webgui/webgui.py
+++ b/src/jobflow_remote/webgui/webgui.py
@@ -175,7 +175,7 @@ def set_job_controller_deamon(project_name):
     job_controller = job_controllers[project_name]
     job_controller_actions = {
         "jobs": {
-            "Play": job_controller.play_jobs,
+            "Resume": job_controller.resume_jobs,
             "Pause": job_controller.pause_jobs,
             "Stop": job_controller.stop_jobs,
             "Retry": job_controller.retry_jobs,

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -199,3 +199,23 @@ def test_report(job_controller) -> None:
         ["flow", "report", "days", "2"],
         required_out=[*output, "Running Flows │   0"],
     )
+
+
+def test_resume(job_controller, two_flows_four_jobs) -> None:
+    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.testing.cli import run_check_cli
+
+    job_controller.stop_job(db_id="1")
+    job_controller.set_job_state(JobState.STOPPED, db_id="2")
+
+    assert job_controller.get_flows_info(db_ids="1")[0].state == FlowState.STOPPED
+
+    run_check_cli(
+        ["flow", "resume", "1"],
+        required_out="2 Job(s) resumed",
+        excluded_out="The Flow was not fully resumed",
+    )
+    assert job_controller.get_job_info(db_id="1").state == JobState.READY
+    assert job_controller.get_job_info(db_id="2").state == JobState.WAITING
+
+    assert job_controller.get_flows_info(db_ids="1")[0].state == FlowState.READY

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -16,6 +16,9 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
     run_check_cli(["job", "list", "-v"])
     run_check_cli(["job", "list", "-vvv"])
 
+    # not checking that the output is actually colored. Just check that runs correctly
+    run_check_cli(["job", "list", "--color"], required_out=outputs)
+
     outputs = ["add1", "READY"]
     excluded = [f"add{i}" for i in range(2, 5)]
     run_check_cli(
@@ -285,7 +288,7 @@ def test_retry(job_controller, two_flows_four_jobs) -> None:
     run_check_cli(["job", "retry", "-did", "2"], required_out="Error while retrying")
 
 
-def test_play_pause(job_controller, two_flows_four_jobs) -> None:
+def test_pause_resume(job_controller, two_flows_four_jobs) -> None:
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -297,14 +300,20 @@ def test_play_pause(job_controller, two_flows_four_jobs) -> None:
     assert job_controller.get_job_info(db_id="1").state == JobState.PAUSED
 
     run_check_cli(
-        ["job", "play", "-did", "1"],
+        ["job", "resume", "-did", "1"],
         required_out="Operation completed: 1 jobs modified",
     )
     assert job_controller.get_job_info(db_id="1").state == JobState.READY
-    run_check_cli(["job", "play", "-did", "1"], required_out="Error while playing")
+    run_check_cli(["job", "resume", "-did", "1"], required_out="Error while resuming")
+
+    # test the deprecated version. Remove when job play is removed.
+    run_check_cli(
+        ["job", "play", "-did", "1"],
+        required_out=["Error while resuming", "deprecated"],
+    )
 
 
-def test_stop(job_controller, two_flows_four_jobs) -> None:
+def test_stop_resume(job_controller, two_flows_four_jobs) -> None:
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 
@@ -314,6 +323,12 @@ def test_stop(job_controller, two_flows_four_jobs) -> None:
     )
     run_check_cli(["job", "stop", "-did", "1"], required_out="Error while stopping")
     assert job_controller.get_job_info(db_id="1").state == JobState.USER_STOPPED
+
+    run_check_cli(
+        ["job", "resume", "-did", "1"],
+        required_out="Operation completed: 1 jobs modified",
+    )
+    assert job_controller.get_job_info(db_id="1").state == JobState.READY
 
 
 def test_queue_out(job_controller, one_job) -> None:
@@ -480,7 +495,7 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
         "No filter has been set. This will apply the change to all the jobs in the DB.",
     ]
     run_check_cli(
-        ["job", "play"],
+        ["job", "resume"],
         cli_input="y",
         required_out=req_output_all,
     )
@@ -492,10 +507,10 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
 
     req_output_partial = [
         "Operation completed: 1 jobs modified",
-        "Error while playing for job 2 ValueError: Job in state WAITING. The action cannot be performed",
+        "Error while resuming for job 2 ValueError: Job in state WAITING. The action cannot be performed",
     ]
     run_check_cli(
-        ["job", "play", "--worker", "test_local_worker"],
+        ["job", "resume", "--worker", "test_local_worker"],
         cli_input="y",
         required_out=req_output_partial,
     )
@@ -513,11 +528,11 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
     )
 
     run_check_cli(
-        ["job", "play", "--end-date", yesterday],
+        ["job", "resume", "--end-date", yesterday],
         required_out="Operation completed: 0 jobs modified",
     )
     run_check_cli(
-        ["job", "play", "--end-date", tomorrow],
+        ["job", "resume", "--end-date", tomorrow],
         required_out="Operation completed: 4 jobs modified",
     )
 
@@ -527,7 +542,7 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
     )
 
     run_check_cli(
-        ["job", "play", "--hours", "1"],
+        ["job", "resume", "--hours", "1"],
         required_out="Operation completed: 4 jobs modified",
     )
 
@@ -545,7 +560,7 @@ def test_queries(job_controller, two_flows_four_jobs) -> None:
         required_out="Operation completed: 1 jobs modified",
     )
     run_check_cli(
-        ["job", "play", "--name", "add*"],
+        ["job", "resume", "--name", "add*"],
         required_out="Operation completed: 1 jobs modified",
     )
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1126,3 +1126,41 @@ def test_stop_children_resume(job_controller, runner) -> None:
     assert job_controller.count_jobs(states=JobState.READY) == 2
     assert job_controller.count_jobs(states=JobState.WAITING) == 3
     assert job_controller.get_flows_info()[0].state == FlowState.RUNNING
+
+
+def test_resume_flow(job_controller, runner):
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.testing import add, replace_and_stop_children
+
+    j_add = add(1, 1)
+    j_stop_children = replace_and_stop_children()
+    j_final = add(j_add.output, j_stop_children.output)
+    flow = Flow([j_add, j_stop_children, j_final])
+    submit_flow(flow=flow, worker="test_local_worker")
+
+    runner.run_one_job(job_id=[j_stop_children.uuid, 1])
+
+    assert job_controller.count_jobs() == 6
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_stop_children.uuid, 1])[0].state
+        == JobState.COMPLETED
+    )
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_add.uuid, 1])[0].state == JobState.READY
+    )
+    assert job_controller.count_jobs(states=JobState.STOPPED) == 4
+    assert job_controller.get_flows_info()[0].state == FlowState.STOPPED
+
+    job_controller.pause_job(job_id=j_add.uuid, job_index=1)
+    assert job_controller.get_flows_info()[0].state == FlowState.STOPPED
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_add.uuid, 1])[0].state
+        == JobState.PAUSED
+    )
+    assert job_controller.resume_flow(flow_id=flow.uuid) == 5
+
+    assert job_controller.get_flows_info()[0].state == FlowState.RUNNING
+    assert job_controller.count_jobs(states=[JobState.STOPPED, JobState.PAUSED]) == 0

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -515,7 +515,7 @@ def test_pause_play(job_controller) -> None:
     assert job_controller.get_job_info(job_id=j.uuid).state == JobState.PAUSED
     assert job_controller.get_flows_info(job_ids=j.uuid)[0].state == FlowState.PAUSED
 
-    assert job_controller.play_jobs(job_ids=(j.uuid, 1)) == ["1"]
+    assert job_controller.resume_jobs(job_ids=(j.uuid, 1)) == ["1"]
     assert job_controller.get_job_info(job_id=j.uuid).state == JobState.READY
     assert job_controller.get_flows_info(job_ids=j.uuid)[0].state == FlowState.READY
 
@@ -1057,3 +1057,72 @@ def test_running_runner(job_controller, daemon_manager, wait_daemon_started):
     ):
         job_controller.clean_running_runner()
     assert job_controller.get_running_runner() == "NO_DOCUMENT"
+
+
+def test_stop_jobflow_resume(job_controller, runner) -> None:
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.testing import add, replace_and_stop_jobflow
+
+    # add other jobs to verify the difference between stop_joblow and stop_children
+    j_add = add(1, 1)
+    j_stop = replace_and_stop_jobflow()
+    j_final = add(j_add.output, j_stop.output)
+    flow = Flow([j_add, j_stop, j_final])
+    submit_flow(flow=flow, worker="test_local_worker")
+
+    runner.run_one_job(job_id=[j_stop.uuid, 1])
+
+    assert job_controller.count_jobs() == 6
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_stop.uuid, 1])[0].state
+        == JobState.COMPLETED
+    )
+    assert job_controller.count_jobs(states=JobState.STOPPED) == 5
+    assert job_controller.get_flows_info()[0].state == FlowState.STOPPED
+
+    job_controller.resume_job(job_id=j_add.uuid)
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_add.uuid, 1])[0].state == JobState.READY
+    )
+    job_controller.resume_job(job_id=j_final.uuid)
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_final.uuid, 1])[0].state
+        == JobState.WAITING
+    )
+    assert job_controller.get_flows_info()[0].state == FlowState.STOPPED
+
+
+def test_stop_children_resume(job_controller, runner) -> None:
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.testing import add, replace_and_stop_children
+
+    j_add = add(1, 1)
+    j_stop_children = replace_and_stop_children()
+    j_final = add(j_add.output, j_stop_children.output)
+    flow = Flow([j_add, j_stop_children, j_final])
+    submit_flow(flow=flow, worker="test_local_worker")
+
+    runner.run_one_job(job_id=[j_stop_children.uuid, 1])
+
+    assert job_controller.count_jobs() == 6
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_stop_children.uuid, 1])[0].state
+        == JobState.COMPLETED
+    )
+    assert (
+        job_controller.get_jobs_info(job_ids=[j_add.uuid, 1])[0].state == JobState.READY
+    )
+    assert job_controller.count_jobs(states=JobState.STOPPED) == 4
+    assert job_controller.get_flows_info()[0].state == FlowState.STOPPED
+
+    job_controller.resume_jobs(states=JobState.STOPPED)
+    assert job_controller.count_jobs(states=JobState.STOPPED) == 0
+    assert job_controller.count_jobs(states=JobState.READY) == 2
+    assert job_controller.count_jobs(states=JobState.WAITING) == 3
+    assert job_controller.get_flows_info()[0].state == FlowState.RUNNING

--- a/tests/unit/cli/test_formatting.py
+++ b/tests/unit/cli/test_formatting.py
@@ -1,0 +1,53 @@
+from jobflow_remote.cli.formatting import get_job_info_table
+
+
+def test_get_job_info_table():
+    import datetime
+
+    from jobflow_remote.jobs.data import JobInfo
+    from jobflow_remote.jobs.state import JobState
+
+    ji1 = JobInfo(
+        uuid="fed516ab-796d-4904-85d6-7f933794b344",
+        index=1,
+        db_id="1",
+        worker="test_worker",
+        name="job1",
+        state=JobState.READY,
+        created_on=datetime.datetime.utcnow(),
+        updated_on=datetime.datetime.utcnow(),
+        hosts=["5e337e69-b153-45e0-82f2-4a7af8b45e44"],
+    )
+
+    ji2 = JobInfo(
+        uuid="15b34018-9401-4b83-83e6-523e027bae29",
+        index=1,
+        db_id="2",
+        worker="another_worker",
+        name="job2",
+        state=JobState.COMPLETED,
+        created_on=datetime.datetime.utcnow(),
+        updated_on=datetime.datetime.utcnow(),
+        hosts=["5e337e69-b153-45e0-82f2-4a7af8b45e44"],
+    )
+
+    ji3 = JobInfo(
+        uuid="d8e27025-7a7e-48d9-9528-0db31985536e",
+        index=1,
+        db_id="2",
+        worker="another_worker",
+        name="job3",
+        state=JobState.COMPLETED,
+        created_on=datetime.datetime.utcnow(),
+        updated_on=datetime.datetime.utcnow(),
+        hosts=["d490d691-8c96-4e93-93c0-8bb2a45e6746"],
+    )
+
+    table = get_job_info_table(jobs_info=[ji1, ji2, ji3], verbosity=0, color=True)
+    cells = list(table.columns[1].cells)
+    assert cells[0].plain == "job1"
+    assert cells[0].style == "red"
+    assert cells[1].plain == "job2"
+    assert cells[1].style == "red"
+    assert cells[2].plain == "job3"
+    assert cells[2].style == "green"


### PR DESCRIPTION
Introducing few minor updates

### color job names
Introducing an option to optionally color the Job names in `jf job list`, so that jobs belonging to the same Flow have the same color. Example:
<img width="893" height="305" alt="Screenshot 2025-07-21 alle 16 22 00" src="https://github.com/user-attachments/assets/5213ac37-ac0b-41cf-ba98-f574f5748409" />
Two potential issues here:
* I had to add the `hosts` attribute to the `JobInfo` model, so that additional information is always fetched from the DB when `JobInfo` is retrieved.
* I manually created a list of colors. I definitely do not want to add something like matplotlib as a dependency to get arbitrary colormaps. Alternatively there would be this nice package: https://cmap-docs.readthedocs.io/en/stable/, but it still depends on numpy. I suppose that numpy and matplotlib will likely be installed in any environment using jobflow-remote, but I would rather keep the dependencies to the minimum. It also avoids importing external libraries at runtime, which might be better when using the CLI.

### Resume STOPPED jobs

Up to now `STOPPED` and `USER_STOPPED` jobs were considered as terminal states, which could not be restarted. Following the discussions in #289 it emerged that it would be a convenient use case to allow resuming a `STOPPED` Job. 
This PR also fixes #291. 
Two issues to consider:
* As discussed in #289, if a Job triggers a `stop_jobflow` and another Job is currently running this will not be stopped (this is fine), but if this latter Job dynamically creates new jobs these will be created as `STOPPED`. Currently they are created normally and will be executed. Fixing this will need adding more information to the DB.
* With the current change the `USER_STOPPED` and `PAUSED` state are almost equivalent. Originally they were mostly differentiated in the (im)possibility of restarting, but now they basically differ just for the states of the Jobs to which they can be applied (`jf job stop` can be applied to any running state, `jf job pause` just to `READY` and `WAITING`). We might consider merging these states in a single one. 

@FabiPi3 let me know if you have any comment or if you want to test this before it is merged.