### PR TITLE
Merge custom and automatic queries

### DIFF
--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -54,7 +54,6 @@ from jobflow_remote.cli.utils import (
     ReportInterval,
     SortOption,
     check_incompatible_opt,
-    check_query_incompatibility,
     check_stopped_runner,
     execute_multi_jobs_cmd,
     exit_with_error_msg,
@@ -143,14 +142,6 @@ def jobs_list(
             help="Color the job names with same colors for Jobs belonging to the same Flow",
         ),
     ] = False,
-    merge_queries: Annotated[
-        bool,
-        typer.Option(
-            "--merge-queries",
-            "-mq",
-            help="If enabled merge the custom query with the automatically generated from the other options.",
-        ),
-    ] = False,
 ):
     """
     Get the list of Jobs in the database.
@@ -160,23 +151,6 @@ def jobs_list(
     # check_incompatible_opt({"state": state, "error": error})
     # check_incompatible_opt({"state": state, "running": running})
     check_incompatible_opt({"output": cli_output_keys, "verbosity": verbosity})
-    if not merge_queries:
-        check_query_incompatibility(
-            custom_query,
-            [
-                job_id,
-                db_id,
-                flow_id,
-                state,
-                start_date,
-                end_date,
-                name,
-                metadata,
-                days,
-                hours,
-                worker_name,
-            ],
-        )
     output_keys = (
         cli_output_keys.split(",")
         if cli_output_keys
@@ -225,7 +199,6 @@ def jobs_list(
                 name=name,
                 metadata=metadata,
                 workers=worker_name,
-                merge_queries=merge_queries,
             )
         out_console.print(f"Number of jobs: {n_jobs}")
     else:
@@ -244,7 +217,6 @@ def jobs_list(
                 workers=worker_name,
                 limit=max_results,
                 sort=db_sort,
-                merge_queries=merge_queries,
             )
 
             table = get_job_info_table(
@@ -1186,22 +1158,6 @@ def job_dump(
     """Dump to json the documents of the selected Jobs from the DB. For debugging."""
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
     check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
-    check_query_incompatibility(
-        custom_query,
-        [
-            job_id,
-            db_id,
-            flow_id,
-            state,
-            start_date,
-            end_date,
-            name,
-            metadata,
-            days,
-            hours,
-            worker_name,
-        ],
-    )
 
     job_ids_indexes = get_job_ids_indexes(job_id)
 
@@ -1210,22 +1166,18 @@ def job_dump(
     start_date = get_start_date(start_date, days, hours)
 
     with loading_spinner():
-        if custom_query:
-            jobs_doc = jc.get_jobs_doc_query(
-                query=custom_query,
-            )
-        else:
-            jobs_doc = jc.get_jobs_doc(
-                job_ids=job_ids_indexes,
-                db_ids=db_id,
-                flow_ids=flow_id,
-                states=state,
-                start_date=start_date,
-                end_date=end_date,
-                name=name,
-                metadata=metadata,
-                workers=worker_name,
-            )
+        jobs_doc = jc.get_jobs_doc(
+            custom_query=custom_query,
+            job_ids=job_ids_indexes,
+            db_ids=db_id,
+            flow_ids=flow_id,
+            states=state,
+            start_date=start_date,
+            end_date=end_date,
+            name=name,
+            metadata=metadata,
+            workers=worker_name,
+        )
         if jobs_doc:
             dumpfn(jsanitize(jobs_doc, strict=True, enum_values=True), file_path)
 

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -206,7 +206,7 @@ def jobs_list(
     if count:
         with loading_spinner():
             n_jobs = jc.count_jobs(
-                custom_query=custom_query,
+                query=custom_query,
                 job_ids=job_ids_indexes,
                 db_ids=db_id,
                 flow_ids=flow_id,

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -135,6 +135,14 @@ def jobs_list(
             f"Available options are: {', '.join(header_name_data_getter_map)}",
         ),
     ] = None,
+    merge_queries: Annotated[
+        bool,
+        typer.Option(
+            "--merge-queries",
+            "-mq",
+            help="If enabled merge the custom query with the automatically generated from the other options.",
+        ),
+    ] = False,
 ):
     """
     Get the list of Jobs in the database.
