### PR TITLE
Optional jobstores

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -406,3 +406,37 @@ def resume(
         )
 
     out_console.print(f"{n_jobs} Job(s) resumed")
+
+
+app_flow_set = JFRTyper(
+    name="set", help="Commands for setting properties for flows", no_args_is_help=True
+)
+app_flow.add_typer(app_flow_set)
+
+
+@app_flow_set.command()
+def store(
+    flow_db_id: flow_db_id_arg,
+    store: Annotated[
+        Optional[str],
+        typer.Argument(
+            help="The name of the Store to be set. If empty will set the default JobStore",
+            metavar="STORE",
+        ),
+    ] = None,
+    job_id_flag: job_flow_id_flag_opt = False,
+) -> None:
+    """Provide detailed information on a Flow."""
+    db_id = job_id = flow_id = None
+    db_id, jf_id = get_job_db_ids(flow_db_id, None)
+    if db_id is None:
+        if job_id_flag:
+            job_id = jf_id
+        else:
+            flow_id = jf_id
+
+    with loading_spinner():
+        jc = get_job_controller()
+
+        jc.set_flow_store(store=store, flow_id=flow_id, db_id=db_id, job_id=job_id)
+    out_console.print("Flow has been updated")

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1255,19 +1255,9 @@ def output(
     with loading_spinner():
         jc = get_job_controller()
 
-        if db_id:
-            job_info = jc.get_job_info(
-                job_id=job_id,
-                job_index=job_index,
-                db_id=db_id,
-            )
-            if job_info:
-                job_id = job_info.uuid
-                job_index = job_info.index
-
-        job_output = None
-        if job_id:
-            job_output = jc.jobstore.get_output(job_id, job_index or "last", load=load)
+        job_output = jc.get_job_output(
+            db_id=db_id, job_id=job_id, job_index=job_index, load=load
+        )
 
     if not job_output:
         exit_with_error_msg("No data matching the request")

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -236,6 +236,18 @@ def check(
                 header = cross
             progress.print(Text.from_markup(header + "Jobstore"))
 
+            if project.optional_jobstores:
+                progress.update(task_id, description="Checking optional jobstores")
+                for jobstore_name in project.optional_jobstores:
+                    err = check_jobstore(project.get_jobstore(jobstore_name))
+                    header = tick
+                    if err:
+                        errors.append((f"Jobstore {jobstore_name}", err))
+                        header = cross
+                    progress.print(
+                        Text.from_markup(header + f"Optional jobstore {jobstore_name}")
+                    )
+
         if check_all or queue:
             progress.update(task_id, description="Checking queue store")
             err = check_queue_store(project.get_queue_store())

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -585,20 +585,39 @@ class Project(BaseModel):
     metadata: Optional[dict] = Field(
         None, description="A dictionary with metadata associated to the project"
     )
+    optional_jobstores: Optional[dict[str, dict]] = Field(
+        default_factory=dict,
+        description="A dictionary of optional JobStores that can be use to store "
+        "outputs instead of the default jobstore. The key is the name used to "
+        "refer to the JobStore.",
+    )
 
-    def get_jobstore(self) -> Optional[JobStore]:
+    def get_jobstore(self, name: Optional[str] = None) -> Optional[JobStore]:
         """
         Generate an instance of the JobStore based on the configuration.
+
+        Parameters
+        ----------
+        name
+            name of the JobStore to fetch. If None the default JobStore,
+            otherwise one of the optional_jobstores.
 
         Returns
         -------
         A JobStore
         """
-        if not self.jobstore:
-            return None
+
+        if name:
+            if name not in self.optional_jobstores:
+                raise ValueError(f"No JobStore named {name} defined in the project.")
+            jobstore_dict = self.optional_jobstores[name]
+        else:
+            if not self.jobstore:
+                return None
+            jobstore_dict = self.jobstore
         if self.jobstore.get("@class") == "JobStore":
-            return JobStore.from_dict(self.jobstore)
-        return JobStore.from_dict_spec(self.jobstore)
+            return JobStore.from_dict(jobstore_dict)
+        return JobStore.from_dict_spec(jobstore_dict)
 
     def get_queue_store(self):
         """
@@ -664,6 +683,23 @@ class Project(BaseModel):
                     f"error while converting jobstore to JobStore. Error: {traceback.format_exc()}"
                 ) from e
         return jobstore
+
+    @field_validator("optional_jobstores")
+    @classmethod
+    def check_optional_jobstore(cls, optional_jobstores: dict) -> dict:
+        """Check that the jobstore configuration could be converted to a JobStore."""
+        if optional_jobstores:
+            for name, jobstore_dict in optional_jobstores.items():
+                try:
+                    if jobstore_dict.get("@class") == "JobStore":
+                        JobStore.from_dict(jobstore_dict)
+                    else:
+                        JobStore.from_dict_spec(jobstore_dict)
+                except Exception as e:
+                    raise ValueError(
+                        f"error while converting optional jobstore to JobStore: {name}. Error: {traceback.format_exc()}"
+                    ) from e
+        return optional_jobstores
 
     @property
     def has_interactive_workers(self) -> bool:

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -78,7 +78,9 @@ def get_initial_job_doc_dict(
     return job_doc.as_db_dict()
 
 
-def get_initial_flow_doc_dict(flow: Flow, job_dicts: list[dict]) -> dict:
+def get_initial_flow_doc_dict(
+    flow: Flow, job_dicts: list[dict], jobstore: Optional[str] = None
+) -> dict:
     """
     Generate a serialized FlowDoc for initial insertion in the DB.
 
@@ -88,6 +90,9 @@ def get_initial_flow_doc_dict(flow: Flow, job_dicts: list[dict]) -> dict:
         The Flow used to generate the FlowDoc.
     job_dicts
         The dictionaries of the Jobs composing the Flow.
+    jobstore
+        The name of the JobStore used for the output of the submitted Flow.
+        If None the default is used.
 
     Returns
     -------
@@ -106,6 +111,7 @@ def get_initial_flow_doc_dict(flow: Flow, job_dicts: list[dict]) -> dict:
         ids=ids,
         parents=parents,
         metadata=flow.metadata or {},
+        jobstore=jobstore,
     )
 
     return flow_doc.as_db_dict()
@@ -312,6 +318,7 @@ class FlowDoc(BaseModel):
     parents: dict[str, dict[str, list[str]]] = Field(default_factory=dict)
     # ids correspond to db_id, uuid, index for each JobDoc
     ids: list[tuple[str, str, int]] = Field(default_factory=list)
+    jobstore: Optional[str] = None
 
     def as_db_dict(self) -> dict:
         """

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2589,11 +2589,12 @@ class JobController:
             The uuid of the Flow.
 
         """
+        if store and store not in self.optional_jobstores:
+            raise ValueError(f"Store {store} is not defined as an optional jobstore")
+
         filter_query = self.generate_flow_id_query(
             db_id=db_id, job_id=job_id, flow_id=flow_id
         )
-        if store and store not in self.optional_jobstores:
-            raise ValueError(f"Store {store} is not defined as an optional jobstore")
         with self.lock_flow(
             filter=filter_query, get_locked_doc=True, projection=["state"]
         ) as flow_lock:
@@ -2689,8 +2690,8 @@ class JobController:
         job_ids = flow["jobs"]
         if delete_output:
             jobstore = self.jobstore
-            if flow.get("jobstore"):
-                jobstore = self.optional_jobstores[flow["jobstore"]]
+            if jobstore_name := flow.get("jobstore"):
+                jobstore = self.optional_jobstores[jobstore_name]
             jobstore.remove_docs({"uuid": {"$in": job_ids}})
         if delete_files:
             jobs_info = self.get_jobs_info(flow_ids=[flow_id])

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -79,8 +79,14 @@ from jobflow_remote.utils.remote import SharedHosts, safe_remove_job_files
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Sequence
+    from enum import Enum
+    from typing import Union
 
     from maggma.stores import MongoStore
+    from monty.json import MSONable
+
+    obj_type = Union[str, Enum, type[MSONable], list[Union[Enum, str, type[MSONable]]]]
+    load_type = Union[bool, dict[str, Union[bool, obj_type]]]
 
 
 logger = logging.getLogger(__name__)
@@ -105,6 +111,7 @@ class JobController:
         flows_collection: str = "flows",
         auxiliary_collection: str = "jf_auxiliary",
         project: Project | None = None,
+        optional_jobstores: dict[str, JobStore] | None = None,
     ) -> None:
         """
         Parameters
@@ -123,15 +130,20 @@ class JobController:
             Uses the DB defined in the queue_store.
         project
             The project where the Stores were defined.
+        optional_jobstores
+            A dictionary of optional JobStores as defined in the project.
         """
         self.queue_store = queue_store
         self.jobstore = jobstore
         self.jobs_collection = self.queue_store.collection_name
         self.flows_collection = flows_collection
         self.auxiliary_collection = auxiliary_collection
