### PR TITLE
Clearer error message for undefined active project

### DIFF
--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -290,7 +290,8 @@ def cli_error_handler(func):
             raise  # Do not capture click or typer exceptions
         except ProjectUndefinedError:
             exit_with_error_msg(
-                "The active project could not be determined and it is required to execute this command"
+                "The active project could not be determined and it is required to execute this command. Please "
+                "check the formatting of your YAML."
             )
         except Exception as e:
             from jobflow_remote import SETTINGS


### PR DESCRIPTION
Closes https://github.com/Matgenix/jobflow-remote/issues/286 by providing a clearer error message to users when the YAML is likely incorrectly formatted. This isn't really a solution per se, but at the very least it prompts the user where to look to fix things.