### PR TITLE
Small fixes and tests improvements

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -167,6 +167,15 @@ def delete(
     delete_output: delete_output_opt = False,
     delete_files: delete_files_opt = False,
     delete_all: delete_all_opt = False,
+    keep_processes: Annotated[
+        bool,
+        typer.Option(
+            "--keep-processes",
+            "-kp",
+            help="Do not attempt to cancel SUBMITTED and RUNNING processes from "
+            "the worker associated with the deleted Flows",
+        ),
+    ] = False,
 ) -> None:
     """Permanently delete Flows from the database"""
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
@@ -234,6 +243,7 @@ def delete(
             flow_ids=to_delete,
             delete_output=delete_output,
             delete_files=delete_files,
+            cancel_processes=not keep_processes,
             max_limit=max_limit,
         )
 

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1342,9 +1342,15 @@ def files_get(
         worker = cm.get_worker(job_info.worker)
         host = worker.get_host()
 
-        file_name: str
         try:
             host.connect()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Error while connecting to worker {job_info.worker}: {getattr(exc, 'message', str(exc))}"
+            ) from exc
+
+        file_name: str
+        try:
             for file_name in filenames:
                 progress.update(task_id, description=f"Retrieving {file_name}")
                 host.get(str(Path(remote_dir) / file_name), str(save_path / file_name))

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -642,7 +642,6 @@ def stop(
 ) -> None:
     """
     Stop a Job. Only Jobs that did not complete or had an error can be stopped.
-    The operation is irreversible.
     If possible, the associated job submitted to the remote queue will be cancelled.
     """
     if break_lock:

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -840,7 +840,7 @@ class JobController:
         if max_limit != 0 and len(queried_dbs_ids) > max_limit:
             raise ValueError(
                 f"Cannot perform {action_description} on {len(queried_dbs_ids)} Jobs "
-                f"as they exceeds the specified maximum limit ({max_limit})."
+                f"as they exceed the specified maximum limit ({max_limit})."
                 f"Increase the limit to complete the action on this many Jobs."
             )
 
@@ -1735,7 +1735,6 @@ class JobController:
         """
         Stop selected Jobs. Only Jobs in the READY and all the running states
         can be stopped.
-        The action is not reversible.
 
         Parameters
         ----------
@@ -1812,7 +1811,6 @@ class JobController:
         can be stopped.
         Selected by db_id or uuid+index. Only one among db_id
         and job_id should be defined.
-        The action is not reversible.
 
         Parameters
         ----------
@@ -2626,6 +2624,7 @@ class JobController:
         max_limit: int = 10,
         delete_output: bool = False,
         delete_files: bool = False,
+        cancel_processes: bool = True,
     ) -> int:
         """
         Delete a list of Flows based on the flow uuids.
@@ -2641,6 +2640,9 @@ class JobController:
             If True also delete the associated output in the JobStore.
         delete_files
             If True also delete the files on the worker.
+        cancel_processes
+            If True will attempt to delete the processes for SUBMITTED and RUNNING jobs.
+            Failure to cancel will not stop the deletion of the Flow.
 
         Returns
         -------
@@ -2655,7 +2657,7 @@ class JobController:
 
         if max_limit != 0 and len(flow_ids) > max_limit:
             raise ValueError(
-                f"Cannot delete {len(flow_ids)} Flows as they exceeds the specified maximum "
+                f"Cannot delete {len(flow_ids)} Flows as they exceed the specified maximum "
                 f"limit ({max_limit}). Increase the limit to delete the Flows."
             )
         deleted = 0
@@ -2664,7 +2666,10 @@ class JobController:
             for fid in flow_ids:
                 # TODO should it catch errors?
                 if self.delete_flow(
-                    fid, delete_output=delete_output, delete_files=delete_files
+                    fid,
+                    delete_output=delete_output,
+                    delete_files=delete_files,
+                    cancel_processes=cancel_processes,
                 ):
                     deleted += 1
 
@@ -2675,6 +2680,7 @@ class JobController:
         flow_id: str,
         delete_output: bool = False,
         delete_files: bool = False,