+        self.optional_jobstores = optional_jobstores or {}
         # TODO should it connect here? Or the passed stores should be connected?
         self.queue_store.connect()
         self.jobstore.connect()
+        for opt_js in self.optional_jobstores.values():
+            opt_js.connect()
         self.db = self.queue_store._collection.database
         self.jobs = self.queue_store._collection
         self.flows = self.db[self.flows_collection]
@@ -177,12 +189,17 @@ class JobController:
         flows_collection = project.queue.flows_collection
         auxiliary_collection = project.queue.auxiliary_collection
         jobstore = project.get_jobstore()
+        optional_jobstores = {}
+        if project.optional_jobstores:
+            for js_name in project.optional_jobstores:
+                optional_jobstores[js_name] = project.get_jobstore(name=js_name)
         return cls(
             queue_store=queue_store,
             jobstore=jobstore,
             flows_collection=flows_collection,
             auxiliary_collection=auxiliary_collection,
             project=project,
+            optional_jobstores=optional_jobstores,
         )
 
     def close(self) -> None:
@@ -196,6 +213,14 @@ class JobController:
             self.jobstore.close()
         except Exception:
             logger.exception("Error while closing the connection to the job store")
+
+        for js_name, js in self.optional_jobstores.items():
+            try:
+                js.close()
+            except Exception:
+                logger.exception(
+                    f"Error while closing the connection to the optional job store {js_name}"
+                )
 
     def _build_query_job(
         self,
@@ -2519,6 +2544,71 @@ class JobController:
 
         return [FlowInfo.from_query_dict(d) for d in data]
 
+    def get_flow_store(self, flow_id: str) -> str | None:
+        """
+        Fetch the name of the optional JobStore to store the outputs
+        of a Flow, if defined.
+
+        Parameters
+        ----------
+        flow_id
+            The uuid of the Flow
+        Returns
+        -------
+        str
+            The name of one of the optional JobStores to be used.
+            None if the default should be used.
+        """
+        out = self.flows.find_one({"uuid": flow_id}, projection=["jobstore"])
+        if not out:
+            raise ValueError(f"No Flow matching id {flow_id}")
+        return out.get("jobstore") or None
+
+    def set_flow_store(
+        self,
+        store: str | None,
+        db_id: str | None = None,
+        job_id: str | None = None,
+        flow_id: str | None = None,
+    ) -> None:
+        """
+        Set the name of the optional JobStore to store the outputs
+        of a Flow. If None the default JobStore will be used.
+        Can be changed only for READY Flows.
+
+        Parameters
+        ----------
+        store
+            The name of one of the optional JobStores. If None sets to the
+            default JobStore.
+        db_id
+            The db_id of one Job belonging to the Flow.
+        job_id
+            The uuid of one Job belonging to the Flow.
+        flow_id
+            The uuid of the Flow.
+
+        """
+        filter_query = self.generate_flow_id_query(
+            db_id=db_id, job_id=job_id, flow_id=flow_id
+        )
+        if store and store not in self.optional_jobstores:
+            raise ValueError(f"Store {store} is not defined as an optional jobstore")
+        with self.lock_flow(
+            filter=filter_query, get_locked_doc=True, projection=["state"]
+        ) as flow_lock:
+            if not flow_lock.locked_document:
+                if flow_lock.unavailable_document:
+                    raise FlowLockedError.from_flow_doc(flow_lock.unavailable_document)
+                raise ValueError(f"No Flow document matching criteria {filter_query}")
+            if FlowState(flow_lock.locked_document["state"]) != FlowState.READY:
+                raise RuntimeError("The JobStore can be set only for a READY Flow")
+            flow_lock.update_on_release = {
+                "$set": {
+                    "jobstore": store,
+                }
+            }
+
     def delete_flows(
         self,
         flow_ids: str | list[str] | None = None,
@@ -2598,7 +2688,10 @@ class JobController:
             return False
         job_ids = flow["jobs"]
         if delete_output:
-            self.jobstore.remove_docs({"uuid": {"$in": job_ids}})
+            jobstore = self.jobstore
+            if flow.get("jobstore"):
+                jobstore = self.optional_jobstores[flow["jobstore"]]
+            jobstore.remove_docs({"uuid": {"$in": job_ids}})
         if delete_files:
             jobs_info = self.get_jobs_info(flow_ids=[flow_id])
             self._safe_delete_files(jobs_info)
@@ -2837,6 +2930,8 @@ class JobController:
 
         if reset_output:
             self.jobstore.remove_docs({})
+            for opt_jobstore in self.optional_jobstores.values():
+                opt_jobstore.remove_docs({})
 
         self.jobs.drop()
         self.flows.drop()
@@ -2937,31 +3032,38 @@ class JobController:
             for idx in flow_custom_indexes:
                 self.flows.create_index(idx, background=background)
 
-        # if the docs_store is a MongoStore with a collection, create a proper composed
-        # index that is the most effective for retrieving outputs. Otherwise create a simple
-        # index based on the maggma interface for the two indexes separately.
-        # In any case trap all exceptions, as this should not be a blocking point
-        try:
-            docs_store = self.jobstore.docs_store
-            if hasattr(docs_store, "_collection"):
-                if drop:
-                    docs_store._collection.drop_indexes()
-                docs_store._collection.create_index(
-                    [("uuid", 1), ("index", -1)], background=background
-                )
-            else:
-                docs_store.ensure_index("uuid")
-                docs_store.ensure_index("index")
-        except Exception:
-            logger.warning("Could not create the index for the JobStore", exc_info=True)
-        # Use the standard interface to create an index for the additional stores
-        for store_name, additional_store in self.jobstore.additional_stores.items():
+        def create_jobstore_indices(jobstore: JobStore, name: str):
+            # if the docs_store is a MongoStore with a collection, create a proper composed
+            # index that is the most effective for retrieving outputs. Otherwise create a simple
+            # index based on the maggma interface for the two indexes separately.
+            # In any case trap all exceptions, as this should not be a blocking point
             try:
-                additional_store.ensure_index("blob_uuid")
+                docs_store = jobstore.docs_store
+                if hasattr(docs_store, "_collection"):
+                    if drop:
+                        docs_store._collection.drop_indexes()
+                    docs_store._collection.create_index(
+                        [("uuid", 1), ("index", -1)], background=background
+                    )
+                else:
+                    docs_store.ensure_index("uuid")
+                    docs_store.ensure_index("index")
             except Exception:
                 logger.warning(
-                    f"Could not create the blob_uuid index for additional store {store_name}"
+                    f"Could not create the index for the {name} JobStore", exc_info=True
                 )
+            # Use the standard interface to create an index for the additional stores
+            for store_name, additional_store in jobstore.additional_stores.items():
+                try:
+                    additional_store.ensure_index("blob_uuid")
+                except Exception:
+                    logger.warning(
+                        f"Could not create the blob_uuid index for additional store {store_name} in {name} Jobstore"
+                    )
+
+        create_jobstore_indices(self.jobstore, "default")
+        for jobstore_name, jobstore in self.optional_jobstores.items():
+            create_jobstore_indices(jobstore, jobstore_name)
 
     def create_indexes(
         self,
@@ -3408,6 +3510,7 @@ class JobController:
         exec_config: ExecutionConfig | None = None,
         resources: dict | QResources | None = None,
         priority: int = 0,
+        jobstore: str | None = None,
     ) -> list[str]:
         from jobflow.core.flow import get_flow
 
@@ -3445,7 +3548,7 @@ class JobController:
                 )
             )
 
