### PR TITLE
CLI plugins

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/doc/source/dev/cliplugin.rst
+++ b/doc/source/dev/cliplugin.rst
@@ -1,0 +1,199 @@
+.. _cliplugin:
+
+**********
+CLI Plugin
+**********
+
+The jobflow-remote CLI supports a plugin mechanism that allows external packages
+to extend the ``jf`` command with additional functionality. This enables
+developers to create packages that seamlessly integrate with the jobflow-remote
+CLI without modifying the core codebase.
+
+Plugin Architecture
+===================
+
+CLI Framework
+-------------
+
+The jobflow-remote CLI is built using `Typer <https://typer.tiangolo.com/>`_, a Python library for building command-line interfaces. The CLI code is organized in the ``src/jobflow_remote/cli/`` directory, where each module typically corresponds to a command group (e.g., ``job.py`` for ``jf job`` commands, ``flow.py`` for ``jf flow`` commands). Understanding this structure helps when extending existing command groups or creating new ones.
+
+Plugin System
+-------------
+
+The plugin system is based on Python entry points and follows these key principles:
+
+- **Entry Point Discovery**: Plugins are discovered through the ``jobflow_remote.plugins`` entry point group
+- **Automatic Loading**: Plugins are automatically loaded when the CLI starts (if enabled in settings)
+- **Function-Based Setup**: Each plugin defines a ``setup_jf_plugin`` function that registers commands
+- **Typer Integration**: Plugins can extend existing typer apps or create new command groups
+
+Creating a Plugin
+=================
+
+Step 1: Define Entry Point
+---------------------------
+
+In your package's ``pyproject.toml``, define an entry point in the ``jobflow_remote.plugins`` group:
+
+.. code-block:: toml
+
+    [project.entry-points."jobflow_remote.plugins"]
+    my_plugin = "my_package.jf_plugin"
+
+Where:
+
+- ``my_plugin`` is the plugin name
+- ``my_package.jf_plugin`` is the module path containing your plugin code
+
+Step 2: Implement Plugin Module
+-------------------------------
+
+Create a module (e.g., ``my_package/jf_plugin.py``) with a ``setup_jf_plugin`` function:
+
+.. code-block:: python
+
+    def setup_jf_plugin():
+        """
+        Plugin setup function called by jobflow-remote CLI.
+        This function should import typer apps and register commands.
+        """
+        from jobflow_remote.cli.job import app_job
+        import typer
+
+        @app_job.command()
+        def my_command():
+            """My custom command added to 'jf job' group."""
+            typer.echo("Hello from my plugin!")
+
+This example adds a ``my-command`` to the ``jf job`` command group, accessible as:
+
+.. code-block:: shell
+
+    jf job my-command
+
+Creating New Command Groups
+===========================
+
+You can also create entirely new command groups:
+
+.. code-block:: python
+
+    def setup_jf_plugin():
+        from jobflow_remote.cli.jf import app
+        from jobflow_remote.cli.jfr_typer import JFRTyper
+        import typer
+
+        # Create a new command group
+        app_backup = JFRTyper(
+            name="backup",
+            help="Backup and restore operations",
+            no_args_is_help=True,
+        )
+
+        @app_backup.command()
+        def create():
+            """Create a backup."""
+            typer.echo("Creating backup...")
+
+        @app_backup.command()
+        def restore():
+            """Restore from backup."""
+            typer.echo("Restoring backup...")
+
+        # Register the new command group
+        app.add_typer(app_backup)
+
+This creates a new ``jf backup`` command group with ``create`` and ``restore`` subcommands.
+
+Plugin Management
+=================
+
+Users can manage plugins using the built-in plugin commands:
+
+List Available Plugins
+-----------------------
+
+.. code-block:: shell
+
+    jf plugin list
+
+This shows all discovered plugins and their status.
+
+View Plugin Errors
+-------------------
+
+.. code-block:: shell
+
+    jf plugin list --error
+
+This displays detailed error messages for plugins that failed to load.
+
+Best Practices
+==============
+
+Error Handling
+--------------
+
+Implement robust error handling in your plugin setup function:
+
+.. code-block:: python
+
+    def setup_jf_plugin():
+        try:
+            from jobflow_remote.cli.job import app_job
+
+            @app_job.command()
+            def my_command():
+                """My plugin command."""
+                pass
+
+        except ImportError as e:
+            # Handle missing dependencies gracefully
+            import logging
+
+            logging.debug(f"Plugin setup failed: {e}")
+
+Logging Integration
+-------------------
+
+The jobflow-remote CLI uses its own logging system initialized through
+the ``initialize_cli_logger`` function. By default, only log messages
+from the ``jobflow_remote`` logger and explicitly registered additional
+loggers are displayed in the CLI output.
+
+If your plugin needs to have its log messages shown in the CLI, register
+your logger names using the ``add_cli_logger_names`` function in ``setup_jf_plugin``:
+
+.. code-block:: python
+
+    def setup_jf_plugin():
+        from jobflow_remote.cli.jf import add_cli_logger_names
+
+        # Register your package's loggers to be displayed in CLI
+        add_cli_logger_names(["my_package", "my_package.submodule"])
+
+
+This ensures that log messages from your plugin modules are properly displayed alongside jobflow-remote's own logging output.
+
+Naming Conventions
+------------------
+
+- Use descriptive plugin names in entry points
+- Follow existing CLI naming patterns for commands
+
+Troubleshooting
+===============
+
+Plugin Fails to Load
+---------------------
+
+- Use ``jf plugin list --error`` to see detailed error messages
+- Check for missing dependencies or import errors
+- Verify the ``setup_jf_plugin`` function exists and is callable
+
+Commands Not Appearing
+-----------------------
+
+- Ensure plugins are enabled in jobflow-remote settings
+- Check that the ``setup_jf_plugin`` function completes without errors
+- Verify you're importing the correct typer app objects

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -90,7 +90,7 @@ Jobflow Remote is a package to submit `Jobflow
 
         +++
 
-        .. button-ref:: dev/devinstall
+        .. button-ref:: dev
             :expand:
             :color: secondary
             :click-parent:

--- a/doc/source/user/cli.rst
+++ b/doc/source/user/cli.rst
@@ -19,6 +19,11 @@ All the commands have an associated help that can be shown with the
 ``--help`` flag. Below are reported the help for all the commands
 available in ``jf``.
 
+It is possible to extend the ``jf`` CLI from external packages through a
+plugin system. The discovery of such plugins is automatic and can be disabled
+by setting the ``cli_load_plugins`` to ``False`` in :ref:`projectconf general`.
+To develop new plugins follow the developer guide for :ref:`cliplugin`
+
 .. typer:: jobflow_remote.cli:app
     :preferred: html
     :width: 65

--- a/src/jobflow_remote/__init__.py
+++ b/src/jobflow_remote/__init__.py
@@ -18,4 +18,5 @@ __all__ = (
     "JobController",
     "get_jobstore",
     "submit_flow",
+    "SETTINGS",
 )

--- a/src/jobflow_remote/cli/__init__.py
+++ b/src/jobflow_remote/cli/__init__.py
@@ -8,4 +8,9 @@ import jobflow_remote.cli.gui
 import jobflow_remote.cli.job
 import jobflow_remote.cli.project
 import jobflow_remote.cli.runner
+from jobflow_remote import SETTINGS
+from jobflow_remote.cli import plugin
 from jobflow_remote.cli.jf import app
+
+if SETTINGS.cli_load_plugins:
+    plugin.load_plugins()

--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Union
 
 import typer
 from rich.text import Text
@@ -21,6 +21,18 @@ app = JFRTyper(
     context_settings={"help_option_names": ["-h", "--help"]},
     epilog=None,  # to remove the default message in JFRTyper
 )
+
+
+ADDITIONAL_LOGGERS = []
+
+
+def add_cli_logger_names(loggers: Union[str, list[str]]):
+    # global ADDITIONAL_LOGGERS
+
+    if isinstance(loggers, str):
+        loggers = [loggers]
+
+    ADDITIONAL_LOGGERS.extend(loggers)
 
 
 def main_result_callback(*args, **kwargs) -> None:
@@ -78,7 +90,9 @@ def main(
         start_profiling()
 
     initialize_cli_logger(
-        level=SETTINGS.cli_log_level.to_logging(), full_exc_info=SETTINGS.cli_full_exc
+        level=SETTINGS.cli_log_level.to_logging(),
+        full_exc_info=SETTINGS.cli_full_exc,
+        loggers=ADDITIONAL_LOGGERS,
     )
 
     # initialize the ConfigManager only once, to avoid parsing the configuration

--- a/src/jobflow_remote/cli/plugin.py
+++ b/src/jobflow_remote/cli/plugin.py
@@ -18,7 +18,7 @@ PLUGIN_LOAD_FUNCTION = "setup_jf_plugin"
 
 app_plugin = JFRTyper(
     name="plugin",
-    help="Commands for handling backup of the database",
+    help="Commands for managing plugins",
     no_args_is_help=True,
 )
 app.add_typer(app_plugin)

--- a/src/jobflow_remote/cli/plugin.py
+++ b/src/jobflow_remote/cli/plugin.py
@@ -1,0 +1,101 @@
+import importlib
+import logging
+import traceback
+from typing import Annotated
+
+import typer
+from rich.padding import Padding
+
+from jobflow_remote.cli.jf import app
+from jobflow_remote.cli.jfr_typer import JFRTyper
+from jobflow_remote.cli.utils import exit_with_warning_msg, out_console
+
+logger = logging.getLogger(__name__)
+
+
+PLUGIN_GROUP = "jobflow_remote.plugins"
+PLUGIN_LOAD_FUNCTION = "setup_jf_plugin"
+
+app_plugin = JFRTyper(
+    name="plugin",
+    help="Commands for handling backup of the database",
+    no_args_is_help=True,
+)
+app.add_typer(app_plugin)
+
+
+def load_plugins():
+    """
+    Load and register plugins from entry points.
+
+    Main function used to load the plugin that will be added to the main CLI
+    """
+
+    try:
+        for entry_point in importlib.metadata.entry_points().select(group=PLUGIN_GROUP):
+            try:
+                plugin_module = entry_point.load()
+
+                # Call the plugin's setup function
+                if hasattr(plugin_module, PLUGIN_LOAD_FUNCTION):
+                    plugin_module.setup_jf_plugin()
+
+            except Exception:
+                logging.debug(
+                    f"Failed to load plugin {entry_point.name}", exc_info=True
+                )
+
+    except Exception:
+        logging.debug("Error discovering plugins", exc_info=True)
+
+
+@app_plugin.command(name="list")
+def list_plugins(
+    error: Annotated[
+        bool,
+        typer.Option(
+            "--error",
+            "-e",
+            help="Print the error messages for the plugin that cannot be loaded",
+        ),
+    ] = False,
+):
+    """List all plugins with an entry point"""
+    from jobflow_remote import SETTINGS
+
+    plugins = {}
+    error_msgs = {}
+    # if there is an error discovering plugins let it pass as it should
+    # be logged by the CLI
+    for entry_point in importlib.metadata.entry_points().select(group=PLUGIN_GROUP):
+        try:
+            plugin_module = entry_point.load()
+
+            # Call the plugin's setup function
+            if hasattr(plugin_module, PLUGIN_LOAD_FUNCTION):
+                plugin_module.setup_jf_plugin()
+                plugins[entry_point.name] = entry_point.value
+            else:
+                error_msgs[entry_point.name] = f"No {PLUGIN_LOAD_FUNCTION} function"
+
+        except Exception:
+            error_msgs[entry_point.name] = traceback.format_exc()
+
+    if plugins:
+        out_console.print("Available plugins:")
+        for name, module in plugins.items():
+            out_console.print(f" - {name}: {module}")
+    else:
+        out_console.print("No plugins found.")
+
+    if error_msgs:
+        if error:
+            out_console.print("Errors discovering plugins:")
+            for name, error_msg in error_msgs.items():
+                out_console.print(f" - {name}:")
+                out_console.print(Padding(error_msg, pad=(0, 0, 0, 4)))
+        else:
+            msg = "Errors discovering plugins."
+            if SETTINGS.cli_suggestions:
+                msg += " Run the command with the --error option to get the details"
+            exit_with_warning_msg(msg)

--- a/src/jobflow_remote/config/settings.py
+++ b/src/jobflow_remote/config/settings.py
@@ -31,9 +31,13 @@ class JobflowRemoteSettings(BaseSettings):
         LogLevel.WARN, description="The level set for logging in the CLI"
     )
     cli_job_list_columns: Optional[list[str]] = Field(
-        None,
+        default=None,
         description="The list of columns to show in the `jf job list` command. For available "
         "options check the corresponding help: `jf job list -h`.",
+    )
+    cli_load_plugins: bool = Field(
+        default=True,
+        description="If False the CLI plugins will not be loaded.",
     )
 
     model_config = SettingsConfigDict(env_prefix="jfremote_")

--- a/src/jobflow_remote/utils/log.py
+++ b/src/jobflow_remote/utils/log.py
@@ -69,7 +69,9 @@ def initialize_runner_logger(
 
 
 def initialize_cli_logger(
-    level: int = logging.WARNING, full_exc_info: bool = True
+    level: int = logging.WARNING,
+    full_exc_info: bool = True,
+    loggers: list[str] | None = None,
 ) -> None:
     """
     Initialize the logger for the CLI based on rich.
@@ -78,7 +80,16 @@ def initialize_cli_logger(
     ----------
     level
         The log level.
+    full_exc_info
+        If True the full stack trace will be printed in the log message
+        in case of error.
+    loggers
+        Additional loggers to be considered. jobflow_remote is always included
     """
+
+    loggers = loggers or []
+    loggers.insert(0, "jobflow_remote")
+
     config = {
         "version": 1,
         "disable_existing_loggers": True,
@@ -98,11 +109,12 @@ def initialize_cli_logger(
             },
         },
         "loggers": {
-            "jobflow_remote": {  # root logger
+            ln: {
                 "handlers": ["rich"],
                 "level": level,
                 "propagate": False,
-            },
+            }
+            for ln in loggers
         },
     }
 

--- a/src/jobflow_remote/webgui/webgui.py
+++ b/src/jobflow_remote/webgui/webgui.py
@@ -610,7 +610,7 @@ def sum_report(proj_name: str, what: str):
     active_count = jfreport.active
 
     # Calculate percentages
-    total_jobs = state_counts.total()  # type: ignore
+    total_jobs = state_counts.total()
     state_percentages = {
         state: (count / total_jobs) * 100 for state, count in state_counts.items()
     }
@@ -684,7 +684,7 @@ def state_distro(proj_name: str, what: str):
     state_counts = Counter(jfreport.state_counts)
 
     # Calculate percentages
-    total_jobs = state_counts.total()  # type: ignore
+    total_jobs = state_counts.total()
     state_percentages = {
         state: (count / total_jobs) * 100 for state, count in state_counts.items()
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,3 +364,36 @@ def patch_project(monkeypatch):
     )
 
     cm.dump_project(current_project_data)
+
+
+@pytest.fixture()
+def remove_jfremote_modules():
+    """
+    At the end of the test remove the jobflow_remote modules from sys
+    so that they are reloaded in the next test.
+
+    Used in case a test modifies the objects in the tests and to prevent
+    influencing the other tests.
+    """
+    import sys
+
+    yield
+
+    for module_name in list(sys.modules.keys()):
+        if module_name.startswith("jobflow_remote"):
+            try:
+                if module_name in sys.modules:
+                    del sys.modules[module_name]
+            except Exception:
+                pass
+
+
+@pytest.fixture(autouse=True)
+def disable_initial_load_plugins(monkeypatch):
+    """
+    Disable the execution of the initial load_plugins happening at import time
+    to avoid that plugins installed in the environment change the CLI.
+    """
+    from jobflow_remote import SETTINGS
+
+    monkeypatch.setattr(SETTINGS, "cli_load_plugins", False)

--- a/tests/unit/cli/test_jf.py
+++ b/tests/unit/cli/test_jf.py
@@ -1,0 +1,24 @@
+import pytest
+
+
+@pytest.fixture()
+def reset_additional_loggers():
+    from jobflow_remote.cli import jf
+
+    backup = list(jf.ADDITIONAL_LOGGERS)
+    yield
+    jf.ADDITIONAL_LOGGERS = backup
+
+
+def test_add_cli_logger_names(reset_additional_loggers):
+    from jobflow_remote.cli.jf import ADDITIONAL_LOGGERS, add_cli_logger_names
+
+    assert [] == ADDITIONAL_LOGGERS
+
+    add_cli_logger_names("test_test")
+
+    assert ["test_test"] == ADDITIONAL_LOGGERS
+
+    add_cli_logger_names(["test1", "test2"])
+
+    assert ["test_test", "test1", "test2"] == ADDITIONAL_LOGGERS

--- a/tests/unit/cli/test_plugin.py
+++ b/tests/unit/cli/test_plugin.py
@@ -1,0 +1,418 @@
+import types
+from unittest.mock import MagicMock, Mock
+
+
+def test_mock_load_plugins_with_valid_plugin(mocker):
+    """Test that a valid plugin with setup function is loaded and executed."""
+    from jobflow_remote.cli.plugin import PLUGIN_GROUP, load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mock the plugin. Nothing is really added to the CLI
+    mock_entry_point = Mock()
+    mock_entry_point.name = "test_plugin"
+
+    mock_plugin_module = Mock()
+    mock_setup_function = Mock()
+    mock_plugin_module.setup_jf_plugin = mock_setup_function
+    mock_entry_point.load.return_value = mock_plugin_module
+
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = [mock_entry_point]
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    load_plugins()
+
+    mock_entry_points.select.assert_called_once_with(group=PLUGIN_GROUP)
+    mock_entry_point.load.assert_called_once()
+    mock_setup_function.assert_called_once()
+
+    run_check_cli(
+        ["plugin", "list"], required_out=["Available plugins:", "test_plugin"]
+    )
+
+
+def test_mock_load_plugins_with_multiple_valid_plugins(mocker):
+    """Test loading multiple plugins successfully."""
+    from jobflow_remote.cli.plugin import PLUGIN_GROUP, load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mock multiple plugins. Nothing is really added to the CLI
+    mock_entry_points_list = []
+    mock_setup_functions = []
+
+    for i in range(3):
+        mock_entry_point = Mock()
+        mock_entry_point.name = f"test_plugin_{i}"
+
+        mock_plugin_module = Mock()
+        mock_setup_function = Mock()
+        mock_plugin_module.setup_jf_plugin = mock_setup_function
+        mock_entry_point.load.return_value = mock_plugin_module
+
+        mock_entry_points_list.append(mock_entry_point)
+        mock_setup_functions.append(mock_setup_function)
+
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = mock_entry_points_list
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    load_plugins()
+
+    mock_entry_points.select.assert_called_once_with(group=PLUGIN_GROUP)
+    assert all(ep.load.call_count == 1 for ep in mock_entry_points_list)
+    assert all(setup_func.call_count == 1 for setup_func in mock_setup_functions)
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out=[
+            "Available plugins:",
+            "test_plugin_0",
+            "test_plugin_1",
+            "test_plugin_2",
+        ],
+    )
+
+
+def test_mock_load_plugins_with_plugin_missing_setup_function(mocker):
+    """Test a plugin where the setup function is missing."""
+    from jobflow_remote.cli.plugin import (
+        PLUGIN_GROUP,
+        PLUGIN_LOAD_FUNCTION,
+        load_plugins,
+    )
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mock the plugin.
+    mock_entry_point = Mock()
+    mock_entry_point.name = "incomplete_plugin"
+
+    # Create a fake module
+    fake_module = types.ModuleType("fake_module")
+
+    # Add a mocked function, but not the setup_jf_plugin
+    fake_module.some_function = MagicMock(return_value="mocked")
+    assert not hasattr(fake_module, PLUGIN_LOAD_FUNCTION)
+
+    mock_entry_point.load.return_value = fake_module
+
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = [mock_entry_point]
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    mock_logger = mocker.patch("logging.debug")
+
+    load_plugins()
+
+    mock_entry_points.select.assert_called_once_with(group=PLUGIN_GROUP)
+    mock_entry_point.load.assert_called_once()
+
+    mock_logger.assert_not_called()
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out="No plugins found.",
+        excluded_out="Available plugins:",
+    )
+
+    run_check_cli(
+        ["plugin", "list", "-e"],
+        required_out=[
+            "No plugins found.",
+            "Errors discovering plugins",
+            "incomplete_plugin",
+            "No setup_jf_plugin function",
+        ],
+        excluded_out=["Available plugins:"],
+    )
+
+
+def test_mock_load_plugins_with_plugin_load_failure(mocker):
+    """Test that plugin load failure is handled."""
+    from jobflow_remote.cli.plugin import load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mock entry point that raises exception on load
+    mock_entry_point = Mock()
+    mock_entry_point.name = "broken_plugin"
+    mock_entry_point.load.side_effect = ImportError("Plugin module not found")
+
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = [mock_entry_point]
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    mock_logger = mocker.patch("logging.debug")
+
+    load_plugins()
+
+    mock_logger.assert_called()
+    logged_calls = [
+        call
+        for call in mock_logger.call_args_list
+        if "Failed to load plugin" in str(call)
+    ]
+    assert len(logged_calls) > 0
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out="No plugins found.",
+        excluded_out="Available plugins:",
+    )
+
+    run_check_cli(
+        ["plugin", "list", "-e"],
+        required_out=[
+            "No plugins found.",
+            "Errors discovering plugins",
+            "Plugin module not found",
+        ],
+        excluded_out=["Available plugins:"],
+    )
+
+
+def test_mock_load_plugins_with_setup_function_failure(mocker):
+    """Test that setup function failure is handled."""
+    from jobflow_remote.cli.plugin import load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mock entry point
+    mock_entry_point = Mock()
+    mock_entry_point.name = "failing_setup_plugin"
+
+    mock_plugin_module = Mock()
+    mock_setup_function = Mock()
+    mock_setup_function.side_effect = RuntimeError("Setup failed")
+    mock_plugin_module.setup_jf_plugin = mock_setup_function
+    mock_entry_point.load.return_value = mock_plugin_module
+
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = [mock_entry_point]
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    mock_logger = mocker.patch("logging.debug")
+
+    load_plugins()
+
+    mock_setup_function.assert_called_once()
+    mock_logger.assert_called()
+    logged_calls = [
+        call
+        for call in mock_logger.call_args_list
+        if "Failed to load plugin" in str(call)
+    ]
+    assert len(logged_calls) > 0
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out="No plugins found.",
+        excluded_out="Available plugins:",
+    )
+
+    run_check_cli(
+        ["plugin", "list", "-e"],
+        required_out=[
+            "No plugins found.",
+            "Errors discovering plugins",
+            "Setup failed",
+        ],
+        excluded_out=["Available plugins:"],
+    )
+
+
+def test_mock_load_plugins_with_no_plugins(mocker):
+    """Test behavior when no plugins are discovered."""
+    from jobflow_remote.cli.plugin import PLUGIN_GROUP, load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = []
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    load_plugins()
+
+    mock_entry_points.select.assert_called_once_with(group=PLUGIN_GROUP)
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out="No plugins found.",
+        excluded_out=["Available plugins:", "Errors discovering plugins"],
+    )
+
+    run_check_cli(
+        ["plugin", "list", "-e"],
+        required_out="No plugins found.",
+        excluded_out=["Available plugins:", "Errors discovering plugins"],
+    )
+
+
+def test_mock_load_plugins_with_entry_points_discovery_failure(mocker):
+    """Test that entry points discovery failure is handled gracefully."""
+    from jobflow_remote.cli.plugin import load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mock entry_points() to raise exception
+    mocker.patch(
+        "importlib.metadata.entry_points",
+        side_effect=RuntimeError("Entry points error"),
+    )
+
+    mock_logger = mocker.patch("logging.debug")
+
+    load_plugins()
+
+    mock_logger.assert_called()
+    logged_calls = [
+        call
+        for call in mock_logger.call_args_list
+        if "Error discovering plugins" in str(call)
+    ]
+    assert len(logged_calls) > 0
+
+    run_check_cli(
+        ["plugin", "list"],
+        error=True,
+        required_out="Entry points error",
+        excluded_out="Available plugins:",
+    )
+
+
+def test_mock_load_plugins_mixed_success_and_failure(mocker):
+    """Test loading plugins where some succeed and some fail."""
+    from jobflow_remote.cli.plugin import load_plugins
+    from jobflow_remote.testing.cli import run_check_cli
+
+    # Mixed scenario: 1 successful, 1 failing load, 1 failing setup
+    mock_entry_points_list = []
+
+    # Successful plugin
+    mock_entry_point_1 = Mock()
+    mock_entry_point_1.name = "good_plugin"
+    mock_plugin_module_1 = Mock()
+    mock_setup_function_1 = Mock()
+    mock_plugin_module_1.setup_jf_plugin = mock_setup_function_1
+    mock_entry_point_1.load.return_value = mock_plugin_module_1
+    mock_entry_points_list.append(mock_entry_point_1)
+
+    # Plugin that fails to load
+    mock_entry_point_2 = Mock()
+    mock_entry_point_2.name = "bad_load_plugin"
+    mock_entry_point_2.load.side_effect = ImportError("Load failed")
+    mock_entry_points_list.append(mock_entry_point_2)
+
+    # Plugin with failing setup
+    mock_entry_point_3 = Mock()
+    mock_entry_point_3.name = "bad_setup_plugin"
+    mock_plugin_module_3 = Mock()
+    mock_setup_function_3 = Mock()
+    mock_setup_function_3.side_effect = RuntimeError("Setup failed")
+    mock_plugin_module_3.setup_jf_plugin = mock_setup_function_3
+    mock_entry_point_3.load.return_value = mock_plugin_module_3
+    mock_entry_points_list.append(mock_entry_point_3)
+
+    # Mock entry points discovery
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = mock_entry_points_list
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    # Mock logging
+    mock_logger = mocker.patch("logging.debug")
+
+    # Execute
+    load_plugins()
+
+    # Verify successful plugin was set up
+    mock_setup_function_1.assert_called_once()
+    mock_setup_function_3.assert_called_once()
+
+    # Verify errors were logged (should be 2 failed plugins)
+    logged_calls = [
+        call
+        for call in mock_logger.call_args_list
+        if "Failed to load plugin" in str(call)
+    ]
+    assert len(logged_calls) == 2
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out=["Available plugins:", "good_plugin"],
+        excluded_out=["No plugins found.", "bad_load_plugin", "bad_setup_plugin"],
+    )
+
+    run_check_cli(
+        ["plugin", "list", "-e"],
+        required_out=[
+            "Available plugins:",
+            "good_plugin",
+            "bad_load_plugin",
+            "bad_setup_plugin",
+            "Load failed",
+            "Setup failed",
+        ],
+        excluded_out=["No plugins found."],
+    )
+
+
+def test_plugin_command_injection(mocker, remove_jfremote_modules):
+    """
+    Test that simulates a plugin actually injecting commands into different
+    points of the app.
+    """
+    from jobflow_remote.cli.jfr_typer import JFRTyper
+    from jobflow_remote.cli.plugin import load_plugins
+    from jobflow_remote.cli.utils import out_console
+    from jobflow_remote.testing.cli import run_check_cli
+
+    app_plugin_example = JFRTyper(name="pluginexample")
+
+    @app_plugin_example.command()
+    def testexample(s: str):
+        out_console.print(s)
+
+    # Create a mock plugin that adds a command to the sub_app
+    def setup_jf_plugin():
+        from jobflow_remote.cli.jf import app
+        from jobflow_remote.cli.job import app_job
+
+        app.add_typer(app_plugin_example)
+
+        @app_job.command()
+        def subcommandexample(i: int):
+            out_console.print(i)
+
+    mock_entry_point = Mock()
+    mock_entry_point.name = "command_injection_plugin"
+    mock_plugin_module = Mock()
+    mock_plugin_module.setup_jf_plugin = setup_jf_plugin
+    mock_entry_point.load.return_value = mock_plugin_module
+
+    # Mock entry points discovery
+    mock_entry_points = Mock()
+    mock_entry_points.select.return_value = [mock_entry_point]
+    mocker.patch("importlib.metadata.entry_points", return_value=mock_entry_points)
+
+    # Execute plugin loading
+    load_plugins()
+
+    run_check_cli(
+        ["-h"],
+        required_out="pluginexample",
+    )
+
+    run_check_cli(
+        ["pluginexample", "testexample", "inputstring"],
+        required_out="inputstring",
+    )
+
+    run_check_cli(
+        ["job", "-h"],
+        required_out="subcommandexample",
+    )
+
+    run_check_cli(
+        ["job", "subcommandexample", "100000"],
+        required_out="100000",
+    )
+
+    run_check_cli(
+        ["plugin", "list"],
+        required_out=["Available plugins:", "command_injection_plugin"],
+    )

--- a/tests/unit/testing/test_cli.py
+++ b/tests/unit/testing/test_cli.py
@@ -1,10 +1,10 @@
 import pytest
 from typer.testing import Result
 
-from jobflow_remote.testing.cli import run_check_cli
-
 
 def test_run_check_cli(patch_cli_consoles):
+    from jobflow_remote.testing.cli import run_check_cli
+
     # Check multiple lines is found
     flow_excerpt = """├── flow: Commands for managing the flows
 │   ├── delete: Permanently delete Flows from the database


### PR DESCRIPTION
New mechanism for extending CLI from external packages based on plugins.

The idea is that a package can define a section in the `pyproject.toml` like:
```toml
[project.entry-points."jobflow_remote.plugins"]
backup = "path.to.some.local.module"
```

and in the module define a `setup_jf_plugin` function that will be automatically discovered and called by jobflow remote. The function should thus import some of the typer app object from jobflow-remote and add sub-apps or commands. 
For example:
```python
def setup_jf_plugin():
    from jobflow_remote.cli.job import app_job
    @app_job.command()
    def example():
        pass
```
Will add a `jf job example` to the standard CLI.

One note about the `load_plugins` and `list_plugins` functions. The logic is overlapping and they could probably be merged in a single function. For the moment I kept them separated because the `load_plugins` function will be executed at every call of the `jf` command and I would thus like to keep it as minimal as possible, while merging them will likely require a series of additional checks. I doubt this will have a real impact on the perceived time, but I thought of trying to minimize the impact

### TODO

If the approach is fine I will add some documentation.