### PR TITLE
Fix batch worker

### DIFF
--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -282,7 +282,7 @@ def shutdown() -> None:
 def restart() -> None:
     """
     Restart the runner. Send a stop signal, wait for the runner to stop and
-    restart it with the same configuration.
+    restart it. The options to start the runner (e.g. --single) remain the same.
     """
     cm = get_config_manager()
     dm = DaemonManager.from_project(cm.get_project())

--- a/src/jobflow_remote/jobs/batch.py
+++ b/src/jobflow_remote/jobs/batch.py
@@ -145,6 +145,37 @@ class RemoteBatchManager:
         for job_id, index, process_uuid in ids:
             self.host.remove(self.terminated_dir / f"{job_id}_{index}_{process_uuid}")
 
+    def delete_running(self, process_id: str) -> None:
+        """
+        Remove job files from the running folder for a specific process uuid.
+
+        Should be used only for jobs that failed and left dangling running files.
+
+        Parameters
+        ----------
+        process_id
+            The uuid of the process for the running files to be removes
+        """
+        if not self._dir_initialized:
+            self._init_files_dir()
+        running_files = self.host.listdir(self.running_dir)
+        for filename in running_files:
+            if filename.endswith(process_id):
+                self.host.remove(self.running_dir / filename)
+
+    def cleanup(self) -> bool:
+        """
+        Remove the files directory on the host.
+
+        Returns
+        -------
+        bool
+            True if the directory was successfully deleted or was not existing.
+        """
+        if self.host.exists(self.files_dir):
+            return self.host.rmtree(self.files_dir, raise_on_error=False)
+        return True
+
 
 class LocalBatchManager:
     """

--- a/src/jobflow_remote/jobs/batch.py
+++ b/src/jobflow_remote/jobs/batch.py
@@ -154,7 +154,7 @@ class RemoteBatchManager:
         Parameters
         ----------
         process_id
-            The uuid of the process for the running files to be removes
+            The uuid of the process for the running files to be removed.
         """
         if not self._dir_initialized:
             self._init_files_dir()

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -28,6 +28,7 @@ from qtoolkit.core.data_objects import CancelStatus, QResources
 import jobflow_remote
 from jobflow_remote.config.base import ConfigError, ExecutionConfig, Project
 from jobflow_remote.config.manager import ConfigManager
+from jobflow_remote.jobs.batch import RemoteBatchManager
 from jobflow_remote.jobs.data import (
     OUT_FILENAME,
     DbCollection,
@@ -2845,6 +2846,26 @@ class JobController:
         self.update_version_information()
         self.build_indexes(drop=True)
 
+        # handle the case that self.project is None, since it is a possibility
+        if self.project:
+            for wname, worker_data in self.project.workers.items():
+                try:
+                    if worker_data.batch is not None:
+                        host = worker_data.get_host()
+                        host.connect()
+                        batch_manager = RemoteBatchManager(
+                            host, worker_data.batch.jobs_handle_dir
+                        )
+                        if not batch_manager.cleanup():
+                            logger.warning(
+                                f"Could not cleanup the jobs_handle_dir for batch worker {wname}"
+                            )
+                except Exception:
+                    logger.warning(
+                        f"Error while cleaning up the jobs_handle_dir for worker {wname}",
+                        exc_info=True,
+                    )
+
         return True
 
     def build_indexes(
@@ -3182,7 +3203,9 @@ class JobController:
             )
         return self.flows.count_documents(query)
 
-    def count_jobs_states(self, states: list[JobState]) -> dict[JobState, int]:
+    def count_jobs_states(
+        self, states: list[JobState], worker: str | None = None
+    ) -> dict[JobState, int]:
         """
         Count the number of jobs in each of the given states.
 
@@ -3190,14 +3213,19 @@ class JobController:
         ----------
         states
             List of JobState to count.
+        worker
+            Name of the worker
 
         Returns
         -------
         dict[JobState, int]
             A dictionary with the count of jobs in each state.
         """
+        query: dict[str, Any] = {"state": {"$in": [s.value for s in states]}}
+        if worker:
+            query["worker"] = worker
         pipeline = [
-            {"$match": {"state": {"$in": [s.value for s in states]}}},
+            {"$match": query},
             {"$group": {"_id": "$state", "count": {"$sum": 1}}},
         ]
         result = self.jobs.aggregate(pipeline) or []

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -1077,6 +1077,10 @@ class Runner:
                     exc_info=True,
                 )
 