-        flow_doc = get_initial_flow_doc_dict(flow, job_dicts)
+        flow_doc = get_initial_flow_doc_dict(flow, job_dicts, jobstore=jobstore)
 
         # inserting first the flow document and, iteratively, all the jobs
         # should not lead to inconsistencies in the states, even if one of
@@ -3689,8 +3792,6 @@ class JobController:
 
         return reserved_uuid, reserved_index
 
-    # TODO if jobstore is not an option anymore, the "store" argument
-    # can be removed and just use self.jobstore.
     def complete_job(
         self, job_doc: dict, local_path: Path | str, store: JobStore
     ) -> bool:
@@ -4760,9 +4861,13 @@ class JobController:
 
             # Optionally delete from jobstore
             if delete_output:
+                jobstore = self.jobstore
+                if self.optional_jobstores:
+                    store_name = self.get_flow_store(job_doc["job"]["hosts"][-1])
+                    if store_name:
+                        jobstore = self.optional_jobstores[store_name]
                 try:
-                    if delete_output:
-                        self.jobstore.remove_docs({"uuid": job_id, "index": job_index})
+                    jobstore.remove_docs({"uuid": job_id, "index": job_index})
                 except Exception:
                     warnings.warn(
                         f"Error while delete the output of job {job_id} {job_index}",
@@ -4867,6 +4972,61 @@ class JobController:
                 delete_files=delete_files,
                 max_limit=max_limit,
             )