+        cancel_processes: bool = True,
     ) -> bool:
         """
         Delete a single Flow based on the uuid.
@@ -2687,6 +2693,9 @@ class JobController:
             If True also delete the associated output in the JobStore.
         delete_files
             If True also delete the files on the worker.
+        cancel_processes
+            If True will attempt to delete the processes for SUBMITTED and RUNNING jobs.
+            Failure to cancel will not stop the deletion of the Flow.
 
         Returns
         -------
@@ -2703,9 +2712,22 @@ class JobController:
             if jobstore_name := flow.get("jobstore"):
                 jobstore = self.optional_jobstores[jobstore_name]
             jobstore.remove_docs({"uuid": {"$in": job_ids}})
-        if delete_files:
+        if delete_files or cancel_processes:
             jobs_info = self.get_jobs_info(flow_ids=[flow_id])
-            self._safe_delete_files(jobs_info)
+            if cancel_processes:
+                for ji in jobs_info:
+                    if ji.state in [JobState.SUBMITTED, JobState.RUNNING]:
+                        # try cancelling the job submitted to the remote queue
+                        try:
+                            self._cancel_queue_process(ji.model_dump(mode="python"))
+                        except Exception:
+                            logger.warning(
+                                f"Failed cancelling the process for Job {ji.uuid} {ji.index} while deleting Flow {flow_id}",
+                                exc_info=True,
+                            )
+            # delete files after cancelling the queue job
+            if delete_files:
+                self._safe_delete_files(jobs_info)
 
         self.jobs.delete_many({"uuid": {"$in": job_ids}})
         self.flows.delete_one({"uuid": flow_id})
@@ -4061,7 +4083,13 @@ class JobController:
         # so this should always be consistent.
         if len(to_ready) > 0:
             self.jobs.update_many(
-                {"db_id": {"$in": to_ready}}, {"$set": {"state": JobState.READY.value}}
+                {"db_id": {"$in": to_ready}},
+                {
+                    "$set": {
+                        "state": JobState.READY.value,
+                        "updated_on": datetime.utcnow(),
+                    }
+                },
             )
         return to_ready
 
@@ -5035,6 +5063,11 @@ class JobController:
                     job_id=job_id,
                     job_index=job_index,
                 )
+                if not job_info:
+                    raise ValueError(
+                        "The Job is not present in the Queue DB, cannot "
+                        "determine the store to fetch the output"
+                    )
             jobstore_name = self.get_flow_store(job_info.hosts[-1])
             if jobstore_name:
                 jobstore = self.optional_jobstores[jobstore_name]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -582,3 +582,34 @@ def disable_initial_load_plugins(monkeypatch):
     from jobflow_remote import SETTINGS
 
     monkeypatch.setattr(SETTINGS, "cli_load_plugins", False)
+
+
+def reenable_log_propagation(f):
+    def wrapper(*args, **kwargs):
+        for logger_dict in args[0].get("loggers", {}).values():
+            if not logger_dict.get("propagate", True):
+                logger_dict["propagate"] = True
+        # setting disable_existing_loggers to False does not seem strictly
+        # necessary, but doing it anyway.
+        args[0]["disable_existing_loggers"] = False
+
+        return f(*args, **kwargs)
+
+    return wrapper
+
+
+@pytest.fixture(autouse=True)
+def allow_log_propagation_during_dict_config(monkeypatch):
+    """
+    logging utils in jobflow_remote disable log propagation, preventing
+    caplog to properly capture the logs during tests.
+    This fixture intercepts the calls to dictConfig and sets propagate=True
+    for all the loggers.
+    """
+    import logging.config
+
+    monkeypatch.setattr(
+        logging.config,
+        "dictConfig",
+        reenable_log_propagation(logging.config.dictConfig),
+    )

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -135,7 +135,7 @@ def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
         submit_flow(flow, worker="test_local_worker")
 
     outputs = [
-        " Cannot delete 11 Flows as they exceeds the specified maximum limit (10)"
+        " Cannot delete 11 Flows as they exceed the specified maximum limit (10)"
     ]
     done_output = ["Deleted Flow(s) with id"]
     # try deleting the flow with max=10. It fails

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -77,11 +77,11 @@ def test_queries(job_controller, runner) -> None:
     assert job_controller.count_jobs(db_ids="1") == 1
     assert job_controller.count_jobs(job_ids=(add_first.uuid, 1)) == 1
     jobs_start_date = job_controller.get_jobs_info(start_date=date_create)
-    assert len(jobs_start_date) == 1
-    assert jobs_start_date[0].uuid == add_first.uuid
+    assert len(jobs_start_date) == 2
+    assert {j.uuid for j in jobs_start_date} == {add_first.uuid, add_second.uuid}
 
     jobs_end_date = job_controller.get_jobs_info(end_date=date_create)
-    assert jobs_end_date[0].uuid == add_second.uuid
+    assert {j.uuid for j in jobs_end_date} == {add_third.uuid, add_fourth.uuid}
 
     assert job_controller.count_jobs(metadata={"test_meta": 1}) == 1
 
@@ -1228,3 +1228,122 @@ def test_get_job_output(job_controller, runner, one_job):
     runner.run_all_jobs(max_seconds=20)
 
     assert job_controller.get_job_output(db_id="1") == 6
+
+
+def test_delete_flow(job_controller, runner, caplog):
+    from pathlib import Path
+
+    from jobflow import Flow
+    from qtoolkit.core.data_objects import CancelStatus
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.testing import add, add_sleep
+
+    j1 = add(5, 6)
+    f1 = Flow([j1])
+    submit_flow(f1, worker="test_local_worker")
+
+    assert job_controller.count_flows() == 1
+    assert job_controller.count_jobs() == 1
+
+    assert job_controller.delete_flow(f1.uuid)
+    assert job_controller.count_flows() == 0
+    assert job_controller.count_jobs() == 0
+
+    # Test delete with output and files
+    completed_job = add(10, 20)
+    completed_flow = Flow([completed_job])
+    submit_flow(completed_flow, worker="test_local_worker")
+
+    # Run to completion to create output and files
+    runner.run_all_jobs(max_seconds=10)
+
+    completed_job_info = job_controller.get_job_info(
+        job_id=completed_job.uuid, job_index=completed_job.index
+    )
+    assert completed_job_info.state == JobState.COMPLETED
+
+    # Verify output exists
+    output = job_controller.get_job_output(job_id=completed_job.uuid)
+    assert output == 30
+
+    # Verify run directory exists
+    run_dir = Path(completed_job_info.run_dir)
+    assert run_dir.exists()
+
+    # Delete with delete_output and delete_files
+    result = job_controller.delete_flow(
+        completed_flow.uuid, delete_output=True, delete_files=True
+    )
+    assert result is True
+
+    # Verify output was deleted
+    with pytest.raises(ValueError, match=".*has no outputs.*"):
+        job_controller.jobstore.get_output(completed_job.uuid)
+
+    # Test process cancellation by simulating jobs in SUBMITTED and RUNNING states
+    j2 = add_sleep(1, 30)
+    f2 = Flow([j2])
+    submit_flow(f2, worker="test_local_worker")
+
+    runner.run_one_job(max_seconds=20, target_state=JobState.RUNNING)
+    j2_info = job_controller.get_job_info(job_id=j2.uuid, job_index=j2.index)
+    assert j2_info.state == JobState.RUNNING
+
+    qm = runner.get_queue_manager("test_local_worker")
+    assert qm.get_jobs_list([j2_info.remote.process_id])
+
+    # delete and cancel the remote processes
+    assert job_controller.delete_flow(f2.uuid, cancel_processes=True)
+
+    assert job_controller.count_flows() == 0
+
+    assert not qm.get_jobs_list([j2_info.remote.process_id])
+
+    # Test cancel_processes=False
+    j3 = add(1, 30)
+    f3 = Flow([j3])
+    submit_flow(f3, worker="test_local_worker")
+
+    runner.run_one_job(max_seconds=20, target_state=JobState.RUNNING)
+    j3_info = job_controller.get_job_info(job_id=j3.uuid, job_index=j3.index)
+    assert j3_info.state == JobState.RUNNING
+
+    assert qm.get_jobs_list([j3_info.remote.process_id])
+
+    assert job_controller.delete_flow(f3.uuid, cancel_processes=False)
+
+    assert qm.get_jobs_list([j3_info.remote.process_id])
+
+    # attempt cancelling the job to speed up the completion of the test. it is not strictly necessary that it succeeds
+    qm.cancel(j3_info.remote.process_id)
+
+    assert job_controller.count_flows() == 0
+
+    # Test cancel_processes=True with already finished Job
+    j4 = add(1, 30)
+    f4 = Flow([j4])
+    submit_flow(f4, worker="test_local_worker")
+
+    runner.run_one_job(max_seconds=20, target_state=JobState.RUNNING)
+    j4_info = job_controller.get_job_info(job_id=j4.uuid, job_index=j4.index)
+    assert j4_info.state == JobState.RUNNING
+
+    assert qm.get_jobs_list([j4_info.remote.process_id])
+    assert qm.cancel(j4_info.remote.process_id).status == CancelStatus.SUCCESSFUL
+    assert not qm.get_jobs_list([j4_info.remote.process_id])
+
+    assert job_controller.delete_flow(f4.uuid, cancel_processes=True)
+
+    warning_records = [
+        r
+        for r in caplog.records
+        if "Failed cancelling the process for Job" in r.message
+    ]
+    assert len(warning_records) == 1
+
+    assert job_controller.count_flows() == 0
+
+    # Test deleting non-existent flow
+    assert not job_controller.delete_flow("non-existent-uuid")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,224 @@ from monty.os import cd
 from python_on_whales import DockerClient
 from python_on_whales import docker as docker_pow
 
+# Note that the workers are identified based on the scheduler_type, assuming that
+# "shell" workers are executed locally and not in any container. If this changes
+# the options will need to be modified. The fixtures will need to be updated accordingly.
+WORKER_TYPES = [
+    "shell",
+    "slurm",
+    "sge",
+    "pbs",
+]
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--worker-types",
+        "--wt",
+        dest="worker_types",
+        nargs="+",
+        help="List of workers to be used for the integration tests. All available if not specified.",
+        default=None,
+        action="store",
+        choices=WORKER_TYPES,
+    )
+
+
+@pytest.fixture(scope="session")
+def workers_list(
+    slurm_ssh_port, sge_ssh_port, pbs_ssh_port, tmp_proj_work_dirs, worker_types
+):
+    """
+    Dictionary workers to be set up based on the types of workers selected.
+    """
+    tmp_proj_dir, workdir = tmp_proj_work_dirs
+
+    prerun = (
+        "source /home/jobflow/.venv/bin/activate; "
+        "export COVERAGE_PROCESS_START=/home/jobflow/pyproject.toml; "
+        "export COVERAGE_FILE=/home/jobflow/coverage/.coverage"
+    )
+    workers = {
+        "test_local_worker": dict(
+            type="local",
+            scheduler_type="shell",
+            work_dir=str(workdir),
+            resources={},
+        ),
+        "test_sanitize_local_worker": dict(
+            type="local",
+            scheduler_type="shell",
+            work_dir=str(workdir),
+            resources={},
+            sanitize_command=True,
+        ),
+        "test_remote_slurm_worker": dict(
+            type="remote",
+            host="localhost",
+            port=slurm_ssh_port,
+            scheduler_type="slurm",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            pre_run=prerun,
+            resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+        ),
+        "test_remote_sge_worker": dict(
+            type="remote",
+            host="localhost",
+            port=sge_ssh_port,
+            scheduler_type="sge",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            scheduler_username="jobflow",
+            pre_run=prerun,
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+        ),
+        "test_remote_pbs_worker": dict(
+            type="remote",
+            host="localhost",
+            port=pbs_ssh_port,
+            scheduler_type="pbs",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            pre_run=prerun,
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+            resources={"walltime": "00:05:00", "select": "nodes=1:ppn=1"},
+        ),
+        "test_remote_limited_worker": dict(
+            type="remote",
+            host="localhost",
+            port=slurm_ssh_port,
+            scheduler_type="slurm",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            pre_run=prerun,
+            resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+            max_jobs=1,
+        ),
+        "test_batch_remote_worker": dict(
+            type="remote",
+            host="localhost",
+            port=slurm_ssh_port,
+            scheduler_type="slurm",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            pre_run=prerun,
+            resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+            batch={
+                "jobs_handle_dir": "/home/jobflow/jfr/batch_handle",
+                "work_dir": "/home/jobflow/jfr/batch_work",
+                "max_wait": 5,
+            },
+            max_jobs=1,
+        ),
+        "test_batch_multi_remote_worker": dict(
+            type="remote",
+            host="localhost",
+            port=slurm_ssh_port,
+            scheduler_type="slurm",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            pre_run=prerun,
+            resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+            batch={
+                "jobs_handle_dir": "/home/jobflow/jfr/batch_multi_handle",
+                "work_dir": "/home/jobflow/jfr/batch_multi_work",
+                "max_wait": 10,
+                "parallel_jobs": 2,
+            },
+            max_jobs=1,
+        ),
+        "test_max_jobs_worker": dict(
+            type="local",
+            scheduler_type="shell",
+            work_dir=str(workdir),
+            resources={},
+            max_jobs=2,
+        ),
+        "test_sanitize_remote_worker": dict(
+            type="remote",
+            host="localhost",
+            port=slurm_ssh_port,
+            scheduler_type="slurm",
+            work_dir="/home/jobflow/jfr",
+            user="jobflow",
+            password="jobflow",
+            pre_run=prerun,
+            resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
+            connect_kwargs={"allow_agent": False, "look_for_keys": False},
+            sanitize_command=True,
+        ),
+    }
+    # remove the workers that do not belong to the selected type
+    return {wn: w for wn, w in workers.items() if w["scheduler_type"] in worker_types}
+
+
+@pytest.fixture(scope="session")
+def worker_types(request):
+    """
+    List of worker types activated during the integration tests
+    """
+    wt = request.config.getoption("--worker-types")
+    if wt is None:
+        wt = list(WORKER_TYPES)
+    return wt
+
+
+@pytest.fixture(scope="session")
+def integration_workers(workers_list):
+    """
+    List of worker names activated during the integration tests
+    """
+    return list(workers_list)
+
+
+@pytest.fixture(autouse=True)
+def check_worker_requirements(request, integration_workers):
+    """
+    Automatically check worker requirements and skip if needed.
+
+    Will skip, depending on the selected worker types:
+      * if there is a parametrization with a parameter named "worker" and
+        the value is not among the selected worker. Only the corresponding
+        parameter value will be skipped
+      * if the test is marked with a list of worker names that are used inside
+        the test (e.g. @pytest.mark.workers(["test_max_jobs_worker"])). If not
+        all the workers are among the selected ones the test will be skipped.
+
+    Tests with no "worker" parametrization or mark will be executed.
+    """
+    # Get the workers marker from the test
+    workers_marker = request.node.get_closest_marker("workers")
+
+    if workers_marker is not None:
+        required_workers = workers_marker.args[0] if workers_marker.args else []
+
+        # Check if any required worker is not in selected workers
+        missing_workers = [w for w in required_workers if w not in integration_workers]
+        if missing_workers:
+            pytest.skip(
+                f"Test requires workers {required_workers}, but {missing_workers} not in selected workers {integration_workers}"
+            )
+
+    # Handle parametrized workers
+    if hasattr(request.node, "callspec") and "worker" in request.node.callspec.params:
+        worker_param = request.node.callspec.params["worker"]
+        if worker_param not in integration_workers:
+            pytest.skip(
+                f"Worker '{worker_param}' not in selected workers {integration_workers}"
+            )
+
 
 @pytest.fixture(autouse=True)
 def mock_fabric_run(monkeypatch) -> None:
@@ -76,10 +294,15 @@ def db_port():
 
 
 @pytest.fixture(scope="session", autouse=True)
-def bake_containers():
+def bake_containers(worker_types):
+    # targets here should be a list containing "slurm", "sge", "pbs"
+    targets = [w for w in worker_types if w != "shell"]
+    # don't bake anything if only "shell" is needed.
+    if not targets:
+        return
     hcl_path = Path(__file__).parent.resolve() / "dockerfiles/docker-bake.hcl"
     docker_pow.buildx.bake(
-        targets=["slurm", "sge", "pbs"],
+        targets=targets,
         files=hcl_path,
         set={"*.context": str(Path(__file__).parent.parent.parent.resolve())},
     )
@@ -94,6 +317,7 @@ def compose_containers(
     bake_containers,
     coverage_file,
     pytestconfig,
+    worker_types,
 ):
     compose_yaml = f"""
 name: jobflow_remote_testing
