### PR TITLE
Bugfix and small updates

### DIFF
--- a/doc/source/user/projectconf.rst
+++ b/doc/source/user/projectconf.rst
@@ -11,6 +11,14 @@ of a single project. The handling of :ref:`projectconf multi` will be described 
 Aside from the project options, a set of :ref:`projectconf general` can be also be
 configured through environment variables or an additional configuration file.
 
+.. warning::
+
+    As this is a common source of error, it is important to note that the jobflow-remote
+    ``Runner`` **reads all the configurations when the processes is started** and does
+    not attempt to refresh them during the execution. Whenever any configuration is changed
+    the ``Runner`` should be restarted.
+
+
 Project options
 ===============
 
@@ -38,7 +46,13 @@ section below, while an example for a full configuration file can be generated r
 Note that, while the default file format is YAML, JSON and TOML are also acceptable format.
 You can generate the example in the other formats using the ``--format`` option.
 
+.. note::
 
+    In case of failed validation of any of the configuration options, the file will not be
+    recognized as a project at all. To check the errors in the validation the easiest
+    option is to run::
+
+        jf project list --warn
 
 Name and folders
 ----------------
@@ -221,6 +235,11 @@ in this project.
             password: <password>
             database: <database name>
             collection_name: outputs
+
+.. note::
+
+    For compatibility with the original jobflow configuration file, the field can
+    also be defined as ``JOB_STORE`` instead of ``jobstore`.
 
 .. _projectconf queuestore:
 
@@ -448,7 +467,7 @@ The most useful variable to set is the ``project`` one, allowing to select the
 default project to be used in a multi-project environment.
 
 Other generic options are the location of the projects folder, instead of
-``~/.jfremote`` (``JFREMOTE_PROJECT_FOLDER``) and the path to the ``~/.jfremote.yaml``
+``~/.jfremote`` (``JFREMOTE_PROJECTS_FOLDER``) and the path to the ``~/.jfremote.yaml``
 file itself (``JFREMOTE_CONFIG_FILE``).
 
 Some customization options are also available for the behaviour of the CLI.

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -213,10 +213,11 @@ def stop(
     """
     cm = get_config_manager()
     dm = DaemonManager.from_project(cm.get_project())
+    stop_sent = False
     with loading_spinner(processing=False) as progress:
         progress.add_task(description="Stopping the daemon...", total=None)
         try:
-            dm.stop(wait=wait, raise_on_error=True)
+            stop_sent = dm.stop(wait=wait, raise_on_error=True)
         except RunningDaemonError as e:
             exit_with_error_msg(
                 f"Error while stopping the daemon: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
@@ -227,7 +228,7 @@ def stop(
             )
     from jobflow_remote import SETTINGS
 
-    if not wait and SETTINGS.cli_suggestions:
+    if stop_sent and not wait and SETTINGS.cli_suggestions:
         out_console.print(
             "The stop signal has been sent to the Runner. Run 'jf runner status' to verify if it stopped",
             style="yellow",
@@ -438,5 +439,10 @@ def reset(
     with loading_spinner(processing=False) as progress:
         progress.add_task(description="Resetting runner information...", total=None)
         jc.clean_running_runner(break_lock=break_lock)
+
+        # Also clean supervisord files, if they exist.
+        cm = get_config_manager()
+        dm = DaemonManager.from_project(cm.get_project())
+        dm.clean_files()
 
     out_console.print("The running runner document was reset")

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -7,7 +7,14 @@ from typing import Annotated, Any, Literal, Optional, Union
 
 from jobflow import JobStore
 from maggma.stores import MongoStore
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+)
 from qtoolkit.io import BaseSchedulerIO, scheduler_mapping
 
 from jobflow_remote.remote.host import BaseHost, LocalHost, RemoteHost
@@ -585,6 +592,7 @@ class Project(BaseModel):
         description="The JobStore used for the output. Can contain the monty "
         "serialized dictionary or the Store in the Jobflow format",
         validate_default=True,
+        validation_alias=AliasChoices("jobstore", "JOB_STORE"),
     )
     remote_jobstore: Optional[dict] = Field(
         None,

--- a/src/jobflow_remote/config/helper.py
+++ b/src/jobflow_remote/config/helper.py
@@ -167,6 +167,11 @@ def check_worker(
         from jobflow_remote.remote.queue import QueueManager
 
         qm = QueueManager(scheduler_io=worker.get_scheduler_io(), host=host)
+
+        if worker.resources:
+            # check that the default resources are properly defined.
+            qm.get_submission_script('echo "test"', options=worker.resources)
+
         qm.get_jobs_list()
 
         workdir_err = _check_workdir(worker=worker, host=host)

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -310,8 +310,6 @@ class DaemonManager:
         """
         Check if the supervisord process is running and belongs to the same user.
 
-        If the supervisord process is not running but the daemon files are present, clean them up.
-
         Returns
         -------
         bool
@@ -340,11 +338,8 @@ class DaemonManager:
         except psutil.NoSuchProcess:
             running = False
 
-        if not running and pid is not None:
-            logger.warning(
-                f"Process with pid {pid} is not running but daemon files are present. Cleaning them up."
-            )
-            self.clean_files()
+        # Here it used to delete the pid files in case they existed and running==False.
+        # This can cause issues with multiple machines sharing the same home.
 
         return running
 
@@ -727,7 +722,8 @@ class DaemonManager:
                 DaemonStatus.SHUT_DOWN,
             ):
                 lock.update_on_release = {"$set": {"running_runner": None}}
-                return True
+                logger.info("The runner is not running")
+                return False
 
             if status in (DaemonStatus.RUNNING, DaemonStatus.PARTIALLY_RUNNING):
                 interface = self.get_interface()

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2385,6 +2385,8 @@ class JobController:
             JobState.FAILED,
             JobState.PAUSED,
             JobState.REMOTE_ERROR,
+            JobState.STOPPED,
+            JobState.USER_STOPPED,
         ]
 
         return self._many_jobs_action(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import time
 import warnings
+from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 
@@ -540,6 +541,35 @@ def update_project_data(
     Project.model_validate(d)
 
     dumpfn(d, project_file_path)
+
+
+@contextmanager
+def update_project_data_ctx(
+    update: dict, dict_mods: bool = True, project_file_path: Path = None
+):
+    from jobflow_remote.config.manager import ConfigManager
+
+    cm = ConfigManager()
+    current_project_data = cm.get_project_data()
+
+    update_project_data(
+        update=update, dict_mods=dict_mods, project_file_path=project_file_path
+    )
+    yield
+
+    cm.dump_project(current_project_data)
+
+
+@pytest.fixture()
+def patch_project_ctx():
+    from jobflow_remote.config.manager import ConfigManager
+
+    cm = ConfigManager()
+    current_project_data = cm.get_project_data()
+
+    return partial(
+        update_project_data_ctx, project_file_path=Path(current_project_data.filepath)
+    )
 
 
 @pytest.fixture()

--- a/tests/db/cli/test_admin.py
+++ b/tests/db/cli/test_admin.py
@@ -2,6 +2,7 @@ import pytest
 
 
 def test_reset(job_controller, one_job, run_check_cli) -> None:
+    import time
     from datetime import datetime
 
     from jobflow import Flow
@@ -19,6 +20,7 @@ def test_reset(job_controller, one_job, run_check_cli) -> None:
     for _ in range(26):
         f = Flow(add(1, 2))
         submit_flow(f, worker="test_local_worker")
+        time.sleep(0.001)
 
     run_check_cli(
         ["admin", "reset"],

--- a/tests/db/jobs/test_daemon.py
+++ b/tests/db/jobs/test_daemon.py
@@ -16,6 +16,13 @@ def _check_running_runner_doc(job_controller, runner_info):
         assert db_info[key] == runner_info[key]
 
 
+@pytest.fixture()
+def pid_file(daemon_manager):
+    daemon_manager.pid_filepath.touch(exist_ok=True)
+    yield daemon_manager.pid_filepath
+    daemon_manager.pid_filepath.unlink(missing_ok=True)
+
+
 @pytest.mark.parametrize(
     "single",
     [True, False],
@@ -96,9 +103,7 @@ def test_kill(job_controller, daemon_manager, wait_daemon_started) -> None:
     assert daemon_manager.check_status() == DaemonStatus.STOPPED
 
 
-def test_kill_supervisord(
-    job_controller, daemon_manager, caplog, wait_daemon_started
-) -> None:
+def test_kill_supervisord(job_controller, daemon_manager, wait_daemon_started) -> None:
     import signal
     import time
 
@@ -118,13 +123,6 @@ def test_kill_supervisord(
         os.kill(process_dict["pid"], signal.SIGKILL)
     time.sleep(2)
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
-    # check that the warning message is present among the logged messages
-    log_msg = caplog.messages
-    assert len(log_msg) > 0
-    assert (
-        f"Process with pid {supervisord_pid} is not running but daemon files are present"
-        in log_msg[-1]
-    )
 
 
 def test_kill_one_process(job_controller, daemon_manager, wait_daemon_started) -> None:
@@ -185,7 +183,9 @@ def test_runner_info_auxiliary(
     assert isinstance(runner_info["last_pinged"], datetime.datetime)
 
 
-def test_runner_different_machine(daemon_manager, job_controller, caplog) -> None:
+def test_runner_different_machine(
+    daemon_manager, job_controller, caplog, pid_file
+) -> None:
     # Test that all the methods will not have effect if in the DB
     # a running_runner is present with a different machine
     from jobflow_remote.jobs.daemon import DaemonStatus, RunningDaemonError
@@ -199,13 +199,19 @@ def test_runner_different_machine(daemon_manager, job_controller, caplog) -> Non
     )
 
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
+    # The pid file is created manually to simulate the case in which the
+    # different machine shares the same home folder. The pid file should
+    # not be deleted.
+    assert daemon_manager.pid_filepath.exists()
     with pytest.raises(
         RunningDaemonError,
         match=r"A daemon runner process may be running on a different machine",
     ):
         daemon_manager.start(raise_on_error=True, single=False)
+    assert daemon_manager.pid_filepath.exists()
 
     assert not daemon_manager.start(raise_on_error=False, single=False)
+    assert daemon_manager.pid_filepath.exists()
 
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
 
@@ -216,8 +222,10 @@ def test_runner_different_machine(daemon_manager, job_controller, caplog) -> Non
         match=r"A daemon runner process may be running on a different machine",
     ):
         daemon_manager.kill(raise_on_error=True)
+    assert daemon_manager.pid_filepath.exists()
 
     assert not daemon_manager.kill(raise_on_error=False)
+    assert daemon_manager.pid_filepath.exists()
 
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
 
@@ -228,8 +236,10 @@ def test_runner_different_machine(daemon_manager, job_controller, caplog) -> Non
         match=r"A daemon runner process may be running on a different machine",
     ):
         daemon_manager.stop(raise_on_error=True)
+    assert daemon_manager.pid_filepath.exists()
 
     assert not daemon_manager.stop(raise_on_error=False)
+    assert daemon_manager.pid_filepath.exists()
 
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
 
@@ -240,12 +250,17 @@ def test_runner_different_machine(daemon_manager, job_controller, caplog) -> Non
         match=r"A daemon runner process may be running on a different machine",
     ):
         daemon_manager.shut_down(raise_on_error=True)
+    assert daemon_manager.pid_filepath.exists()
 
     assert not daemon_manager.shut_down(raise_on_error=False)
+    assert daemon_manager.pid_filepath.exists()
 
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
 
     _check_running_runner_doc(job_controller=job_controller, runner_info=runner_info)
+
+    daemon_manager.clean_files()
+    assert not daemon_manager.pid_filepath.exists()
 
 
 def test_stop_restart_diff(daemon_manager, caplog, wait_daemon_started):

--- a/tests/integration/test_workers.py
+++ b/tests/integration/test_workers.py
@@ -49,7 +49,9 @@ def test_paramiko_ssh_connection(random_project_name, job_controller) -> None:
             )
 
 
-def test_project_check(job_controller, integration_workers, run_check_cli) -> None:
+def test_project_check(
+    job_controller, integration_workers, run_check_cli, patch_project_ctx
+) -> None:
     from jobflow_remote.testing.cli import run_check_cli
 
     expected = [f"✓ Worker {wn}" for wn in integration_workers]
@@ -63,6 +65,27 @@ def test_project_check(job_controller, integration_workers, run_check_cli) -> No
     # jobflow-remote version between the local environment and the one in the
     # container
     run_check_cli(["project", "check", "-e"], required_out=expected)
+
+    # Set wrong resources for a batch worker. Should give an error.
+    # Only test if the batch worker is present (may be absent in case a subset of
+    # the workers is used in local tests)
+    if "test_batch_remote_worker" in job_controller.project.workers:
+        with patch_project_ctx(
+            update={
+                "_set": {
+                    "workers->test_batch_remote_worker->resources->wrong_key": "some value"
+                }
+            }
+        ):
+            errors = [
+                "Errors",
+                "x Worker test_batch_remote_worker",
+                "The following keys are not present in the template: wrong_key",
+            ]
+            run_check_cli(
+                ["project", "check", "-e", "-w" "test_batch_remote_worker"],
+                required_out=errors,
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR addresses some minor issues:
* Create a `JOB_STORE` alias for `jobstore` in the project configuration #328
* Improve documentation for project configuration
* Fix `JFREMOTE_PROJECT_FOLDER` in docs #362
* Check worker resources in `jf project check` #371
* Fix runner stop with multiple machines sharing the same home folder #373
* Allow to change run properties for STOPPED jobs
* For some reason cli.test_admin.test_reset started failing on my local DB due to the many submitted jobs in a row. I added a very short sleep. It should not slow down the test much
* ~~in `JobController.get_all_batches` the `sort` argument was set as a dict. It seems that it is a relatively recent change that allows dictionaries instead of list of tuples. I had a somewhat older version of pymongo and it was failing for me locally. I switched it to the more standard option of using a list.~~