+
+    def get_job_output(
+        self,
+        job_id: str | None = None,
+        db_id: str | None = None,
+        job_index: int | None = None,
+        load: load_type = False,
+    ) -> Any:
+        """
+        Get the output of a single Job based on db_id or uuid+index.
+        Only one among db_id and job_id should be defined.
+
+        Parameters
+        ----------
+        db_id
+            The db_id of the Job.
+        job_id
+            The uuid of the Job.
+        job_index
+            The index of the Job. If None the Job with the largest index
+            will be selected.
+        load
+            Which items to load from additional stores. Setting to ``True`` will load
+            all items stored in additional stores. See the ``JobStore`` constructor for
+            more details.
+
+        Returns
+        -------
+        Any
+            The output(s) for the job
+        """
+        job_info = None
+        if db_id:
+            job_info = self.get_job_info(
+                job_id=job_id,
+                job_index=job_index,
+                db_id=db_id,
+            )
+            if not job_info:
+                raise ValueError(f"No Job with db_id {db_id}")
+            job_id = job_info.uuid
+            job_index = job_info.index
+
+        jobstore = self.jobstore
+        # if jobstore are defined need to check which JobStore to use
+        if self.optional_jobstores:
+            if not job_info:
+                job_info = self.get_job_info(
+                    job_id=job_id,
+                    job_index=job_index,
+                )
+            jobstore_name = self.get_flow_store(job_info.hosts[-1])
+            if jobstore_name:
+                jobstore = self.optional_jobstores[jobstore_name]
+        return jobstore.get_output(job_id, job_index or "last", load=load)
 
     def backup_dump(
         self,

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -858,7 +858,7 @@ class Runner:
         worker = self.get_worker(doc["worker"])
         if not worker.is_local:
             host = self.get_host(doc["worker"])
-            store = self.get_jobstore(doc["hosts"][-1])
+            store = self.get_jobstore(job_dict["hosts"][-1])
 
             remote_path = doc["run_dir"]
             local_path = get_local_data_path(

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -10,7 +10,7 @@ import signal
 import time
 import traceback
 import uuid
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -48,6 +48,8 @@ from jobflow_remote.utils.remote import UnsafeDeletionError, safe_remove_job_fil
 from jobflow_remote.utils.schedule import SafeScheduler
 
 if TYPE_CHECKING:
+    from jobflow.core.store import JobStore
+
     from jobflow_remote.remote.host import BaseHost
     from jobflow_remote.utils.db import MongoLock
 
@@ -138,6 +140,14 @@ class Runner:
         # How to deal with cases where the connection gets closed?
         # how to deal with file based stores?
         self.jobstore = self.project.get_jobstore()
+        self.optional_jobstores = {}
+        if self.project.optional_jobstores:
+            self.optional_jobstores = {
+                name: self.project.get_jobstore(name)
+                for name in self.project.optional_jobstores
+            }
+        # create a cached for the jobstores to be used in the get_jobstore method
+        self._cached_jostores: OrderedDict[str, JobStore] = OrderedDict()
 
         if connect_interactive:
             for host_name, host in self.hosts.items():
@@ -220,6 +230,47 @@ class Runner:
                 worker.get_scheduler_io(), self.get_host(worker_name)
             )
         return self.queue_managers[worker_name]
+
+    def get_jobstore(self, flow_id: str | None) -> JobStore:
+        """
+        Get the JobStore associated to a Flow.
+
+        Uses a small internal cache to reduce the calls to the DB, assuming
+        that not too many Flows will be updated at the same time.
+
+        Parameters
+        ----------
+        flow_id
+            The uuid of the Flow.
+
+        Returns
+        -------
+        JobStore
+            The JobStore associated to a Flow.
+        """
+        # A simple manual cache based on an OrderedDict is used here.
+        # The lru_cache decorator is discouraged since it will prevent
+        # garbage collection of the object. In principle this is likely
+        # not an issue for the Runner, but to avoid potential issues it is
+        # not used.
+        # Other packages exist that offer these functionalities (e.g. cachetools),
+        # but adding a dependence for this trivial caching seems an overkill.
+        # Note that an OrderedDict is needed because popitem() for a standard
+        # dict does not have the `last` argument.
+        if flow_id in self._cached_jostores:
+            return self._cached_jostores[flow_id]
+        jobstore = self.jobstore
+        if flow_id and self.optional_jobstores:
+            store_name = self.job_controller.get_flow_store(flow_id=flow_id)
+            if store_name:
+                jobstore = self.optional_jobstores[store_name]
+
+        self._cached_jostores[flow_id] = jobstore
+
+        if len(self._cached_jostores) > 20:
+            self._cached_jostores.popitem(last=False)
+
+        return jobstore
 
     def run(
         self,
@@ -621,7 +672,8 @@ class Runner:
                     no_retry=False,
                 ) from e
 
-        store = self.jobstore
+        store = self.get_jobstore(job_dict["hosts"][-1])
+
         # TODO would it be better/feasible to keep a pool of the required
         # Stores already connected, to avoid opening and closing them?
         store.connect()
@@ -806,7 +858,7 @@ class Runner:
         worker = self.get_worker(doc["worker"])
         if not worker.is_local:
             host = self.get_host(doc["worker"])
-            store = self.jobstore
+            store = self.get_jobstore(doc["hosts"][-1])
 
             remote_path = doc["run_dir"]
             local_path = get_local_data_path(
@@ -883,7 +935,7 @@ class Runner:
         )
 
         try:
-            store = self.jobstore
+            store = self.get_jobstore(doc["job"]["hosts"][-1])
             completed = self.job_controller.complete_job(doc, local_path, store)
 
         except json.JSONDecodeError as exc:
@@ -1301,5 +1353,14 @@ class Runner:
             self.jobstore.close()
         except Exception:
             logging.exception("error while closing connection to jobstore")
+
+        if self.optional_jobstores:
+            for name, optional_jobstore in self.optional_jobstores.items():
+                try:
+                    optional_jobstore.close()
+                except Exception:
+                    logging.exception(
+                        f"error while closing connection to optional jobstore {name}"
+                    )
 
         self.job_controller.close()

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -147,7 +147,7 @@ class Runner:
                 for name in self.project.optional_jobstores
             }
         # create a cached for the jobstores to be used in the get_jobstore method