+            # Set the process state to BATCH_RUNNING for those that are
+            # in the BATCH_SUBMITTED and started.
+            # This requires running the query at each check consider devising
+            # a cheaper option in terms of DB queries.
             for job_id, job_index, process_running_uuid in running_jobs:
                 lock_filter = {
                     "uuid": job_id,
@@ -1146,6 +1150,8 @@ class Runner:
                                 if lock.locked_document:
                                     err_msg = f"The batch process that was running the job (process_id: {pid}, uuid: {process_running_uuid} was likely killed before terminating the job execution"
                                     raise RemoteError(err_msg, no_retry=True)
+                    # Also remove the corresponding files from the running folder of batch manager
+                    batch_manager.delete_running(batch_processes_data[pid])
 
                 processes = list(running_processes)
 
@@ -1153,7 +1159,8 @@ class Runner:
             # amount to reach max_jobs, if needed.
 
             dict_n_jobs = self.job_controller.count_jobs_states(
-                [JobState.BATCH_SUBMITTED, JobState.BATCH_RUNNING]
+                [JobState.BATCH_SUBMITTED, JobState.BATCH_RUNNING],
+                worker=worker_name,
             )
             n_jobs_submitted = dict_n_jobs[JobState.BATCH_SUBMITTED]
             n_jobs_running = dict_n_jobs[JobState.BATCH_RUNNING]

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -161,6 +161,21 @@ class BaseHost(MSONable):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def exists(self, path: str | Path) -> bool:
+        """
+        Test whether a path exists.
+
+        Parameters
+        ----------
+        path
+            The path to the directory tree to be removed.
+        Returns
+        -------
+        bool
+            True if the path exists
+        """
+
     @property
     def interactive_login(self) -> bool:
         """

--- a/src/jobflow_remote/remote/host/base.py
+++ b/src/jobflow_remote/remote/host/base.py
@@ -169,7 +169,7 @@ class BaseHost(MSONable):
         Parameters
         ----------
         path
-            The path to the directory tree to be removed.
+            The path to check whether it exists.
         Returns
         -------
         bool

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -175,3 +175,18 @@ class LocalHost(BaseHost):
         if pre_cmd:
             cmd = f"{pre_cmd}; {shell}"
         Context().run(cmd, pty=True)
+
+    def exists(self, path: str | Path) -> bool:
+        """
+        Test whether a path exists.
+
+        Parameters
+        ----------
+        path
+            The path to the directory tree to be removed.
+        Returns
+        -------
+        bool
+            True if the path exists
+        """
+        return os.path.exists(path)

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -183,7 +183,7 @@ class LocalHost(BaseHost):
         Parameters
         ----------
         path
-            The path to the directory tree to be removed.
+            The path to check whether it exists.
         Returns
         -------
         bool

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -453,7 +453,7 @@ class RemoteHost(BaseHost):
         Parameters
         ----------
         path
-            The path to the directory tree to be removed.
+            The path to check whether it exists.
 
         Returns
         -------

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -446,6 +446,30 @@ class RemoteHost(BaseHost):
             cmd = f"{pre_cmd}; {shell}"
         self.connection.run(cmd, pty=True)
 
+    def exists(self, path: str | Path) -> bool:
+        """
+        Test whether a path exists.
+
+        Parameters
+        ----------
+        path
+            The path to the directory tree to be removed.
+
+        Returns
+        -------
+        bool
+            True if the path exists
+        """
+        try:
+            stat = self._execute_remote_func(
+                lambda host: host.connection.sftp().stat, str(path)
+            )
+            if stat:
+                return True
+        except FileNotFoundError:
+            pass
+        return False
+
 
 def inter_handler(title, instructions, prompt_list):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -344,8 +344,9 @@ def update_project_data(
     else:
         d = d | update
 
-    # validate the Project to get an error, otherwise if the values
-    # are wrong the error may be hidden by the runner/daemon starting
+    # Validate the Project to get an error in case of invalid file generated,
+    # otherwise if the values are wrong the error may be hidden by the
+    # runner/daemon
     Project.model_validate(d)
 
     dumpfn(d, project_file_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,3 +327,39 @@ def wait_daemon_shutdown():
         target_status=DaemonStatus.SHUT_DOWN,
         acceptable_states=acceptable_states,
     )
+
+
+def update_project_data(
+    update: dict, dict_mods: bool = True, project_file_path: Path = None
+):
+    from jobflow.utils.dict_mods import apply_mod
+    from monty.serialization import dumpfn, loadfn
+
+    from jobflow_remote.config.base import Project
+
+    d = loadfn(project_file_path)
+
+    if dict_mods:
+        apply_mod(update, d)
+    else:
+        d = d | update
+
+    # validate the Project to get an error, otherwise if the values
+    # are wrong the error may be hidden by the runner/daemon starting
+    Project.model_validate(d)
+
+    dumpfn(d, project_file_path)
+
+
+@pytest.fixture()
+def patch_project(monkeypatch):
+    from jobflow_remote.config.manager import ConfigManager
+
+    cm = ConfigManager()
+    current_project_data = cm.get_project_data()
+
+    yield partial(
+        update_project_data, project_file_path=Path(current_project_data.filepath)
+    )
+
+    cm.dump_project(current_project_data)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -429,3 +429,19 @@ def write_tmp_settings(
         os.environ["JFREMOTE_PROJECT"] = original_jf_remote_project
     if original_config_file is not None:
         os.environ["JFREMOTE_CONFIG_FILE"] = original_config_file
+
+
+@pytest.fixture()
+def clean_slurm_queue(write_tmp_settings):
+    """
+    Clean the list of Jobs in the SLURM queue at the end of the test.
+    """
+    from jobflow_remote.remote.queue import QueueManager
+
+    yield
+    project = write_tmp_settings
+    worker = project.workers["test_remote_slurm_worker"]
+    queue_manager = QueueManager(worker.get_scheduler_io(), worker.get_host())
+    for qjob in queue_manager.get_jobs_list():
+        queue_manager.cancel(qjob)
+        time.sleep(0.1)

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -87,7 +87,6 @@ def test_run_batch_multi_fail(
     wait_daemon_shutdown,
     clean_slurm_queue,
 ) -> None:
-    from jobflow import Flow
     from qtoolkit.core.data_objects import CancelStatus
 
     from jobflow_remote import submit_flow
@@ -101,8 +100,7 @@ def test_run_batch_multi_fail(
         for _ in range(n):
             add_j = add_sleep(2, sleep)
 
-            flow = Flow([add_j])
-            submit_flow(flow, worker=worker_name)
+            submit_flow(add_j, worker=worker_name)
             job_ids.append(add_j.uuid)
         return job_ids
 
@@ -304,7 +302,4 @@ def test_max_jobs_worker(
     max_running_jobs = check_running_jobs(60)
     assert max_running_jobs == 2
 
-    jobs_info = job_controller.get_jobs_info(job_ids=job_ids)
-    for ji in jobs_info:
-        print(ji.db_id, ji.state)
     assert job_controller.count_jobs(states=JobState.COMPLETED) == 4

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pytest
 
@@ -8,7 +9,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_run_batch(job_controller, monkeypatch) -> None:
+def test_run_batch(job_controller, monkeypatch, clean_slurm_queue) -> None:
     from jobflow import Flow
 
     from jobflow_remote import submit_flow
@@ -44,7 +45,7 @@ def test_run_batch(job_controller, monkeypatch) -> None:
         assert jobs_info[i].end_time < jobs_info[i + 1].start_time
 
 
-def test_run_batch_multi(job_controller, monkeypatch) -> None:
+def test_run_batch_multi(job_controller, monkeypatch, clean_slurm_queue) -> None:
     from jobflow import Flow
 
     from jobflow_remote import submit_flow
@@ -76,6 +77,165 @@ def test_run_batch_multi(job_controller, monkeypatch) -> None:
     for ji1 in jobs_info:
         for ji2 in jobs_info:
             assert ji1.start_time < ji2.end_time
+
+
+def test_run_batch_multi_fail(
+    patch_project,
+    job_controller,
+    daemon_manager,
+    wait_daemon_started,
+    wait_daemon_shutdown,
+    clean_slurm_queue,
+) -> None:
+    from jobflow import Flow
+    from qtoolkit.core.data_objects import CancelStatus
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.batch import RemoteBatchManager
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.remote.queue import QueueManager
+    from jobflow_remote.testing import add_sleep
+
+    def submit_jobs(n: int, sleep: int):
+        job_ids = []
+        for _ in range(n):
+            add_j = add_sleep(2, sleep)
+
+            flow = Flow([add_j])
+            submit_flow(flow, worker=worker_name)
+            job_ids.append(add_j.uuid)
+        return job_ids
+
+    proj = job_controller.project
+    worker_name = "test_batch_multi_remote_worker"
+    patch_project({"_set": {"runner->delay_update_batch": 1}})
+
+    job_ids = submit_jobs(2, sleep=60)
+
+    daemon_manager.start()
+    wait_daemon_started(daemon_manager)
+
+    for _ in range(10):
+        if (
+            len(
+                job_controller.get_jobs_info(
+                    job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                    states=JobState.BATCH_RUNNING,
+                )
+            )
+            == 2
+        ):
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError(
+            "The submitted jobs were never both running at the same time"
+        )
+
+    daemon_manager.shut_down()
+    wait_daemon_shutdown(daemon_manager)
+
+    assert (
+        len(
+            job_controller.get_jobs_info(
+                job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                states=JobState.BATCH_RUNNING,
+            )
+        )
+        == 2
+    )
+
+    # check that jobs were submitted only for the correct worker
+    # (a bug submitted jobs for the wrong worker as well)
+    full_dict_batch_processes = job_controller.get_batch_processes()
+    for batch_worker_name, submitted_jobs in full_dict_batch_processes.items():
+        n_submitted = 1 if batch_worker_name == worker_name else 0
+        assert (
+            len(submitted_jobs) == n_submitted
+        ), f"wrong number of jobs for worker {batch_worker_name}"
+
+    worker = proj.workers[worker_name]
+    host = worker.get_host()
+    host.connect()
+    batch_manager = RemoteBatchManager(host, worker.batch.jobs_handle_dir)
+    queue_manager = QueueManager(worker.get_scheduler_io(), host)
+    dict_batch_processes = job_controller.get_batch_processes(worker_name)
+    assert len(dict_batch_processes[worker_name]) == 1
+    assert (
+        queue_manager.cancel(next(iter(dict_batch_processes[worker_name]))).status
+        == CancelStatus.SUCCESSFUL
+    )
+    assert len(queue_manager.get_jobs_list()) == 0
+
+    assert len(batch_manager.get_running()) == 2
+
+    # now restart the runner and verify that the job is set to remote error
+    # and running files are properly cleaned
+    daemon_manager.start()
+    wait_daemon_started(daemon_manager)
+    for _ in range(10):
+        if all(
+            ji.state == JobState.REMOTE_ERROR
+            for ji in job_controller.get_jobs_info(
+                job_ids=list(zip(job_ids, [1] * len(job_ids)))
+            )
+        ):
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError("The Jobs were not set to REMOTE_ERROR state")
+
+    assert len(batch_manager.get_running()) == 0
+
+    # submit more jobs, will also be used to check that the files are cleaned during the reset
+    job_ids = submit_jobs(4, 60)
+
+    for _ in range(10):
+        if (
+            len(
+                job_controller.get_jobs_info(
+                    job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                    states=JobState.BATCH_RUNNING,
+                )
+            )
+            == 2
+        ):
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError(
+            "The submitted jobs were never both running at the same time"
+        )
+
+    daemon_manager.shut_down()
+    wait_daemon_shutdown(daemon_manager)
+
+    assert (
+        len(
+            job_controller.get_jobs_info(
+                job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                states=JobState.BATCH_RUNNING,
+            )
+        )
+        == 2
+    )
+    assert (
+        len(
+            job_controller.get_jobs_info(
+                job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                states=JobState.BATCH_SUBMITTED,
+            )
+        )
+        == 2
+    )
+
+    assert len(batch_manager.get_running()) == 2
+
+    # now reset the DB, the files should also be cleaned up
+    job_controller.reset()
+    assert len(batch_manager.get_terminated()) == 0
+    assert len(batch_manager.get_submitted()) == 0
+    assert len(batch_manager.get_running()) == 0
 
 
 def test_max_jobs_worker(


### PR DESCRIPTION
Following the discussion in #326, adding the cleanup of the batch managerment folder for batch workers.

Two small bugs also fixed:
* Wrong counting of the number of required jobs if multiple batch workers present in the same project
* Files for running jobs remained hanging in the folder if the job in the (e.g. slurm) queue is cancelled/killed.

Extended the tests for the batch worker. 