@@ -111,6 +335,9 @@ services:
       retries: 28
       start_period: 2s
 
+"""
+    if "slurm" in worker_types:
+        compose_yaml += f"""
   jobflow_remote_testing_slurm:
     image: ghcr.io/matgenix/jobflow-remote-testing-slurm:latest
     container_name: jobflow_testing_slurm
@@ -125,6 +352,10 @@ services:
       retries: 30
       start_period: 2s
 
+"""
+
+    if "sge" in worker_types:
+        compose_yaml += f"""
   jobflow_remote_testing_sge:
     image: ghcr.io/matgenix/jobflow-remote-testing-sge:latest
     container_name: jobflow_testing_sge
@@ -139,6 +370,10 @@ services:
       retries: 30
       start_period: 2s
 
+"""
+
+    if "pbs" in worker_types:
+        compose_yaml += f"""
   jobflow_remote_testing_pbs:
     image: ghcr.io/matgenix/jobflow-remote-testing-pbs:latest
     container_name: jobflow_testing_pbs
@@ -328,6 +563,7 @@ def write_tmp_settings(
     db_port,
     tmp_proj_work_dirs,
     pytestconfig,
+    workers_list,
 ):
     """Collects the various sub-configs and writes them to a temporary file in a
     temporary directory."""
@@ -340,11 +576,6 @@ def write_tmp_settings(
     # config on import
     from jobflow_remote.config import Project
 
-    prerun = (
-        "source /home/jobflow/.venv/bin/activate; "
-        "export COVERAGE_PROCESS_START=/home/jobflow/pyproject.toml; "
-        "export COVERAGE_FILE=/home/jobflow/coverage/.coverage"
-    )
     project = Project(
         name=random_project_name,
         jobstore={
@@ -376,127 +607,7 @@ def write_tmp_settings(
             "flows_collection": "flows",
         },
         log_level="debug",
-        workers={
-            "test_local_worker": dict(
-                type="local",
-                scheduler_type="shell",
-                work_dir=str(workdir),
-                resources={},
-            ),
-            "test_sanitize_local_worker": dict(
-                type="local",
-                scheduler_type="shell",
-                work_dir=str(workdir),
-                resources={},
-                sanitize_command=True,
-            ),
-            "test_remote_slurm_worker": dict(
-                type="remote",
-                host="localhost",
-                port=slurm_ssh_port,
-                scheduler_type="slurm",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                pre_run=prerun,
-                resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-            ),
-            "test_remote_sge_worker": dict(
-                type="remote",
-                host="localhost",
-                port=sge_ssh_port,
-                scheduler_type="sge",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                scheduler_username="jobflow",
-                pre_run=prerun,
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-            ),
-            "test_remote_pbs_worker": dict(
-                type="remote",
-                host="localhost",
-                port=pbs_ssh_port,
-                scheduler_type="pbs",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                pre_run=prerun,
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-                resources={"walltime": "00:05:00", "select": "nodes=1:ppn=1"},
-            ),
-            "test_remote_limited_worker": dict(
-                type="remote",
-                host="localhost",
-                port=slurm_ssh_port,
-                scheduler_type="slurm",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                pre_run=prerun,
-                resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-                max_jobs=1,
-            ),
-            "test_batch_remote_worker": dict(
-                type="remote",
-                host="localhost",
-                port=slurm_ssh_port,
-                scheduler_type="slurm",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                pre_run=prerun,
-                resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-                batch={
-                    "jobs_handle_dir": "/home/jobflow/jfr/batch_handle",
-                    "work_dir": "/home/jobflow/jfr/batch_work",
-                    "max_wait": 5,
-                },
-                max_jobs=1,
-            ),
-            "test_batch_multi_remote_worker": dict(
-                type="remote",
-                host="localhost",
-                port=slurm_ssh_port,
-                scheduler_type="slurm",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                pre_run=prerun,
-                resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-                batch={
-                    "jobs_handle_dir": "/home/jobflow/jfr/batch_multi_handle",
-                    "work_dir": "/home/jobflow/jfr/batch_multi_work",
-                    "max_wait": 10,
-                    "parallel_jobs": 2,
-                },
-                max_jobs=1,
-            ),
-            "test_max_jobs_worker": dict(
-                type="local",
-                scheduler_type="shell",
-                work_dir=str(workdir),
-                resources={},
-                max_jobs=2,
-            ),
-            "test_sanitize_remote_worker": dict(
-                type="remote",
-                host="localhost",
-                port=slurm_ssh_port,
-                scheduler_type="slurm",
-                work_dir="/home/jobflow/jfr",
-                user="jobflow",
-                password="jobflow",
-                pre_run=prerun,
-                resources={"partition": "debug", "ntasks": 1, "time": "00:01:00"},
-                connect_kwargs={"allow_agent": False, "look_for_keys": False},
-                sanitize_command=True,
-            ),
-        },
+        workers=workers_list,
         exec_config={
             "test": {"export": {"TESTING_ENV_VAR": random_project_name}},
             "some_pre_run": {
@@ -528,13 +639,18 @@ def write_tmp_settings(
 
 
 @pytest.fixture()
-def clean_slurm_queue(write_tmp_settings, coverage_file):
+def clean_slurm_queue(write_tmp_settings, coverage_file, worker_types):
     """
     Clean the list of Jobs in the SLURM queue at the end of the test.
     """
     from jobflow_remote.remote.queue import QueueManager
 
     yield
+
+    # Skip if slurm has been deselected. In principle, this fixture should never be used in that case.
+    if "slurm" not in worker_types:
+        return
+
     project = write_tmp_settings
     worker = project.workers["test_remote_slurm_worker"]
     queue_manager = QueueManager(worker.get_scheduler_io(), worker.get_host())

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -9,6 +9,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+@pytest.mark.workers(["test_batch_remote_worker"])
 def test_run_batch(job_controller, monkeypatch, clean_slurm_queue) -> None:
     from jobflow import Flow
 
@@ -45,6 +46,7 @@ def test_run_batch(job_controller, monkeypatch, clean_slurm_queue) -> None:
         assert jobs_info[i].end_time < jobs_info[i + 1].start_time
 
 
+@pytest.mark.workers(["test_batch_multi_remote_worker"])
 def test_run_batch_multi(job_controller, monkeypatch, clean_slurm_queue) -> None:
     from jobflow import Flow
 
@@ -79,6 +81,7 @@ def test_run_batch_multi(job_controller, monkeypatch, clean_slurm_queue) -> None
             assert ji1.start_time < ji2.end_time
 
 
+@pytest.mark.workers(["test_batch_multi_remote_worker"])
 def test_run_batch_multi_fail(
     patch_project,
     job_controller,
@@ -113,7 +116,7 @@ def test_run_batch_multi_fail(
     daemon_manager.start()
     wait_daemon_started(daemon_manager)
 
-    for _ in range(10):
+    for _ in range(20):
         if (
             len(
                 job_controller.get_jobs_info(
@@ -171,7 +174,7 @@ def test_run_batch_multi_fail(
     # and running files are properly cleaned
     daemon_manager.start()
     wait_daemon_started(daemon_manager)
-    for _ in range(10):
+    for _ in range(20):
         if all(
             ji.state == JobState.REMOTE_ERROR
             for ji in job_controller.get_jobs_info(
@@ -188,7 +191,7 @@ def test_run_batch_multi_fail(
     # submit more jobs, will also be used to check that the files are cleaned during the reset
     job_ids = submit_jobs(4, 15)
 
-    for _ in range(10):
+    for _ in range(20):
         if (
             len(
                 job_controller.get_jobs_info(
@@ -236,6 +239,7 @@ def test_run_batch_multi_fail(
     assert len(batch_manager.get_running()) == 0
 
 
+@pytest.mark.workers(["test_max_jobs_worker"])
 def test_max_jobs_worker(
     job_controller, daemon_manager, wait_daemon_started, wait_daemon_shutdown
 ) -> None:

--- a/tests/integration/test_workers.py
+++ b/tests/integration/test_workers.py
@@ -49,21 +49,16 @@ def test_paramiko_ssh_connection(random_project_name, job_controller) -> None:
             )
 
 
-def test_project_check(job_controller, run_check_cli) -> None:
-    expected = [
-        "✓ Worker test_local_worker",
-        "✓ Worker test_sanitize_local_worker",
-        "✓ Worker test_remote_slurm_worker",
-        "✓ Worker test_remote_sge_worker",
-        "✓ Worker test_remote_limited_worker",
-        "✓ Worker test_batch_remote_worker",
-        "✓ Worker test_max_jobs_worker",
-        "✓ Worker test_sanitize_remote_worker",
-        "✓ Worker test_remote_slurm_worker",
-        "✓ Worker test_remote_sge_worker",
-        "✓ Jobstore",
-        "✓ Queue store",
-    ]
+def test_project_check(job_controller, integration_workers, run_check_cli) -> None:
+    from jobflow_remote.testing.cli import run_check_cli
+
+    expected = [f"✓ Worker {wn}" for wn in integration_workers]
+    expected.extend(
+        [
+            "✓ Jobstore",
+            "✓ Queue store",
+        ]
+    )
     # Here there will be "errors" reported as there likely be a mismatch of the
     # jobflow-remote version between the local environment and the one in the
     # container
@@ -332,11 +327,11 @@ def test_undefined_additional_stores(worker, job_controller) -> None:
 
 
 @pytest.mark.parametrize(
-    "remote_worker_name",
+    "worker",
     ["test_remote_slurm_worker", "test_remote_sge_worker", "test_remote_pbs_worker"],
 )
 def test_submit_flow_with_scheduler_username(
-    remote_worker_name, monkeypatch, job_controller
+    worker, monkeypatch, job_controller
 ) -> None:
     from jobflow import Flow
 
@@ -348,16 +343,16 @@ def test_submit_flow_with_scheduler_username(
 
     job = add(1, 1)
     flow = Flow([job])
-    submit_flow(flow, worker=remote_worker_name)
+    submit_flow(flow, worker=worker)
 
     # modify the runner so that uses a patched version of the worker
     # where the scheduler_username is set
     runner = Runner()
-    patched_worker = runner.get_worker(remote_worker_name).model_copy()
+    patched_worker = runner.get_worker(worker).model_copy()
     patched_worker.scheduler_username = "jobflow"
 
     def patched_get_worker(self, worker_name):
-        if worker_name != remote_worker_name:
+        if worker_name != worker:
             return runner.workers[worker_name]
         return patched_worker
 


### PR DESCRIPTION
A set of small updates:
* fix `updated_on` upon job completion
* fix docstrings and error messages
* Attempt to cancel running processes when deleting a Flow. Will be done automatically by default
* New option when running integration tests `--worker-types`. Allows to select the types of worker for integration tests. This makes easier to run them only on some containers, since I have problems running on SLURM, PBS and SGE with the same docker options.