-        self._cached_jostores: OrderedDict[str, JobStore] = OrderedDict()
+        self._cached_jobstores: OrderedDict[str, JobStore] = OrderedDict()
 
         if connect_interactive:
             for host_name, host in self.hosts.items():
@@ -257,18 +257,18 @@ class Runner:
         # but adding a dependence for this trivial caching seems an overkill.
         # Note that an OrderedDict is needed because popitem() for a standard
         # dict does not have the `last` argument.
-        if flow_id in self._cached_jostores:
-            return self._cached_jostores[flow_id]
+        if flow_id in self._cached_jobstores:
+            return self._cached_jobstores[flow_id]
         jobstore = self.jobstore
         if flow_id and self.optional_jobstores:
             store_name = self.job_controller.get_flow_store(flow_id=flow_id)
             if store_name:
                 jobstore = self.optional_jobstores[store_name]
 
-        self._cached_jostores[flow_id] = jobstore
+        self._cached_jobstores[flow_id] = jobstore
 
-        if len(self._cached_jostores) > 20:
-            self._cached_jostores.popitem(last=False)
+        if len(self._cached_jobstores) > 20:
+            self._cached_jobstores.popitem(last=False)
 
         return jobstore
 

--- a/src/jobflow_remote/jobs/store.py
+++ b/src/jobflow_remote/jobs/store.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
     from jobflow.core.store import JobStore
 
 
