### PR TITLE
Dw/test cli colors

### DIFF
--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-err_console = Console(force_terminal=True, stderr=True)
-out_console = Console(force_terminal=True)
+err_console = Console(stderr=True)
+out_console = Console()
 
 
 fmt_datetime = "%Y-%m-%d %H:%M"

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-err_console = Console(stderr=True)
-out_console = Console()
+err_console = Console(force_terminal=True, stderr=True)
+out_console = Console(force_terminal=True)
 
 
 fmt_datetime = "%Y-%m-%d %H:%M"

--- a/src/jobflow_remote/testing/cli.py
+++ b/src/jobflow_remote/testing/cli.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import io
 import re
 from typing import IO, TYPE_CHECKING, Any
 
+from rich.console import Console
+from rich.text import Text
 from typer.testing import CliRunner, Result
 
 from jobflow_remote.cli.jf import app
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+
+
+ansi_esc_pattern = re.compile(r"\x1B\[\d+(;\d+){0,2}m")
 
 
 def run_check_cli(
@@ -18,6 +24,7 @@ def run_check_cli(
     catch_exceptions: bool = False,
     required_out: str | Sequence[str] | None = None,
     excluded_out: str | Sequence[str] | None = None,
+    required_out_colored: str | Sequence[str] | None = None,
     error: bool = False,
     terminal_width: int = 1000,
 ) -> Result:
@@ -25,6 +32,8 @@ def run_check_cli(
         required_out = [required_out]
     if isinstance(excluded_out, str):
         excluded_out = [excluded_out]
+    if isinstance(required_out_colored, str):
+        required_out_colored = [required_out_colored]
 
     cli_runner = CliRunner()
 
@@ -51,18 +60,36 @@ def run_check_cli(
 
     # The print of the output in the console during the tests may result in newlines added
     # that prevent the output to be matched. replace all spaces with a single space.
-    single_space_output = re.sub(r"[\n\t\s]*", " ", result_out)
+    single_space_output = re.sub(r"\s+", " ", result_out)
+    # Remove ansi escape codes
+    single_space_output_no_ansi_esc = ansi_esc_pattern.sub("", single_space_output)
+    # Remove again multiple spaces. This is needed otherwise we can sometimes (??) have 2 spaces
+    # when ansi escape codes have been removed)
+    single_space_output_no_ansi_esc = re.sub(
+        r"\s+", " ", single_space_output_no_ansi_esc
+    )
 
     if required_out:
         for ro in required_out:
-            assert (
-                re.sub(r"[\n\t\s]*", " ", ro) in single_space_output
+            assert re.sub(r"\s+", " ", ro) in repr(
+                single_space_output_no_ansi_esc
             ), f"{ro} missing from stdout: {result_out}"
 
     if excluded_out:
         for eo in excluded_out:
             assert (
-                re.sub(r"[\n\t\s]*", " ", eo) not in single_space_output
+                re.sub(r"\s+", " ", eo) not in single_space_output_no_ansi_esc
             ), f"{eo} present in stdout: {result_out}"
+
+    if required_out_colored:
+        for roc in required_out_colored:
+            roc_text = Text.from_markup(roc)
+            buf = io.StringIO()
+            console = Console(file=buf, force_terminal=True, color_system="truecolor")
+            console.print(roc_text, end="")
+            roc_string = buf.getvalue()
+            assert (
+                re.sub(r"\s+", " ", roc_string) in single_space_output
+            ), f'"{roc_string}" ({roc}) missing from stdout: {result_out}'
 
     return result

--- a/src/jobflow_remote/testing/cli.py
+++ b/src/jobflow_remote/testing/cli.py
@@ -44,6 +44,7 @@ def run_check_cli(
         env=cli_env,
         catch_exceptions=catch_exceptions,
         terminal_width=terminal_width,
+        color=True,
     )
 
     # Since typer 0.16.0 and click 8.2 the stderr is necessarily separated from the output.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 from rich.console import Console
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def patch_cli_consoles(monkeypatch):
     import jobflow_remote.cli
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import logging.config
 import random
@@ -7,6 +8,22 @@ from functools import partial
 from pathlib import Path
 
 import pytest
+from rich.console import Console
+
+
+@pytest.fixture(autouse=True)
+def patch_cli_consoles(monkeypatch):
+    import jobflow_remote.cli
+
+    err_console = Console(force_terminal=True, stderr=True)
+    out_console = Console(force_terminal=True)
+    # The out_console and err_console have to be patched everywhere they are imported
+    # Doing this only for the cli
+    for _mod_name, module in inspect.getmembers(jobflow_remote.cli, inspect.ismodule):
+        if hasattr(module, "err_console"):
+            monkeypatch.setattr(module, "err_console", err_console)
+        if hasattr(module, "out_console"):
+            monkeypatch.setattr(module, "out_console", out_console)
 
 
 @pytest.fixture(scope="session")

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -1,7 +1,7 @@
 import os
 
 
-def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
+def test_jobs_list(job_controller, two_flows_four_jobs, patch_cli_consoles) -> None:
     from jobflow_remote.jobs.state import JobState
     from jobflow_remote.testing.cli import run_check_cli
 

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -19,6 +19,17 @@ def test_jobs_list(job_controller, two_flows_four_jobs) -> None:
     # not checking that the output is actually colored. Just check that runs correctly
     run_check_cli(["job", "list", "--color"], required_out=outputs)
 
+    run_check_cli(
+        ["job", "list", "--color"],
+        required_out=outputs,
+        required_out_colored=[
+            "[green]add1[/green]",
+            "[green]add2[/green]",
+            "[red]add3[/red]",
+            "[red]add4[/red]",
+        ],
+    )
+
     outputs = ["add1", "READY"]
     excluded = [f"add{i}" for i in range(2, 5)]
     run_check_cli(

--- a/tests/unit/testing/test_cli.py
+++ b/tests/unit/testing/test_cli.py
@@ -4,7 +4,7 @@ from typer.testing import Result
 from jobflow_remote.testing.cli import run_check_cli
 
 
-def test_run_check_cli():
+def test_run_check_cli(patch_cli_consoles):
     # Check multiple lines is found
     flow_excerpt = """├── flow: Commands for managing the flows
 │   ├── delete: Permanently delete Flows from the database

--- a/tests/unit/testing/test_cli.py
+++ b/tests/unit/testing/test_cli.py
@@ -1,0 +1,56 @@
+import pytest
+from typer.testing import Result
+
+from jobflow_remote.testing.cli import run_check_cli
+
+
+def test_run_check_cli():
+    # Check multiple lines is found
+    flow_excerpt = """├── flow: Commands for managing the flows
+│   ├── delete: Permanently delete Flows from the database
+│   ├── graph: Provide detailed information on a Flow.
+│   ├── info: Provide detailed information on a Flow.
+│   ├── list: Get the list of Flows in the database."""
+    res = run_check_cli(
+        ["--tree"], required_out=["flow: Commands for managing the flows", flow_excerpt]
+    )
+    assert isinstance(res, Result)
+    assert res.exit_code == 0
+
+    # Check exclusion
+    with pytest.raises(
+        AssertionError, match=r"flow: Commands for managing the flows present in stdout"
+    ):
+        run_check_cli(
+            ["--tree"], excluded_out=["flow: Commands for managing the flows"]
+        )
+
+    # Check with some additional spaces
+    with pytest.raises(
+        AssertionError,
+        match=r"flow:   Commands for managing the \nflows present in stdout",
+    ):
+        run_check_cli(
+            ["--tree"], excluded_out=["flow:   Commands for managing the \nflows"]
+        )
+
+    run_check_cli(["--tree"], required_out_colored="[bold red]jf[/bold red]")
+
+    with pytest.raises(AssertionError):
+        run_check_cli(["--tree"], required_out_colored="[green]jf[/green]")
+
+    run_check_cli(
+        ["--tree"],
+        required_out_colored="[bold green]job[/bold green]: Commands for   managing the jobs",
+    )
+
+    with pytest.raises(AssertionError):
+        run_check_cli(
+            ["--tree"], required_out_colored="job: Commands for managing the jobs"
+        )
+
+    with pytest.raises(AssertionError):
+        run_check_cli(
+            ["--tree"],
+            required_out_colored="[bold green]job[/bold green]: Commands [red]for[/red] managing the jobs",
+        )


### PR DESCRIPTION
Some fix (to be checked?) of run_check_cli: the replace of spaces was putting a space between every character, not just replacing multiple spaces with only one.
Added possibility to check for colors using markup language on the text (separate argument from the "standard" required_out).
Added tests.