@@ -144,22 +152,23 @@ def jobs_list(
     # check_incompatible_opt({"state": state, "error": error})
     # check_incompatible_opt({"state": state, "running": running})
     check_incompatible_opt({"output": cli_output_keys, "verbosity": verbosity})
-    check_query_incompatibility(
-        custom_query,
-        [
-            job_id,
-            db_id,
-            flow_id,
-            state,
-            start_date,
-            end_date,
-            name,
-            metadata,
-            days,
-            hours,
-            worker_name,
-        ],
-    )
+    if not merge_queries:
+        check_query_incompatibility(
+            custom_query,
+            [
+                job_id,
+                db_id,
+                flow_id,
+                state,
+                start_date,
+                end_date,
+                name,
+                metadata,
+                days,
+                hours,
+                worker_name,
+            ],
+        )
     output_keys = (
         cli_output_keys.split(",")
         if cli_output_keys
@@ -197,7 +206,7 @@ def jobs_list(
     if count:
         with loading_spinner():
             n_jobs = jc.count_jobs(
-                query=custom_query,
+                custom_query=custom_query,
                 job_ids=job_ids_indexes,
                 db_ids=db_id,
                 flow_ids=flow_id,
@@ -208,31 +217,27 @@ def jobs_list(
                 name=name,
                 metadata=metadata,
                 workers=worker_name,
+                merge_queries=merge_queries,
             )
         out_console.print(f"Number of jobs: {n_jobs}")
     else:
         with loading_spinner():
-            if custom_query:
-                jobs_info = jc.get_jobs_info_query(
-                    query=custom_query,
-                    limit=max_results,
-                    sort=db_sort,
-                )
-            else:
-                jobs_info = jc.get_jobs_info(
-                    job_ids=job_ids_indexes,
-                    db_ids=db_id,
-                    flow_ids=flow_id,
-                    states=state,
-                    start_date=start_date,
-                    locked=locked,
-                    end_date=end_date,
-                    name=name,
-                    metadata=metadata,
-                    workers=worker_name,
-                    limit=max_results,
-                    sort=db_sort,
-                )
+            jobs_info = jc.get_jobs_info(
+                custom_query=custom_query,
+                job_ids=job_ids_indexes,
+                db_ids=db_id,
+                flow_ids=flow_id,
+                states=state,
+                start_date=start_date,
+                locked=locked,
+                end_date=end_date,
+                name=name,
+                metadata=metadata,
+                workers=worker_name,
+                limit=max_results,
+                sort=db_sort,
+                merge_queries=merge_queries,
+            )
 
             table = get_job_info_table(
                 jobs_info,

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -62,7 +62,7 @@ flow_ids_opt = Annotated[
     typer.Option(
         "--flow-id",
         "-fid",
-        help="One or more flow ids",
+        help="One or more flow ids. Can the db id (i.e. an integer) or a string (i.e. the uuid)",
     ),
 ]
 

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -419,7 +419,8 @@ query_opt = Annotated[
         "--query",
         "-q",
         help="A JSON string representing a generic query in the form of a dictionary. "
-        "Overrides all other query options. Requires knowledge of the internal structure of the DB. "
+        "Overrides all other query options. Except the merge_queries option is enabled. "
+        "Requires knowledge of the internal structure of the DB. "
         "Can be either a list of comma separated key=value pairs or a string with the JSON"
         " representation of a dictionary containing the mongoDB query that "
         'should be performed (e.g \'{"key1.key2": 1, "key3": "test"}\')',

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -419,7 +419,7 @@ query_opt = Annotated[
         "--query",
         "-q",
         help="A JSON string representing a generic query in the form of a dictionary. "
-        "Overrides all other query options. Except the merge_queries option is enabled. "
+        "Keys must not overlap with those from other specified query options. "
         "Requires knowledge of the internal structure of the DB. "
         "Can be either a list of comma separated key=value pairs or a string with the JSON"
         " representation of a dictionary containing the mongoDB query that "

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -470,22 +470,6 @@ def execute_multi_jobs_cmd(
                 {"start_date": start_date, "days": days, "hours": hours}
             )
             check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
-            check_query_incompatibility(
-                custom_query,
-                [
-                    job_ids,
-                    db_ids,
-                    flow_ids,
-                    states,
-                    start_date,
-                    end_date,
-                    name,
-                    metadata,
-                    days,
-                    hours,
-                    workers,
-                ],
-            )
 
             job_ids_indexes = get_job_ids_indexes(job_ids)
             start_date = get_start_date(start_date, days, hours)

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -6,7 +6,6 @@ import importlib.metadata
 import logging
 import shutil
 import traceback
-import uuid
 import warnings
 from collections import defaultdict
 from contextlib import ExitStack
@@ -60,6 +59,7 @@ from jobflow_remote.remote.data import (
 )
 from jobflow_remote.remote.queue import QueueManager
 from jobflow_remote.utils.data import (
+    check_valid_uuid,
     deep_merge_dict,
     get_past_time_rounded,
     get_utc_offset,
@@ -84,14 +84,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def check_valid_uuid(uuid_str) -> bool:
-    with contextlib.suppress(ValueError):
-        uuid_obj = uuid.UUID(uuid_str)
-        if str(uuid_obj) == uuid_str:
-            return True
-    return False
 
 
 class JobController:
@@ -265,21 +257,14 @@ class JobController:
         db_ids = [db_ids] if isinstance(db_ids, str) else db_ids or []
 
         flow_ids = [flow_ids] if isinstance(flow_ids, str) else flow_ids or []
-        flow_uuids, flow_db_ids = [], []
-        for flow_id in flow_ids:
-            if check_valid_uuid(flow_id):
-                flow_uuids.append(flow_id)
-            else:
-                flow_db_ids.append(flow_id)
-
-        for flow_db_id in flow_db_ids:
-            flows_info = self.get_flows_info(
-                db_ids=flow_db_id,
-                limit=1,
-                full=True,  # needed?
-            )
-            if flows_info:
-                db_ids.extend(flows_info[0].db_ids)
+        flow_uuids = [
+            fid
+            if check_valid_uuid(fid)
+            else self.flows.find_one(
+                {"ids": {"$elemMatch": {"0": fid}}}, projection=["uuid"]
+            )["uuid"]
+            for fid in flow_ids
+        ]
 
         if isinstance(states, JobState):
             states = [states]

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -413,6 +413,7 @@ class JobController:
 
     def get_jobs_info(
         self,
+        custom_query: dict | None = None,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: str | list[str] | None = None,
         flow_ids: str | list[str] | None = None,
@@ -426,12 +427,15 @@ class JobController:
         sort: list[tuple[str, int]] | None = None,
         limit: int = 0,
         skip: int = 0,
+        merge_queries: bool = False,
     ) -> list[JobInfo]:
         """
         Query for Jobs based on standard parameters and return a list of JobInfo.
 
         Parameters
         ----------
+        custom_query
+            A generic query. Will override all the other parameters. Unless merge_queries is specified.
         job_ids
             One or more tuples, each containing the (uuid, index) pair of the
             Jobs to retrieve.
@@ -464,6 +468,8 @@ class JobController:
             Maximum number of entries to retrieve. 0 means no limit.
         skip
             The number of documents to omit (from the start of the result set).
+        merge_queries
+            Merge the custom query and the automatically generated query.
 
         Returns
         -------
@@ -482,6 +488,8 @@ class JobController:
             metadata=metadata,
             workers=workers,
         )
+        if custom_query:
+            query = query | custom_query if merge_queries else custom_query
         return self.get_jobs_info_query(query=query, sort=sort, limit=limit, skip=skip)
 
     def get_jobs_doc_query(self, query: dict = None, **kwargs) -> list[JobDoc]:
@@ -2888,6 +2896,7 @@ class JobController:
         name: str | None = None,
         metadata: dict | None = None,
         workers: str | list[str] | None = None,
+        merge_queries: bool = False,
     ) -> int:
         """
         Count Jobs based on filters.
@@ -2895,7 +2904,7 @@ class JobController:
         Parameters
         ----------
         query
-            A generic query. Will override all the other parameters.
+            A generic query. Will override all the other parameters. Unless merge_queries is specified.
         job_ids
             One or more tuples, each containing the (uuid, index) pair of the
             Jobs to retrieve.
@@ -2921,26 +2930,29 @@ class JobController:
             exact match for all the values provided.
         workers
             One or more worker names.
+        merge_queries
+            Merge the custom query and the automatically generated query.
 
         Returns
         -------
         int
             Number of Jobs matching the criteria.
         """
-        if query is None:
-            query = self._build_query_job(
-                job_ids=job_ids,
-                db_ids=db_ids,
-                flow_ids=flow_ids,
-                states=states,
-                locked=locked,
-                start_date=start_date,
-                end_date=end_date,
-                name=name,
-                metadata=metadata,
-                workers=workers,
-            )
-        return self.jobs.count_documents(query)
+        full_query = self._build_query_job(
+            job_ids=job_ids,
+            db_ids=db_ids,
+            flow_ids=flow_ids,
+            states=states,
+            locked=locked,
+            start_date=start_date,
+            end_date=end_date,
+            name=name,
+            metadata=metadata,
+            workers=workers,
+        )
+        if query:
+            full_query = full_query | query if merge_queries else query
+        return self.jobs.count_documents(full_query)
 
     def count_flows(
         self,

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -311,13 +311,13 @@ class JobController:
         if workers:
             query["worker"] = {"$in": workers}
 
-        custom_query_dict = custom_query or {}
-        if not set(query).isdisjoint(custom_query_dict):
+        custom_query = custom_query or {}
+        if not set(query).isdisjoint(custom_query):
             raise ValueError(
-                f"Custom_query must not overlap with other query options. Duplicates: {set(query) & set(custom_query_dict)}"
+                f"Custom_query must not overlap with other query options. Duplicates: {set(query) & set(custom_query)}"
             )
 
-        return query | custom_query_dict
+        return query | custom_query
 
     def _build_query_flow(
         self,

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -6,6 +6,7 @@ import importlib.metadata
 import logging
 import shutil
 import traceback
+import uuid
 import warnings
 from collections import defaultdict
 from contextlib import ExitStack
@@ -83,6 +84,14 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def check_valid_uuid(uuid_str) -> bool:
+    with contextlib.suppress(ValueError):
+        uuid_obj = uuid.UUID(uuid_str)
+        if str(uuid_obj) == uuid_str:
+            return True
+    return False
 
 
 class JobController:
@@ -222,7 +231,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids or DB_IDs to which the Jobs to retrieve belong.
         states
             One or more states of the Jobs.
         locked
@@ -253,10 +262,25 @@ class JobController:
         if job_ids and not any(isinstance(ji, (list, tuple)) for ji in job_ids):
             # without these cast mypy is confused about the type
             job_ids = cast(list[tuple[str, int]], [job_ids])
-        if db_ids is not None and not isinstance(db_ids, (list, tuple)):
-            db_ids = [db_ids]
-        if flow_ids and not isinstance(flow_ids, (list, tuple)):
-            flow_ids = [flow_ids]
+        db_ids = [db_ids] if isinstance(db_ids, str) else db_ids or []
+
+        flow_ids = [flow_ids] if isinstance(flow_ids, str) else flow_ids or []
+        flow_uuids, flow_db_ids = [], []
+        for flow_id in flow_ids:
+            if check_valid_uuid(flow_id):
+                flow_uuids.append(flow_id)
+            else:
+                flow_db_ids.append(flow_id)
+
+        for flow_db_id in flow_db_ids:
+            flows_info = self.get_flows_info(
+                db_ids=flow_db_id,
+                limit=1,
+                full=True,  # needed?
+            )
+            if flows_info:
+                db_ids.extend(flows_info[0].db_ids)
+
         if isinstance(states, JobState):
             states = [states]
         if isinstance(workers, str):
@@ -273,8 +297,8 @@ class JobController:
                 or_list.append({"uuid": job_id, "index": job_index})
             query["$or"] = or_list
 
-        if flow_ids:
-            query["job.hosts"] = {"$in": flow_ids}
+        if flow_uuids:
+            query["job.hosts"] = {"$in": flow_uuids}
 
         if states:
             query["state"] = {"$in": [s.value for s in states]}
@@ -450,7 +474,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         locked
@@ -546,7 +570,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         locked
@@ -750,7 +774,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             The state of the Jobs.
         locked
@@ -856,7 +880,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -1466,7 +1490,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -1632,7 +1656,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -1710,7 +1734,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -1937,7 +1961,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -2255,7 +2279,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -2581,7 +2605,7 @@ class JobController:
         Parameters
         ----------
         flow_id
-            One or more Flow uuids.
+            One Flow ids. Can be db_id or uuid.
         delete_output
             If True also delete the associated output in the JobStore.
         delete_files
@@ -2632,7 +2656,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date
@@ -3082,7 +3106,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         locked
@@ -4781,7 +4805,7 @@ class JobController:
         db_ids
             One or more db_ids of the Jobs to retrieve.
         flow_ids
-            One or more Flow uuids to which the Jobs to retrieve belong.
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
         states
             One or more states of the Jobs.
         start_date

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -208,6 +208,7 @@ class JobController:
         name: str | None,
         metadata: dict | None,
         workers: str | list[str] | None,
+        custom_query: dict | None,
     ) -> dict:
         """
         Build a query to search for Jobs, based on standard parameters.
@@ -240,6 +241,8 @@ class JobController:
             exact match for all the values provided.
         workers
             One or more worker names.
+        custom_query
+            A generic query. Keys must not overlap with other specified query options.
 
         Returns
         -------
@@ -299,7 +302,13 @@ class JobController:
         if workers:
             query["worker"] = {"$in": workers}
 
-        return query
+        custom_query_dict = custom_query or {}
+        if not set(query).isdisjoint(custom_query_dict):
+            raise ValueError(
+                f"Custom_query must not overlap with other query options. Duplicates: {set(query) & set(custom_query_dict)}"
+            )
+
+        return query | custom_query_dict
 
     def _build_query_flow(
         self,
@@ -427,7 +436,6 @@ class JobController:
         sort: list[tuple[str, int]] | None = None,
         limit: int = 0,
         skip: int = 0,
-        merge_queries: bool = False,
     ) -> list[JobInfo]:
         """
         Query for Jobs based on standard parameters and return a list of JobInfo.
@@ -435,7 +443,7 @@ class JobController:
         Parameters
         ----------
         custom_query
-            A generic query. Will override all the other parameters. Unless merge_queries is specified.
+            A generic query. Keys must not overlap with other specified query options.
         job_ids
             One or more tuples, each containing the (uuid, index) pair of the
             Jobs to retrieve.
@@ -468,8 +476,6 @@ class JobController:
             Maximum number of entries to retrieve. 0 means no limit.
         skip
             The number of documents to omit (from the start of the result set).
-        merge_queries
-            Merge the custom query and the automatically generated query.
 
         Returns
         -------
@@ -487,9 +493,8 @@ class JobController:
             name=name,
             metadata=metadata,
             workers=workers,
+            custom_query=custom_query,
         )
-        if custom_query:
-            query = query | custom_query if merge_queries else custom_query
         return self.get_jobs_info_query(query=query, sort=sort, limit=limit, skip=skip)
 
     def get_jobs_doc_query(self, query: dict = None, **kwargs) -> list[JobDoc]:
@@ -514,6 +519,7 @@ class JobController:
 
     def get_jobs_doc(
         self,
+        custom_query: dict | None = None,
         job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
         db_ids: str | list[str] | None = None,
         flow_ids: str | list[str] | None = None,
@@ -532,6 +538,8 @@ class JobController:
 
         Parameters
         ----------
+        custom_query
+            A dictionary representing the filter.
         job_ids
             One or more tuples, each containing the (uuid, index) pair of the
             Jobs to retrieve.
@@ -579,6 +587,7 @@ class JobController:
             name=name,
             metadata=metadata,
             workers=workers,
+            custom_query=custom_query,
         )
         return self.get_jobs_doc_query(query=query, sort=sort, limit=limit)
 
@@ -761,7 +770,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -776,36 +785,19 @@ class JobController:
         list
             List of db_ids of the updated Jobs.
         """
-        filtering_options = [
-            job_ids,
-            db_ids,
-            flow_ids,
-            states,
-            start_date,
-            end_date,
-            name,
-            metadata,
-            workers,
-        ]
-        if custom_query and any(opt is not None for opt in filtering_options):
-            raise ValueError(
-                "The custom query option is incompatible with all the other filtering options"
-            )
-        if custom_query:
-            query = custom_query
-        else:
-            query = self._build_query_job(
-                job_ids=job_ids,
-                db_ids=db_ids,
-                flow_ids=flow_ids,
-                states=states,
-                start_date=start_date,
-                end_date=end_date,
-                name=name,
-                metadata=metadata,
-                workers=workers,
-                locked=False,
-            )
+        query = self._build_query_job(
+            job_ids=job_ids,
+            db_ids=db_ids,
+            flow_ids=flow_ids,
+            states=states,
+            start_date=start_date,
+            end_date=end_date,
+            name=name,
+            metadata=metadata,
+            workers=workers,
+            locked=False,
+            custom_query=custom_query,
+        )
         result = self.jobs.find(query, projection=["db_id"])
 
         queried_dbs_ids = [r["db_id"] for r in result]
@@ -882,7 +874,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -1492,7 +1484,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -1658,7 +1650,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -1736,7 +1728,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -1963,7 +1955,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -2169,6 +2161,7 @@ class JobController:
                 name=None,
                 metadata=None,
                 workers=None,
+                custom_query=None,
             )
             job_db_ids_to_resume = [
                 d["db_id"] for d in self.jobs.find(jobs_filter, projection=["db_id"])
@@ -2280,7 +2273,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.
@@ -2673,6 +2666,7 @@ class JobController:
             name=name,
             metadata=metadata,
             workers=workers,
+            custom_query=None,
         )
 
         result = self.jobs.update_many(
@@ -3074,7 +3068,6 @@ class JobController:
         name: str | None = None,
         metadata: dict | None = None,
         workers: str | list[str] | None = None,
-        merge_queries: bool = False,
     ) -> int:
         """
         Count Jobs based on filters.
@@ -3082,7 +3075,7 @@ class JobController:
         Parameters
         ----------
         query
-            A generic query. Will override all the other parameters. Unless merge_queries is specified.
+            A generic query.
         job_ids
             One or more tuples, each containing the (uuid, index) pair of the
             Jobs to retrieve.
@@ -3108,8 +3101,6 @@ class JobController:
             exact match for all the values provided.
         workers
             One or more worker names.
-        merge_queries
-            Merge the custom query and the automatically generated query.
 
         Returns
         -------
@@ -3127,9 +3118,8 @@ class JobController:
             name=name,
             metadata=metadata,
             workers=workers,
+            custom_query=query,
         )
-        if query:
-            full_query = full_query | query if merge_queries else query
         return self.jobs.count_documents(full_query)
 
     def count_flows(
@@ -4809,7 +4799,7 @@ class JobController:
         workers
             One or more worker names.
         custom_query
-            A generic query. Incompatible with all the other filtering options.
+            A generic query. Keys must not overlap with other specified query options.
         raise_on_error
             If True raise in case of error on one job error and stop the loop.
             Otherwise, just log the error and proceed.

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import os
+import uuid
 from collections.abc import Mapping, MutableMapping
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -239,3 +241,24 @@ def suuid() -> str:
     from uuid import uuid4
 
     return str(uuid4())
+
+
+def check_valid_uuid(uuid_str: str) -> bool:
+    """
+    Check if the given uuid is valid.
+
+    Parameters
+    ----------
+    uuid_str
+        The uuid string to check.
+
+    Returns
+    -------
+    bool
+        True if the given uuid is valid, False otherwise.
+    """
+    with contextlib.suppress(ValueError):
+        uuid_obj = uuid.UUID(uuid_str)
+        if str(uuid_obj) == uuid_str:
+            return True
+    return False

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -68,6 +68,11 @@ def test_jobs_list(job_controller, two_flows_four_jobs, patch_cli_consoles) -> N
     run_check_cli(
         ["job", "list", "-fid", "1", "--count"], required_out="Number of jobs: 2"
     )
+    second_flow_uuid = two_flows_four_jobs[1].uuid
+    run_check_cli(
+        ["job", "list", "-fid", "1", "-fid", second_flow_uuid, "--count"],
+        required_out="Number of jobs: 4",
+    )
 
     # trigger the additional information
     assert job_controller.set_job_state(JobState.REMOTE_ERROR, db_id="1")

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -65,6 +65,9 @@ def test_jobs_list(job_controller, two_flows_four_jobs, patch_cli_consoles) -> N
         ],
         required_out="Number of jobs: 1",
     )
+    run_check_cli(
+        ["job", "list", "-fid", "1", "--count"], required_out="Number of jobs: 2"
+    )
 
     # trigger the additional information
     assert job_controller.set_job_state(JobState.REMOTE_ERROR, db_id="1")

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -30,6 +30,41 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
         ["job", "list", "-q", '{"db_id": "1"}', "--count"],
         required_out="Number of jobs: 1",
     )
+    run_check_cli(
+        ["job", "list", "-q", '{"db_id": {"$in": ["1", "2"]}}', "--count"],
+        required_out="Number of jobs: 2",
+    )
+    run_check_cli(
+        ["job", "list", "-q", '{"db_id": {"$in": ["1", "2"]}}', "-did", "1"],
+        error=True,
+    )
+    run_check_cli(
+        [
+            "job",
+            "list",
+            "-q",
+            '{"db_id": {"$in": ["1", "2"]}}',
+            "--count",
+            "-s",
+            "READY",
+            "-mq",
+        ],
+        required_out="Number of jobs: 1",
+    )
+    # check that duplicate query is overwritten
+    run_check_cli(
+        [
+            "job",
+            "list",
+            "-q",
+            '{"db_id": {"$in": ["1", "2"]}}',
+            "--count",
+            "-did",
+            "1",
+            "-mq",
+        ],
+        required_out="Number of jobs: 2",
+    )
 
     # trigger the additional information
     assert job_controller.set_job_state(JobState.REMOTE_ERROR, db_id="1")

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -51,6 +51,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs, patch_cli_consoles) -> N
     run_check_cli(
         ["job", "list", "-q", '{"db_id": {"$in": ["1", "2"]}}', "-did", "1"],
         error=True,
+        required_out="Custom_query must not overlap with other query options. Duplicates: {'db_id'}",
     )
     run_check_cli(
         [
@@ -61,23 +62,8 @@ def test_jobs_list(job_controller, two_flows_four_jobs, patch_cli_consoles) -> N
             "--count",
             "-s",
             "READY",
-            "-mq",
         ],
         required_out="Number of jobs: 1",
-    )
-    # check that duplicate query is overwritten
-    run_check_cli(
-        [
-            "job",
-            "list",
-            "-q",
-            '{"db_id": {"$in": ["1", "2"]}}',
-            "--count",
-            "-did",
-            "1",
-            "-mq",
-        ],
-        required_out="Number of jobs: 2",
     )
 
     # trigger the additional information

--- a/tests/db/utils/test_data.py
+++ b/tests/db/utils/test_data.py
@@ -61,3 +61,12 @@ def test_get_utc_offset():
     assert get_utc_offset("Asia/Shanghai") == "+08:00"
     with pytest.raises(ValueError, match="Could not determine the timezone for XXX"):
         get_utc_offset("XXX")
+
+
+def test_check_valid_uuid():
+    from jobflow_remote.utils.data import check_valid_uuid
+
+    assert check_valid_uuid("3140") is False
+    assert check_valid_uuid("abc-3140") is False
+    assert check_valid_uuid("bb4ab187-9b4b-470e-a0f2-483e2e0c0332") is True
+    assert check_valid_uuid("d0c2274c-ad5a-45e2-b5ae-0524a107f7b7") is True


### PR DESCRIPTION
Enables the use of a custom_query AND other query-options in the `jf job list` command. This is controlled by a new option `merge_queries`.

Is there a reason why this is not a good idea? It seems to work for me just fine.

For the reason of completeness one might need to transfer this also to other cli commands.