-def get_jobstore(project_name: str | None = None) -> JobStore:
+def get_jobstore(
+    project_name: str | None = None, jobstore_name: str | None = None
+) -> JobStore:
     """
     Helper function to get the jobstore in a project.
 
@@ -16,6 +18,8 @@ def get_jobstore(project_name: str | None = None) -> JobStore:
     ----------
     project_name
         Name of the project or None to use the one from the settings.
+    jobstore_name
+        The name of the optional jobstore to return. If None the default JobStore.
 
     Returns
     -------
@@ -23,4 +27,4 @@ def get_jobstore(project_name: str | None = None) -> JobStore:
     """
     cm = ConfigManager(warn=False)
     project = cm.get_project(project_name=project_name)
-    return project.get_jobstore()
+    return project.get_jobstore(jobstore_name)

--- a/src/jobflow_remote/jobs/submit.py
+++ b/src/jobflow_remote/jobs/submit.py
@@ -21,6 +21,7 @@ def submit_flow(
     resources: dict | QResources | None = None,
     priority: int = 0,
     allow_external_references: bool = False,
+    jobstore: str | None = None,
 ) -> list[str]:
     """
     Submit a flow for calculation to the selected Worker.
@@ -49,6 +50,9 @@ def submit_flow(
     allow_external_references
         If False all the references to other outputs should be from other Jobs
         of the Flow.
+    jobstore
+        The name of the JobStore used for the output of the submitted Flow.
+        If None the default is used.
 
     Returns
     -------
@@ -73,9 +77,9 @@ def submit_flow(
     flow = get_flow(flow, allow_external_references=allow_external_references)
 
     # check that all the additional stores are properly defined
-    jobstore = proj_obj.get_jobstore()
+    jobstore_obj = proj_obj.get_jobstore(jobstore)
     for job, _ in flow.iterflow():
-        missing_stores = check_additional_stores(job, jobstore)
+        missing_stores = check_additional_stores(job, jobstore_obj)
         if missing_stores:
             raise ConfigError(
                 f"Additional stores {missing_stores!r} are not configured for this project."
@@ -90,4 +94,5 @@ def submit_flow(
         resources=resources,
         priority=priority,
         allow_external_references=allow_external_references,
+        jobstore=jobstore,
     )

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -219,3 +219,34 @@ def test_resume(job_controller, two_flows_four_jobs) -> None:
     assert job_controller.get_job_info(db_id="2").state == JobState.WAITING
 
     assert job_controller.get_flows_info(db_ids="1")[0].state == FlowState.READY
+
+
+def test_set_store(job_controller, runner, one_job):
+    from jobflow_remote.testing.cli import run_check_cli
+
+    assert job_controller.get_flow_store(one_job.uuid) is None
+
+    run_check_cli(
+        ["flow", "set", "store", one_job.uuid, "other_jobstore"],
+        required_out="Flow has been updated",
+    )
+
+    assert job_controller.get_flow_store(one_job.uuid) == "other_jobstore"
+
+    run_check_cli(
+        ["flow", "set", "store", "1"],
+        required_out="Flow has been updated",
+    )
+
+    assert job_controller.get_flow_store(one_job.uuid) is None
+
+    runner.run_one_job(db_id="1")
+
+    run_check_cli(
+        ["flow", "set", "store", "1", "other_jobstore"],
+        required_out="The JobStore can be set only for a READY Flow",
+        excluded_out="Flow has been updated",
+        error=True,
+    )
+
+    assert job_controller.get_flow_store(one_job.uuid) is None

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -139,6 +139,26 @@ def write_tmp_settings(
             max_step_attempts=3,
             delta_retry=(1, 1, 1),
         ),
+        optional_jobstores={
+            "other_jobstore": {
+                "docs_store": {
+                    "type": "MongoStore",
+                    "database": store_database_name,
+                    "host": mongoclient.HOST,
+                    "port": mongoclient.PORT,
+                    "collection_name": "other_docs",
+                },
+                "additional_stores": {
+                    "big_data": {
+                        "type": "GridFSStore",
+                        "database": store_database_name,
+                        "host": mongoclient.HOST,
+                        "port": mongoclient.PORT,
+                        "collection_name": "other_data",
+                    },
+                },
+            },
+        },
     )
     project_json = project.model_dump_json(indent=2)
     with open(tmp_dir / f"{random_project_name}.json", "w") as f:

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1164,3 +1164,67 @@ def test_resume_flow(job_controller, runner):
 
     assert job_controller.get_flows_info()[0].state == FlowState.RUNNING
     assert job_controller.count_jobs(states=[JobState.STOPPED, JobState.PAUSED]) == 0
+
+
+def test_flow_store(job_controller, two_flows_four_jobs, runner):
+    from jobflow_remote.jobs.state import FlowState
+
+    job_controller.set_flow_store("other_jobstore", flow_id=two_flows_four_jobs[0].uuid)
+
+    assert (
+        job_controller.get_flow_store(flow_id=two_flows_four_jobs[0].uuid)
+        == "other_jobstore"
+    )
+    assert job_controller.get_flow_store(flow_id=two_flows_four_jobs[1].uuid) is None
+
+    with pytest.raises(
+        ValueError,
+        match=".*Store wrong_jobstore is not defined as an optional jobstore.*",
+    ):
+        job_controller.set_flow_store(
+            "wrong_jobstore", flow_id=two_flows_four_jobs[0].uuid
+        )
+
+    with pytest.raises(ValueError, match="No Flow document matching criteria"):
+        job_controller.set_flow_store("other_jobstore", flow_id="wrong_id")
+
+    job_controller.set_flow_store("other_jobstore", flow_id=two_flows_four_jobs[1].uuid)
+    assert (
+        job_controller.get_flow_store(flow_id=two_flows_four_jobs[1].uuid)
+        == "other_jobstore"
+    )
+    job_controller.set_flow_store(None, flow_id=two_flows_four_jobs[1].uuid)
+    assert job_controller.get_flow_store(flow_id=two_flows_four_jobs[1].uuid) is None
+
+    with pytest.raises(ValueError, match="No Flow matching id"):
+        job_controller.get_flow_store(flow_id="wrong_id")
+
+    runner.run_one_job(job_id=(two_flows_four_jobs[0][0].uuid, 1))
+
+    assert (
+        job_controller.get_flows_info(flow_ids=[two_flows_four_jobs[0].uuid])[0].state
+        == FlowState.RUNNING
+    )
+    with pytest.raises(
+        RuntimeError, match=".*The JobStore can be set only for a READY Flow.*"
+    ):
+        job_controller.set_flow_store(
+            "other_jobstore", flow_id=two_flows_four_jobs[0].uuid
+        )
+
+    # test get_job_output from the additional store
+    assert job_controller.get_job_output(job_id=two_flows_four_jobs[0][0].uuid) == 6
+
+
+def test_get_job_output(job_controller, runner, one_job):
+    # here it is tested with the standard jobstore. The optional jobstore is
+    # tested in test_flow_store
+
+    with pytest.raises(
+        ValueError, match=rf".*UUID: {one_job[0].uuid} \(index: 1\) has no outputs.*"
+    ):
+        job_controller.get_job_output(db_id="1")
+
+    runner.run_all_jobs(max_seconds=20)
+
+    assert job_controller.get_job_output(db_id="1") == 6

--- a/tests/db/jobs/test_runner.py
+++ b/tests/db/jobs/test_runner.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_upload_cleanup_error(job_controller, runner, monkeypatch):
     from pathlib import Path
 
@@ -141,3 +144,46 @@ def test_resolve_references(job_controller, runner):
     assert isinstance(out_doc["output"], dict)
     assert out_doc["output"]["@class"] == "OutputReference"
     assert out_doc["output"]["uuid"] == j1.uuid
+
+
+def test_optional_store(job_controller, runner, two_flows_four_jobs):
+    # test that the jobs will run in different stores and that
+    # references are correctly resolved within a Flow.
+    job_controller.set_flow_store(
+        store="other_jobstore", flow_id=two_flows_four_jobs[0].uuid
+    )
+    runner.run_all_jobs(max_seconds=30)
+
+    std_js = job_controller.jobstore
+    assert std_js.get_output(two_flows_four_jobs[1][0].uuid)
+    assert std_js.get_output(two_flows_four_jobs[1][1].uuid)
+    with pytest.raises(
+        ValueError, match=f".*UUID: {two_flows_four_jobs[0][0].uuid} has no outputs.*"
+    ):
+        std_js.get_output(two_flows_four_jobs[0][0].uuid)
+    with pytest.raises(
+        ValueError, match=f".*UUID: {two_flows_four_jobs[0][1].uuid} has no outputs.*"
+    ):
+        std_js.get_output(two_flows_four_jobs[0][1].uuid)
+
+    opt_js = job_controller.optional_jobstores["other_jobstore"]
+    assert opt_js.get_output(two_flows_four_jobs[0][0].uuid)
+    assert opt_js.get_output(two_flows_four_jobs[0][1].uuid)
+    with pytest.raises(
+        ValueError, match=f".*UUID: {two_flows_four_jobs[1][0].uuid} has no outputs.*"
+    ):
+        opt_js.get_output(two_flows_four_jobs[1][0].uuid)
+    with pytest.raises(
+        ValueError, match=f".*UUID: {two_flows_four_jobs[1][1].uuid} has no outputs.*"
+    ):
+        opt_js.get_output(two_flows_four_jobs[1][1].uuid)
+
+    assert (
+        runner._cached_jostores[two_flows_four_jobs[0].uuid].docs_store.collection_name
+        == "other_docs"
+    )
+    assert (
+        runner._cached_jostores[two_flows_four_jobs[1].uuid].docs_store.collection_name
+        == "docs"
+    )
+    assert len(runner._cached_jostores) == 2

--- a/tests/db/jobs/test_runner.py
+++ b/tests/db/jobs/test_runner.py
@@ -179,11 +179,11 @@ def test_optional_store(job_controller, runner, two_flows_four_jobs):
         opt_js.get_output(two_flows_four_jobs[1][1].uuid)
 
     assert (
-        runner._cached_jostores[two_flows_four_jobs[0].uuid].docs_store.collection_name
+        runner._cached_jobstores[two_flows_four_jobs[0].uuid].docs_store.collection_name
         == "other_docs"
     )
     assert (
-        runner._cached_jostores[two_flows_four_jobs[1].uuid].docs_store.collection_name
+        runner._cached_jobstores[two_flows_four_jobs[1].uuid].docs_store.collection_name
         == "docs"
     )
-    assert len(runner._cached_jostores) == 2
+    assert len(runner._cached_jobstores) == 2

--- a/tests/db/jobs/test_submit.py
+++ b/tests/db/jobs/test_submit.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+def test_submit_optional_jobstore(job_controller, runner) -> None:
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.testing import add
+
+    add_first = add(1, 5)
+    add_second = add(add_first.output, 5)
+
+    flow = Flow([add_first, add_second])
+
+    with pytest.raises(
+        ValueError, match=".*No JobStore named wrong_jobstore defined in the project.*"
+    ):
+        submit_flow(flow, worker="test_local_worker", jobstore="wrong_jobstore")
+
+    submit_flow(flow, worker="test_local_worker", jobstore="other_jobstore")
+
+    runner.run_all_jobs(max_seconds=10)
+    assert job_controller.count_jobs(states=JobState.COMPLETED) == 2
+
+    with pytest.raises(ValueError, match=".*has no outputs.*"):
+        job_controller.jobstore.get_output(add_first.uuid)
+    assert (
+        job_controller.optional_jobstores["other_jobstore"].get_output(add_first.uuid)
+        == 6
+    )
+
+    assert job_controller.get_job_output(db_id="2") == 11


### PR DESCRIPTION
As discussed in #317, adding the option to select a different JobStore for each Flow.
The store is set at the Flow level since it would be otherwise impossible (or at least very complicated) resolving references if single Jobs belonging to the same Flow could be assigned to different JobStores.
The changes include a new `optional_jobstores` element in the project configuration and the options to set the JobStore during flow submission or with the CLI. 
Default behaviour is unchanged.

### TODO

* Update documentation 
* Possibly add some more tests



Pinging @Andrew-S-Rosen and @blaked8619 in case you are interested to test this before it is merged. Or in case you are willing to review this PR.