### PR TITLE
CLI commands to remove job folders

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -17,6 +17,7 @@ from jobflow_remote.cli.formatting import (
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
+    break_lock_opt,
     cli_output_keys_opt,
     count_opt,
     days_opt,
@@ -41,12 +42,15 @@ from jobflow_remote.cli.types import (
     start_date_opt,
     stored_data_keys_opt,
     verbosity_opt,
+    wait_lock_opt,
+    yes_opt,
 )
 from jobflow_remote.cli.utils import (
     ReportInterval,
     SortOption,
     check_incompatible_opt,
     check_output_stored_data_keys,
+    check_stopped_runner,
     exit_with_error_msg,
     exit_with_warning_msg,
     get_job_controller,
@@ -57,6 +61,7 @@ from jobflow_remote.cli.utils import (
 )
 from jobflow_remote.jobs.graph import get_graph, plot_dash
 from jobflow_remote.jobs.report import FlowsReport
+from jobflow_remote.jobs.state import JobState
 
 app_flow = JFRTyper(
     name="flow", help="Commands for managing the flows", no_args_is_help=True
@@ -181,6 +186,8 @@ def delete(
             "the worker associated with the deleted Flows",
         ),
     ] = False,
+    wait: wait_lock_opt = None,
+    break_lock: break_lock_opt = False,
 ) -> None:
     """Permanently delete Flows from the database"""
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
@@ -244,17 +251,25 @@ def delete(
         if progress:
             progress.add_task(description="Deleting flows...", total=None)
 
-        jc.delete_flows(
+        deleted = jc.delete_flows(
             flow_ids=to_delete,
             delete_output=delete_output,
             delete_files=delete_files,
             cancel_processes=not keep_processes,
             max_limit=max_limit,
+            wait=wait,
+            break_lock=break_lock,
         )
 
-    out_console.print(
-        f"Deleted Flow(s) with id: {', '.join(str(i) for i in to_delete)}"
-    )
+    if not_deleted := set(to_delete) - set(deleted):
+        out_console.print(
+            f"Some of the selected Flows were not deleted: {', '.join(i for i in not_deleted)}"
+        )
+
+    if deleted:
+        out_console.print(
+            f"Deleted Flow(s) with id: {', '.join(str(i) for i in deleted)}"
+        )
 
 
 @app_flow.command(name="info")
@@ -476,13 +491,32 @@ def clean(
     metadata: metadata_opt = None,
     locked: locked_flow_opt = False,
     verbosity: verbosity_opt = 0,
-    force: force_opt = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Do not check if runner is active",
+        ),
+    ] = False,
+    yes: yes_opt = False,
+    all_states: Annotated[
+        bool,
+        typer.Option(
+            "--all-states",
+            "-as",
+            help="Delete files for Jobs in any state",
+        ),
+    ] = False,
 ):
     """
     Remove the files of the executed Jobs.
     """
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
     check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
+
+    if all_states and not force:
+        check_stopped_runner(error=True)
 
     jc = get_job_controller()
 
@@ -506,7 +540,7 @@ def clean(
     if not flows_info:
         exit_with_warning_msg("No flows matching criteria")
 
-    if not force:
+    if not yes:
         if verbosity:
             preamble = Text.from_markup(
                 f"[red]This operation will [bold]delete the files of the following {len(flows_info)} Flow(s)[/bold][/red]"
@@ -531,6 +565,13 @@ def clean(
         out_console.print("Deleting files...")
     else:
         spinner_cm = loading_spinner(processing=False)
+
+    skipped_jobs = []
+    cleanable_states = (
+        JobState.COMPLETED,
+        JobState.FAILED,
+        JobState.REMOTE_ERROR,
+    )
     with spinner_cm as progress:
         if progress:
             progress.add_task(description="Deleting files...", total=None)
@@ -538,7 +579,11 @@ def clean(
         for fi in flows_info:
             for ji in fi.jobs_info:
                 if ji.run_dir:
-                    jobs_info[ji.db_id] = ji
+                    if not all_states and ji.state not in cleanable_states:
+                        skipped_jobs.append(ji)
+                    else:
+                        jobs_info[ji.db_id] = ji
+
         deleted = jc.safe_delete_files(list(jobs_info.values()))
 
     deleted_dict = {ji.db_id: ji for ji in deleted}
@@ -547,6 +592,25 @@ def clean(
         out_console.print("Folder was not deleted for the following jobs:")
         for db_id in not_deleted:
             out_console.print(f" - {db_id}: {jobs_info[db_id].run_dir}")
+    if skipped_jobs:
+        out_console.print(
+            f"{len(skipped_jobs)} were not cleaned-up due to their state:"
+        )
+        if len(skipped_jobs) < 10:
+            for ji in skipped_jobs:
+                out_console.print(f" - {ji.db_id} - {ji.state}")
+        else:
+            confirmed = False
+            if not yes:
+                text = (
+                    "The number of skipped jobs is too large to be printed, the list can be "
+                    "dumped to the `skipped_cleanup.dat` file. Do you want to create the file?"
+                )
+                confirmed = Confirm.ask(text, default=False)
+            if yes or confirmed:
+                with open("skipped_cleanup.dat", "w") as f:
+                    for ji in skipped_jobs:
+                        f.writelines(f" - {ji.db_id} - {ji.state}")
 
     out_console.print(f"Deleted execution folders of {len(deleted)} Jobs")
 

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -462,6 +462,92 @@ def resume(
     out_console.print(f"{n_jobs} Job(s) resumed")
 
 
+@app_flow.command()
+def clean(
+    job_id: job_ids_opt = None,
+    db_id: db_ids_opt = None,
+    flow_id: flow_ids_opt = None,
+    state: flow_state_opt = None,
+    start_date: start_date_opt = None,
+    end_date: end_date_opt = None,
+    name: name_opt = None,
+    days: days_opt = None,
+    hours: hours_opt = None,
+    metadata: metadata_opt = None,
+    locked: locked_flow_opt = False,
+    verbosity: verbosity_opt = 0,
+    force: force_opt = False,
+):
+    check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
+    check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
+
+    jc = get_job_controller()
+
+    start_date = get_start_date(start_date, days, hours)
+
+    with loading_spinner():
+        with_jobs_info = ["run_dir"]
+        flows_info = jc.get_flows_info(
+            job_ids=job_id,
+            db_ids=db_id,
+            flow_ids=flow_id,
+            states=state,
+            start_date=start_date,
+            end_date=end_date,
+            name=name,
+            metadata=metadata,
+            locked=locked,
+            with_jobs_info=with_jobs_info,
+        )
+
+    if not flows_info:
+        exit_with_warning_msg("No flows matching criteria")
+
+    if not force:
+        if verbosity:
+            preamble = Text.from_markup(
+                f"[red]This operation will [bold]delete the files of the following {len(flows_info)} Flow(s)[/bold][/red]"
+            )
+            out_console.print(preamble)
+            table = get_flow_info_table(flows_info, verbosity=verbosity - 1)
+            out_console.print(table)
+            text = Text.from_markup("[red]Proceed anyway?[/red]")
+        else:
+            text = Text.from_markup(
+                f"[red]This operation will [bold]delete the files of {len(flows_info)} Flow(s)[/bold]. Proceed anyway?[/red]"
+            )
+
+        confirmed = Confirm.ask(text, default=False)
+        if not confirmed:
+            raise typer.Exit(0)
+
+    # if potentially interactive do not start the spinner.
+    spinner_cm: contextlib.AbstractContextManager
+    if jc.project.has_interactive_workers:
+        spinner_cm = contextlib.nullcontext()
+        out_console.print("Deleting files...")
+    else:
+        spinner_cm = loading_spinner(processing=False)
+    with spinner_cm as progress:
+        if progress:
+            progress.add_task(description="Deleting files...", total=None)
+        jobs_info = {}
+        for fi in flows_info:
+            for ji in fi.jobs_info:
+                if ji.run_dir:
+                    jobs_info[ji.db_id] = ji
+        deleted = jc.safe_delete_files(list(jobs_info.values()))
+
+    deleted_dict = {ji.db_id: ji for ji in deleted}
+    not_deleted = set(jobs_info) - set(deleted_dict)
+    if not_deleted:
+        out_console.print("Folder was not deleted for the following jobs:")
+        for db_id in not_deleted:
+            out_console.print(f" - {db_id}: {jobs_info[db_id].run_dir}")
+
+    out_console.print(f"Deleted execution folders of {len(deleted)} Jobs")
+
+
 app_flow_set = JFRTyper(
     name="set", help="Commands for setting properties for flows", no_args_is_help=True
 )

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -478,6 +478,9 @@ def clean(
     verbosity: verbosity_opt = 0,
     force: force_opt = False,
 ):
+    """
+    Remove the files of the executed Jobs.
+    """
     check_incompatible_opt({"start_date": start_date, "days": days, "hours": hours})
     check_incompatible_opt({"end_date": end_date, "days": days, "hours": hours})
 

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1343,6 +1343,14 @@ def files_get(
 def files_delete(
     job_db_id: job_db_id_arg,
     job_index: job_index_opt = None,
+    all_states: Annotated[
+        bool,
+        typer.Option(
+            "--all-states",
+            "-as",
+            help="Delete files for a Job in any state",
+        ),
+    ] = False,
 ) -> None:
     """
     Delete files from the Job's execution folder.
@@ -1366,6 +1374,17 @@ def files_delete(
 
     if not remote_dir:
         exit_with_warning_msg("The remote folder has not been created yet")
+
+    cleanable_states = (
+        JobState.COMPLETED,
+        JobState.FAILED,
+        JobState.REMOTE_ERROR,
+    )
+    if not all_states and job_info.state not in cleanable_states:
+        exit_with_error_msg(
+            f"Job is in state {job_info.state.value}. To delete such "
+            "a Job run the command with the --all-states option"
+        )
 
     with loading_spinner(processing=False) as progress:
         progress.add_task(description="Deleting files...", total=None)

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1343,13 +1343,6 @@ def files_get(
 def files_delete(
     job_db_id: job_db_id_arg,
     job_index: job_index_opt = None,
-    filenames: Annotated[
-        Optional[list[str]],
-        typer.Argument(
-            help="A list of file names to be retrieved from the job run dir",
-            metavar="FILE_NAMES",
-        ),
-    ] = None,
 ) -> None:
     """
     Delete files from the Job's execution folder.

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1351,10 +1351,21 @@ def files_delete(
             help="Delete files for a Job in any state",
         ),
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Do not check if runner is active",
+        ),
+    ] = False,
 ) -> None:
     """
     Delete files from the Job's execution folder.
     """
+    if all_states and not force:
+        check_stopped_runner(error=True)
+
     db_id, job_id = get_job_db_ids(job_db_id, job_index)
 
     jc = get_job_controller()

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1337,3 +1337,48 @@ def files_get(
                 host.close()
             except Exception:
                 pass
+
+
+@app_job_files.command(name="delete")
+def files_delete(
+    job_db_id: job_db_id_arg,
+    job_index: job_index_opt = None,
+    filenames: Annotated[
+        Optional[list[str]],
+        typer.Argument(
+            help="A list of file names to be retrieved from the job run dir",
+            metavar="FILE_NAMES",
+        ),
+    ] = None,
+) -> None:
+    """
+    Delete files from the Job's execution folder.
+    """
+    db_id, job_id = get_job_db_ids(job_db_id, job_index)
+
+    jc = get_job_controller()
+
+    with loading_spinner(processing=False) as progress:
+        progress.add_task(description="Retrieving info...", total=None)
+        job_info = jc.get_job_info(
+            job_id=job_id,
+            job_index=job_index,
+            db_id=db_id,
+        )
+
+    if not job_info:
+        exit_with_error_msg("No data matching the request")
+
+    remote_dir = job_info.run_dir
+
+    if not remote_dir:
+        exit_with_warning_msg("The remote folder has not been created yet")
+
+    with loading_spinner(processing=False) as progress:
+        progress.add_task(description="Deleting files...", total=None)
+        deleted = jc.safe_delete_files([job_info])
+
+    if not deleted:
+        exit_with_error_msg(f"The files were not deleted in folder: {job_info.run_dir}")
+
+    out_console.print(f"Folder deleted {job_info.run_dir}")

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -266,6 +266,15 @@ force_opt = Annotated[
     ),
 ]
 
+yes_opt = Annotated[
+    bool,
+    typer.Option(
+        "--yes",
+        "-y",
+        help="Sets any confirmation values to 'yes' automatically",
+    ),
+]
+
 
 job_flow_id_flag_opt = Annotated[
     bool,

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1046,6 +1046,8 @@ class JobController:
 
             if job_state in [JobState.READY]:
                 raise ValueError("The Job is in the READY state. No need to rerun.")
+            if job_state in [JobState.WAITING]:
+                raise ValueError("The Job is in the WAITING state. Cannot be rerun.")
             if job_state in RESETTABLE_STATES:
                 # if in one of the resettable states no need to lock the flow or
                 # update children.
@@ -2498,7 +2500,7 @@ class JobController:
         jobs_sort: list[tuple] | None = None,
         limit: int = 0,
         skip: int = 0,
-        with_jobs_info: bool = False,
+        with_jobs_info: bool | list = False,
     ) -> list[FlowInfo]:
         """
         Query for Flows based on standard parameters and return a list of FlowInfo.
@@ -2530,14 +2532,18 @@ class JobController:
         sort
             A list of (key, direction) pairs specifying the sort order for this
             query. Follows pymongo conventions.
+        jobs_sort
+            A list of (key, direction) pairs specifying the sort order for the
+            jobs of each Flow. Follows pymongo conventions.
         limit
             Maximum number of entries to retrieve. 0 means no limit.
         skip
             The number of documents to omit (from the start of the result set).
         with_jobs_info
-            If True, data is fetched from both the Flow collection and Job collection
-            with an aggregate and JobInfo for each job will be created.
-            Otherwise, only the Job information in the Flow document will be used.
+            If True or a list, data is fetched from both the Flow collection and
+            Job collection with an aggregate and JobInfo for each job will be created.
+            If a list, it should contain additional properties to add to the job info.
+            If False, only the Job information in the Flow document will be used.
 
         Returns
         -------
@@ -2559,7 +2565,12 @@ class JobController:
         # Only use the full aggregation if more job details are needed.
         # The single flow document is enough for basic information
         if with_jobs_info:
-            projection_job = {f: 1 for f in projection_flow_info_jobs}
+            if isinstance(with_jobs_info, bool):
+                projection_job = {f: 1 for f in projection_flow_info_jobs}
+            else:
+                projection_job = {
+                    f: 1 for f in projection_flow_info_jobs + with_jobs_info
+                }
             projection_flow = {k: 1 for k in FlowDoc.model_fields}
 
             data = self.get_flow_job_aggreg(
@@ -2750,7 +2761,7 @@ class JobController:
                             )
             # delete files after cancelling the queue job
             if delete_files:
-                self._safe_delete_files(jobs_info)
+                self.safe_delete_files(jobs_info)
 
         self.jobs.delete_many({"uuid": {"$in": job_ids}})
         self.flows.delete_one({"uuid": flow_id})
@@ -2824,7 +2835,7 @@ class JobController:
         )
         return result.modified_count
 
-    def _safe_delete_files(
+    def safe_delete_files(
         self, jobs_info: Sequence[JobInfo | dict]
     ) -> list[JobInfo | dict]:
         """
@@ -5043,7 +5054,7 @@ class JobController:
 
             if delete_files:
                 job_info = JobInfo.from_query_output(job_doc)
-                self._safe_delete_files([job_info])
+                self.safe_delete_files([job_info])
 
             return job_doc["db_id"]
 

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -2329,6 +2329,21 @@ class JobController:
         list
             List of db_ids of the updated Jobs.
         """
+        # if only priority is changed, any state is acceptable
+        if priority and not worker and not exec_config:
+            acceptable_states = None
+        else:
+            acceptable_states = [
+                JobState.READY,
+                JobState.WAITING,
+                JobState.COMPLETED,
+                JobState.FAILED,
+                JobState.PAUSED,
+                JobState.REMOTE_ERROR,
+                JobState.STOPPED,
+                JobState.USER_STOPPED,
+            ]
+
         set_dict: dict[str, Any] = {}
         if worker:
             if worker not in self.project.workers:
@@ -2376,17 +2391,6 @@ class JobController:
 
         if priority is not None:
             set_dict["priority"] = priority
-
-        acceptable_states = [
-            JobState.READY,
-            JobState.WAITING,
-            JobState.COMPLETED,
-            JobState.FAILED,
-            JobState.PAUSED,
-            JobState.REMOTE_ERROR,
-            JobState.STOPPED,
-            JobState.USER_STOPPED,
-        ]
 
         return self._many_jobs_action(
             method=self.set_job_doc_properties,
@@ -2564,7 +2568,7 @@ class JobController:
 
         # Only use the full aggregation if more job details are needed.
         # The single flow document is enough for basic information
-        if with_jobs_info:
+        if with_jobs_info is not False:
             if isinstance(with_jobs_info, bool):
                 projection_job = {f: 1 for f in projection_flow_info_jobs}
             else:
@@ -2659,7 +2663,10 @@ class JobController:
         delete_output: bool = False,
         delete_files: bool = False,
         cancel_processes: bool = True,
-    ) -> int:
+        raise_on_error: bool = False,
+        wait: int | None = None,
+        break_lock: bool = False,
+    ) -> list[str]:
         """
         Delete a list of Flows based on the flow uuids.
 
@@ -2677,11 +2684,21 @@ class JobController:
         cancel_processes
             If True will attempt to delete the processes for SUBMITTED and RUNNING jobs.
             Failure to cancel will not stop the deletion of the Flow.
-
+        raise_on_error
+            If True raise in case of error on one job error and stop the loop.
+            Otherwise, just log the error and proceed.
+        wait
+            In case the Flow that needs to be deleted is locked,
+            wait this time (in seconds) for the lock to be released.
+            Raise an error if lock is not released.
+        break_lock
+            Forcibly break the lock on locked documents. Use with care and
+            verify that the lock has been set by a process that is not running
+            anymore. Doing otherwise will likely lead to inconsistencies in the DB.
         Returns
         -------
-        int
-            Number of deleted Flows.
+        list
+            List of uuids of the deleted Flows.
         """
         if isinstance(flow_ids, str):
             flow_ids = [flow_ids]
@@ -2694,18 +2711,24 @@ class JobController:
                 f"Cannot delete {len(flow_ids)} Flows as they exceed the specified maximum "
                 f"limit ({max_limit}). Increase the limit to delete the Flows."
             )
-        deleted = 0
+        deleted = []
         # Open the SharedHosts so that hosts will be shared for all the Flows
         with SharedHosts(self.project):
             for fid in flow_ids:
-                # TODO should it catch errors?
-                if self.delete_flow(
-                    fid,
-                    delete_output=delete_output,
-                    delete_files=delete_files,
-                    cancel_processes=cancel_processes,
-                ):
-                    deleted += 1
+                try:
+                    if self.delete_flow(
+                        fid,
+                        delete_output=delete_output,
+                        delete_files=delete_files,
+                        cancel_processes=cancel_processes,
+                        wait=wait,
+                        break_lock=break_lock,
+                    ):
+                        deleted.append(fid)
+                except Exception:
+                    if raise_on_error:
+                        raise
+                    logger.exception(f"Error while deleting Flow with id {fid}")
 
         return deleted
 
@@ -2715,6 +2738,8 @@ class JobController:
         delete_output: bool = False,
         delete_files: bool = False,
         cancel_processes: bool = True,
+        wait: int | None = None,
+        break_lock: bool = False,
     ) -> bool:
         """
         Delete a single Flow based on the uuid.
@@ -2730,41 +2755,68 @@ class JobController:
         cancel_processes
             If True will attempt to delete the processes for SUBMITTED and RUNNING jobs.
             Failure to cancel will not stop the deletion of the Flow.
+        wait
+            In case the Flow that needs to be deleted is locked,
+            wait this time (in seconds) for the lock to be released.
+            Raise an error if lock is not released.
+        break_lock
+            Forcibly break the lock on locked documents. Use with care and
+            verify that the lock has been set by a process that is not running
+            anymore. Doing otherwise will likely lead to inconsistencies in the DB.
 
         Returns
         -------
         bool
             True if the flow has been deleted.
         """
-        # TODO should this lock anything (FW does not lock)?
-        flow = self.get_flow_info_by_flow_uuid(flow_id)
-        if not flow:
-            return False
-        job_ids = flow["jobs"]
-        if delete_output:
-            jobstore = self.jobstore
-            if jobstore_name := flow.get("jobstore"):
-                jobstore = self.optional_jobstores[jobstore_name]
-            jobstore.remove_docs({"uuid": {"$in": job_ids}})
-        if delete_files or cancel_processes:
-            jobs_info = self.get_jobs_info(flow_ids=[flow_id])
-            if cancel_processes:
-                for ji in jobs_info:
-                    if ji.state in [JobState.SUBMITTED, JobState.RUNNING]:
-                        # try cancelling the job submitted to the remote queue
-                        try:
-                            self._cancel_queue_process(ji.model_dump(mode="python"))
-                        except Exception:
-                            logger.warning(
-                                f"Failed cancelling the process for Job {ji.uuid} {ji.index} while deleting Flow {flow_id}",
-                                exc_info=True,
-                            )
-            # delete files after cancelling the queue job
-            if delete_files:
-                self.safe_delete_files(jobs_info)
+        sleep = None
+        if wait:
+            sleep = 10
+        # TODO locking the Flow prevents deleting it while one if its Jobs is
+        # completing, and thus avoids that Jobs are dynamically created while
+        # the Flow is being deleted.
+        # To avoid any sort of concurrent action it may be necessary to lock all the
+        # Jobs of the Flow. Consider doing this in the future.
+        with self.lock_flow(
+            filter={"uuid": flow_id},
+            sleep=sleep,
+            max_wait=wait,
+            get_locked_doc=True,
+            break_lock=break_lock,
+        ) as flow_lock:
+            if not flow_lock.locked_document:
+                if flow_lock.unavailable_document:
+                    raise FlowLockedError.from_flow_doc(flow_lock.unavailable_document)
+                return False
+            flow = flow_lock.locked_document
 
-        self.jobs.delete_many({"uuid": {"$in": job_ids}})
-        self.flows.delete_one({"uuid": flow_id})
+            job_ids = flow["jobs"]
+            if delete_output:
+                jobstore = self.jobstore
+                if jobstore_name := flow.get("jobstore"):
+                    jobstore = self.optional_jobstores[jobstore_name]
+                jobstore.remove_docs({"uuid": {"$in": job_ids}})
+            if delete_files or cancel_processes:
+                jobs_info = self.get_jobs_info(flow_ids=[flow_id])
+                if cancel_processes:
+                    for ji in jobs_info:
+                        if ji.state in [JobState.SUBMITTED, JobState.RUNNING]:
+                            # try cancelling the job submitted to the remote queue
+                            try:
+                                self._cancel_queue_process(ji.model_dump(mode="python"))
+                            except Exception:
+                                logger.warning(
+                                    f"Failed cancelling the process for Job {ji.uuid} {ji.index} while deleting Flow {flow_id}",
+                                    exc_info=True,
+                                )
+                # delete files after cancelling the queue job
+                if delete_files:
+                    self.safe_delete_files(jobs_info)
+
+            self.jobs.delete_many({"uuid": {"$in": job_ids}})
+
+            # Flow is deleted by the lock release
+            flow_lock.delete_on_release = True
         return True
 
     def unlock_jobs(

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -116,6 +116,14 @@ def no_resolve(ref):
     return ref
 
 
+@job(config=JobConfig(on_missing_references=OnMissing.NONE))
+def onmissing_none(args):
+    """
+    A job that can run even if references are missing
+    """
+    return args
+
+
 @job
 def replace_and_stop_jobflow(a=1, b=1) -> Response[None]:
     from jobflow import Flow

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -430,7 +430,6 @@ def test_clean(
         running_fids.append(flow.uuid)
         submit_flow(flow, worker="test_local_worker")
         for j in add_jobs:
-            # job_controller.set_job_state(state=JobState.RUNNING, job_id=j.uuid)
             assert job_controller.set_job_doc_properties(
                 {
                     "state": JobState.RUNNING.value,

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -1,5 +1,6 @@
 import os.path
 import re
+import time
 
 import pytest
 
@@ -394,7 +395,8 @@ def test_clean(
     daemon_manager.start(raise_on_error=True)
     wait_daemon_started(daemon_manager)
 
-    for _ in range(10):
+    for _ in range(20):
+        time.sleep(0.1)
         job_slow_doc = job_controller.get_job_doc(job_id=slow_flow.jobs[0].uuid)
         if job_slow_doc.state in (JobState.SUBMITTED, JobState.RUNNING):
             break

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -285,3 +285,70 @@ def test_set_store(job_controller, runner, one_job, run_check_cli):
     )
 
     assert job_controller.get_flow_store(one_job.uuid) is None
+
+
+def test_clean(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+    from jobflow_remote.jobs.runner import Runner
+
+    run_check_cli(
+        ["flow", "delete", "-fid", "wrong_uuid"],
+        required_out="No flows matching criteria",
+        cli_input="y",
+    )
+
+    # run one of the jobs to check that the output is not deleted
+    runner = Runner()
+    runner.run_all_jobs(max_seconds=30)
+    job_1_uuid = two_flows_four_jobs[0].jobs[0].uuid
+    job_1_doc = job_controller.get_job_doc(job_id=job_1_uuid)
+    job_2_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[0].uuid)
+    job_3_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[1].uuid)
+
+    assert os.path.isdir(job_1_doc.run_dir)
+
+    required_out_1 = [
+        "This operation will delete the files of the following 1 Flow(s)",
+        two_flows_four_jobs[0].uuid,
+        "Deleted execution folders of 2 Jobs",
+    ]
+    run_check_cli(
+        ["flow", "clean", "-v", "-fid", two_flows_four_jobs[0].uuid],
+        required_out=required_out_1,
+        cli_input="y",
+    )
+    assert job_controller.count_flows() == 2
+
+    # check that the directory was deleted
+    assert not os.path.isdir(job_1_doc.run_dir)
+
+    assert os.path.isdir(job_2_doc.run_dir)
+    assert os.path.isdir(job_3_doc.run_dir)
+
+    # don't confirm and no verbose option
+    required_out_2 = [
+        "This operation will delete the files of 1 Flow(s)",
+    ]
+    run_check_cli(
+        ["flow", "clean", "-fid", two_flows_four_jobs[1].uuid],
+        required_out=required_out_2,
+        cli_input="n",
+    )
+    assert os.path.isdir(job_2_doc.run_dir)
+    assert os.path.isdir(job_3_doc.run_dir)
+
+    os.unlink(os.path.join(job_3_doc.run_dir, "jfremote_in.json"))
+
+    required_out_3 = [
+        "Deleted execution folders of 1 Jobs",
+        "Folder was not deleted for the following jobs:",
+        f"- {job_3_doc.db_id}",
+    ]
+    excluded_out = ["Proceed anyway"]
+    run_check_cli(
+        ["flow", "clean", "-fid", two_flows_four_jobs[1].uuid, "-f"],
+        required_out=required_out_3,
+        excluded_out=excluded_out,
+    )
+
+    assert not os.path.isdir(job_2_doc.run_dir)
+    assert os.path.isdir(job_3_doc.run_dir)

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -69,9 +69,25 @@ def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
 
     assert os.path.isdir(job_1_doc.run_dir)
 
+    # try deleting the Flow while locked. Should not succeed
+    with job_controller.lock_flow(filter={"uuid": two_flows_four_jobs[0].uuid}):
+        run_check_cli(
+            ["flow", "delete", "-fid", two_flows_four_jobs[0].uuid],
+            required_out=[
+                "FlowLockedError",
+                "Some of the selected Flows were not deleted",
+            ],
+            excluded_out="Deleted Flow",
+            cli_input="y",
+        )
+
+    assert job_controller.count_flows() == 2
+    assert job_controller.count_jobs() == 4
+
     run_check_cli(
         ["flow", "delete", "-fid", two_flows_four_jobs[0].uuid],
         required_out="Deleted Flow",
+        excluded_out="Some of the selected Flows were not deleted",
         cli_input="y",
     )
     assert job_controller.count_flows() == 1
@@ -287,8 +303,22 @@ def test_set_store(job_controller, runner, one_job, run_check_cli):
     assert job_controller.get_flow_store(one_job.uuid) is None
 
 
-def test_clean(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+@pytest.mark.filterwarnings("ignore:Some jobs are not connected")
+def test_clean(
+    job_controller,
+    two_flows_four_jobs,
+    run_check_cli,
+    daemon_manager,
+    wait_daemon_started,
+    wait_daemon_shutdown,
+    tmp_dir,
+) -> None:
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
     from jobflow_remote.jobs.runner import Runner
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.testing import add, add_sleep
 
     run_check_cli(
         ["flow", "delete", "-fid", "wrong_uuid"],
@@ -299,12 +329,12 @@ def test_clean(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     # run one of the jobs to check that the output is not deleted
     runner = Runner()
     runner.run_all_jobs(max_seconds=30)
-    job_1_uuid = two_flows_four_jobs[0].jobs[0].uuid
-    job_1_doc = job_controller.get_job_doc(job_id=job_1_uuid)
-    job_2_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[0].uuid)
-    job_3_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[1].uuid)
+    job_1_1_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[0].jobs[0].uuid)
+    job_1_2_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[0].jobs[1].uuid)
+    job_2_1_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[0].uuid)
+    job_2_2_doc = job_controller.get_job_doc(job_id=two_flows_four_jobs[1].jobs[1].uuid)
 
-    assert os.path.isdir(job_1_doc.run_dir)
+    assert os.path.isdir(job_1_1_doc.run_dir)
 
     required_out_1 = [
         "This operation will delete the files of the following 1 Flow(s)",
@@ -319,10 +349,11 @@ def test_clean(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     assert job_controller.count_flows() == 2
 
     # check that the directory was deleted
-    assert not os.path.isdir(job_1_doc.run_dir)
+    assert not os.path.isdir(job_1_1_doc.run_dir)
+    assert not os.path.isdir(job_1_2_doc.run_dir)
 
-    assert os.path.isdir(job_2_doc.run_dir)
-    assert os.path.isdir(job_3_doc.run_dir)
+    assert os.path.isdir(job_2_1_doc.run_dir)
+    assert os.path.isdir(job_2_2_doc.run_dir)
 
     # don't confirm and no verbose option
     required_out_2 = [
@@ -331,24 +362,87 @@ def test_clean(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     run_check_cli(
         ["flow", "clean", "-fid", two_flows_four_jobs[1].uuid],
         required_out=required_out_2,
+        excluded_out=two_flows_four_jobs[1].uuid,
         cli_input="n",
     )
-    assert os.path.isdir(job_2_doc.run_dir)
-    assert os.path.isdir(job_3_doc.run_dir)
+    assert os.path.isdir(job_2_1_doc.run_dir)
+    assert os.path.isdir(job_2_2_doc.run_dir)
 
-    os.unlink(os.path.join(job_3_doc.run_dir, "jfremote_in.json"))
+    os.unlink(os.path.join(job_2_2_doc.run_dir, "jfremote_in.json"))
 
     required_out_3 = [
         "Deleted execution folders of 1 Jobs",
         "Folder was not deleted for the following jobs:",
-        f"- {job_3_doc.db_id}",
+        f"- {job_2_2_doc.db_id}",
+        "WARNING  Did not delete folder",
+        "jfremote_in.json is missing",
     ]
     excluded_out = ["Proceed anyway"]
     run_check_cli(
-        ["flow", "clean", "-fid", two_flows_four_jobs[1].uuid, "-f"],
+        ["flow", "clean", "-fid", two_flows_four_jobs[1].uuid, "--yes"],
         required_out=required_out_3,
         excluded_out=excluded_out,
     )
 
-    assert not os.path.isdir(job_2_doc.run_dir)
-    assert os.path.isdir(job_3_doc.run_dir)
+    assert not os.path.isdir(job_2_1_doc.run_dir)
+    assert os.path.isdir(job_2_2_doc.run_dir)
+
+    # add one more Flow with a slow sleep
+    slow_flow = Flow(add_sleep(2, 5))
+    submit_flow(slow_flow, worker="test_local_worker")
+
+    daemon_manager.start(raise_on_error=True)
+    wait_daemon_started(daemon_manager)
+
+    for _ in range(10):
+        job_slow_doc = job_controller.get_job_doc(job_id=slow_flow.jobs[0].uuid)
+        if job_slow_doc.state in (JobState.SUBMITTED, JobState.RUNNING):
+            break
+    else:
+        raise RuntimeError(
+            f"The slow job did not become RUNNING within the expected time. Final state: {job_slow_doc.state}"
+        )
+    run_check_cli(
+        ["flow", "clean", "-fid", slow_flow.uuid, "--all-states"],
+        required_out="The daemon should not be running while performing this operation",
+        error=True,
+    )
+    assert os.path.isdir(job_slow_doc.run_dir)
+
+    run_check_cli(
+        ["flow", "clean", "-fid", slow_flow.uuid, "--all-states", "--force"],
+        excluded_out="The daemon should not be running while performing this operation",
+        required_out="Deleted execution folders of 1 Jobs",
+        cli_input="y",
+    )
+    assert not os.path.isdir(job_slow_doc.run_dir)
+
+    daemon_manager.shut_down(raise_on_error=True)
+    wait_daemon_shutdown(daemon_manager)
+
+    # add enough jobs to trigger
+    running_fids = []
+    for _ in range(3):
+        add_jobs = [add(1, 2) for _ in range(4)]
+        flow = Flow(add_jobs)
+        running_fids.append(flow.uuid)
+        submit_flow(flow, worker="test_local_worker")
+        for j in add_jobs:
+            # job_controller.set_job_state(state=JobState.RUNNING, job_id=j.uuid)
+            assert job_controller.set_job_doc_properties(
+                {
+                    "state": JobState.RUNNING.value,
+                    "run_dir": "/SOME/not/EXISTING/fake/PaTh",
+                },
+                job_id=j.uuid,
+            )
+
+    run_check_cli(
+        sum((["-fid", fid] for fid in running_fids), start=["flow", "clean"]),
+        required_out=[
+            "The number of skipped jobs is too large to be printed",
+            "Deleted execution folders of 0 Jobs",
+        ],
+        cli_input="y\ny",
+    )
+    assert os.path.isfile("skipped_cleanup.dat")

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -481,7 +481,14 @@ def test_files_get(job_controller, one_job, tmp_dir, run_check_cli) -> None:
     )
 
 
-def test_files_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+def test_files_delete(
+    job_controller,
+    two_flows_four_jobs,
+    run_check_cli,
+    daemon_manager,
+    wait_daemon_started,
+    wait_daemon_shutdown,
+) -> None:
     import os
 
     from jobflow_remote.jobs.runner import Runner
@@ -522,13 +529,6 @@ def test_files_delete(job_controller, two_flows_four_jobs, run_check_cli) -> Non
         required_out=["The remote folder has not been created yet"],
     )
 
-    # assert job_controller.set_job_doc_properties(
-    #     {
-    #         "state": JobState.RUNNING.value,
-    #         "run_dir": "/SOME/not/EXISTING/fake/PaTh",
-    #     },
-    #     db_id="3",
-    # )
     runner.run_one_job(db_id="3", target_state=JobState.RUNNING)
     run_check_cli(
         ["job", "files", "delete", "3"],
@@ -538,12 +538,24 @@ def test_files_delete(job_controller, two_flows_four_jobs, run_check_cli) -> Non
     job_info3 = job_controller.get_job_info(db_id="3")
     assert os.path.exists(job_info3.run_dir)
 
+    daemon_manager.start()
+    wait_daemon_started(daemon_manager)
     run_check_cli(
         ["job", "files", "delete", "3", "--all-states"],
+        excluded_out="Folder deleted",
+        required_out="The daemon should not be running while performing this operation",
+        error=True,
+    )
+
+    run_check_cli(
+        ["job", "files", "delete", "3", "--all-states", "--force"],
         excluded_out=["run the command with the --all-states option"],
         required_out="Folder deleted",
     )
     assert not os.path.exists(job_info3.run_dir)
+
+    daemon_manager.shut_down()
+    wait_daemon_shutdown(daemon_manager)
 
 
 def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -481,6 +481,47 @@ def test_files_get(job_controller, one_job, tmp_dir, run_check_cli) -> None:
     )
 
 
+def test_files_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+    import os
+
+    from jobflow_remote.jobs.runner import Runner
+
+    run_check_cli(
+        ["job", "files", "get", "1", "queue.err"],
+        required_out="The remote folder has not been created yet",
+    )
+
+    runner = Runner()
+    runner.run_one_job(db_id="1")
+    runner.run_one_job(db_id="2")
+
+    run_check_cli(
+        ["job", "files", "delete", "10"],
+        required_out="No data matching the request",
+        error=True,
+    )
+
+    job_info1 = job_controller.get_job_info(db_id="1")
+    assert os.path.exists(job_info1.run_dir)
+    run_check_cli(["job", "files", "delete", "1"], required_out="Folder deleted")
+    assert not os.path.exists(job_info1.run_dir)
+
+    job_info2 = job_controller.get_job_info(db_id="2")
+    assert os.path.exists(job_info2.run_dir)
+    os.unlink(os.path.join(job_info2.run_dir, "jfremote_in.json"))
+    run_check_cli(
+        ["job", "files", "delete", "2"],
+        required_out=["The files were not deleted in folder"],
+        error=True,
+    )
+    assert os.path.exists(job_info2.run_dir)
+
+    run_check_cli(
+        ["job", "files", "delete", "3"],
+        required_out=["The remote folder has not been created yet"],
+    )
+
+
 def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     run_check_cli(
         ["job", "delete", "-did", "2", "--output"],

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -485,6 +485,7 @@ def test_files_delete(job_controller, two_flows_four_jobs, run_check_cli) -> Non
     import os
 
     from jobflow_remote.jobs.runner import Runner
+    from jobflow_remote.jobs.state import JobState
 
     run_check_cli(
         ["job", "files", "get", "1", "queue.err"],
@@ -520,6 +521,29 @@ def test_files_delete(job_controller, two_flows_four_jobs, run_check_cli) -> Non
         ["job", "files", "delete", "3"],
         required_out=["The remote folder has not been created yet"],
     )
+
+    # assert job_controller.set_job_doc_properties(
+    #     {
+    #         "state": JobState.RUNNING.value,
+    #         "run_dir": "/SOME/not/EXISTING/fake/PaTh",
+    #     },
+    #     db_id="3",
+    # )
+    runner.run_one_job(db_id="3", target_state=JobState.RUNNING)
+    run_check_cli(
+        ["job", "files", "delete", "3"],
+        required_out=["run the command with the --all-states option"],
+        error=True,
+    )
+    job_info3 = job_controller.get_job_info(db_id="3")
+    assert os.path.exists(job_info3.run_dir)
+
+    run_check_cli(
+        ["job", "files", "delete", "3", "--all-states"],
+        excluded_out=["run the command with the --all-states option"],
+        required_out="Folder deleted",
+    )
+    assert not os.path.exists(job_info3.run_dir)
 
 
 def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -158,9 +158,19 @@ def test_rerun_completed(job_controller, runner) -> None:
     assert j2_info.state == JobState.READY
     assert j3_info.state == JobState.WAITING
 
-    # try rerunning the second job. Wrong state
+    # try rerunning the second and third job. Wrong state
     with pytest.raises(ValueError, match="The Job is in the READY state"):
         job_controller.rerun_job(job_id=j2.uuid, job_index=j2.index)
+
+    with pytest.raises(ValueError, match="The Job is in the WAITING state"):
+        job_controller.rerun_job(job_id=j3.uuid, job_index=j3.index)
+
+    # check that the state did not change
+    j2_info = job_controller.get_job_info(job_id=j2.uuid, job_index=j2.index)
+    j3_info = job_controller.get_job_info(job_id=j3.uuid, job_index=j3.index)
+
+    assert j2_info.state == JobState.READY
+    assert j3_info.state == JobState.WAITING
 
     assert len(list(j1_path.iterdir())) > 0
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1370,3 +1370,28 @@ def test_delete_flow(job_controller, runner, caplog):
 
     # Test deleting non-existent flow
     assert not job_controller.delete_flow("non-existent-uuid")
+
+
+def test_complete_onmissing_none(job_controller, runner):
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.testing import always_fails, onmissing_none
+
+    j1 = always_fails()
+    j2 = onmissing_none(j1.output)
+    flow = Flow([j1, j2])
+
+    submit_flow(flow, worker="test_local_worker")
+
+    runner.run_one_job(max_seconds=20)
+
+    assert job_controller.get_job_info(job_id=j1.uuid).state == JobState.FAILED
+    assert job_controller.get_job_info(job_id=j2.uuid).state == JobState.READY
+
+    runner.run_one_job(max_seconds=20)
+
+    assert job_controller.get_job_info(job_id=j2.uuid).state == JobState.COMPLETED
+    # The job returns the input argument, so it should be None
+    assert job_controller.get_job_output(job_id=j2.uuid) is None

--- a/tests/unit/testing/test_cli.py
+++ b/tests/unit/testing/test_cli.py
@@ -5,6 +5,7 @@ from typer.testing import Result
 def test_run_check_cli(run_check_cli):
     # Check multiple lines is found
     flow_excerpt = """├── flow: Commands for managing the flows
+│   ├── clean: Remove the files of the executed Jobs.
 │   ├── delete: Permanently delete Flows from the database
 │   ├── graph: Provide detailed information on a Flow.
 │   ├── info: Provide detailed information on a Flow.


### PR DESCRIPTION
Following the discussion in https://matsci.org/t/create-jobs-immune-to-stop-children/65765/1 I thought it would would be useful to have a command to just remove the execution folders, without the need to remove the content of the DB.
Two options implemented: `jf job files delete` and `jf flow clean`. I am not fully convinced about the namings, but changing will be easy.

In the same discussion it emerged that `jf job rerun` was setting to `READY` a `WAITING` Job. It is now not possible to rerun a `WAITING` Job. If needed it is still possible to change the state using `jf job set-state`.