### PR TITLE
Add CLI option to edit project files

### DIFF
--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -20,6 +20,7 @@ from jobflow_remote.cli.types import (
 from jobflow_remote.cli.utils import (
     SerializeFileFormat,
     check_incompatible_opt,
+    check_stopped_runner,
     exit_with_error_msg,
     exit_with_warning_msg,
     get_config_manager,
@@ -28,7 +29,7 @@ from jobflow_remote.cli.utils import (
     out_console,
     print_success_msg,
 )
-from jobflow_remote.config import ConfigError, ConfigManager
+from jobflow_remote.config import ConfigError, ConfigManager, Project
 from jobflow_remote.config.helper import (
     check_jobstore,
     check_queue_store,
@@ -419,13 +420,27 @@ def replace(
         ),
     ] = False,
     force: force_opt = False,
+    no_backup: Annotated[
+        bool,
+        typer.Option(
+            "--no-backup",
+            "-nb",
+            help="Avoid creating a backup copy of the project file",
+        ),
+    ] = False,
 ) -> None:
     """
     Replace a string in one or more project files.
 
     This command performs a text replacement in the YAML project files,
     replacing all instances of old_string with new_string.
+    By default, creates a backup of the original file.
     """
+    import json
+
+    import tomlkit
+    from ruamel.yaml import YAML
+
     cm = get_config_manager()
 
     # Determine which projects to process
@@ -439,6 +454,8 @@ def replace(
     else:
         project_data = cm.get_project_data()
         projects_to_process = [project_data.project.name]
+
+        check_stopped_runner(error=True)
 
     modified_count = 0
 
@@ -481,8 +498,32 @@ def replace(
                         )
                     )
 
+                    try:
+                        if project_data.ext == "yaml":
+                            model = YAML().load(modified_content)
+                        elif project_data.ext == "json":
+                            model = json.loads(modified_content)
+                        elif project_data.ext == "toml":
+                            model = tomlkit.parse(modified_content)
+                        else:
+                            out_console.print(
+                                f"Unknown file format for project: {project_data.ext}"
+                            )
+                            continue
+                        Project.model_validate(model)
+                    except Exception as e:
+                        out_console.print(
+                            "[bold]WARNING: The modification to the project file will result in "
+                            f"an invalid file/project [/bold]: {getattr(e, 'message', str(e))}",
+                            style="red",
+                        )
+
                     if not Confirm.ask(f"Apply these changes to {project_name}?"):
                         continue
+
+                # create a backup of the project file before overwriting
+                if not no_backup:
+                    cm.backup_project(project_name)
 
                 # Write back the modified content
                 filepath.write_text(modified_content)
@@ -499,6 +540,9 @@ def replace(
             out_console.print(f"  ✗ Error processing {project_name}: {e}", style="red")
 
     if modified_count > 0:
-        print_success_msg(f"Successfully modified {modified_count} project file(s)")
+        print_success_msg(
+            f"Successfully modified {modified_count} project file(s). For the changes "
+            "to be registered the runner of all the modified projects needs to be restarted"
+        )
     if modified_count == 0:
         out_console.print("No replacements were made in any files", style="yellow")

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -430,7 +430,8 @@ def replace(
 
     # Determine which projects to process
     if all_projects:
-        projects_to_process = list(cm.projects_data)
+        # sort to make it reproducible
+        projects_to_process = sorted(cm.projects_data)
 
         if not projects_to_process:
             exit_with_error_msg("No valid project files found that can be parsed")

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -1,7 +1,11 @@
+import difflib
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import typer
+from rich.panel import Panel
 from rich.prompt import Confirm
+from rich.syntax import Syntax
 from rich.text import Text
 
 from jobflow_remote.cli.formatting import get_exec_config_table, get_worker_table
@@ -387,3 +391,113 @@ def list_worker(
     project = cm.get_project()
     table = get_worker_table(project.workers, verbosity)
     out_console.print(table)
+
+
+#####################################
+# Edit app
+#####################################
+
+
+app_edit = JFRTyper(
+    name="edit",
+    help="Edit the project files",
+    no_args_is_help=True,
+)
+app_project.add_typer(app_edit)
+
+
+@app_edit.command()
+def replace(
+    old_string: Annotated[str, typer.Argument(help="String to search for and replace")],
+    new_string: Annotated[str, typer.Argument(help="String to replace with")],
+    all_projects: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help="Apply replacement to all project files",
+        ),
+    ] = False,
+    force: force_opt = False,
+) -> None:
+    """
+    Replace a string in one or more project files.
+
+    This command performs a text replacement in the YAML project files,
+    replacing all instances of old_string with new_string.
+    """
+    cm = get_config_manager()
+
+    # Determine which projects to process
+    if all_projects:
+        projects_to_process = list(cm.projects_data)
+
+        if not projects_to_process:
+            exit_with_error_msg("No valid project files found that can be parsed")
+
+    else:
+        project_data = cm.get_project_data()
+        projects_to_process = [project_data.project.name]
+
+    modified_count = 0
+
+    for project_name in projects_to_process:
+        try:
+            project_data = cm.get_project_data(project_name)
+            filepath = Path(project_data.filepath)
+
+            # Read the file as text
+            original_content = filepath.read_text()
+
+            modified_content = original_content.replace(old_string, new_string)
+
+            if original_content != modified_content:
+                # Show diff and ask for confirmation if not forced
+                if not force:
+                    out_console.print(
+                        f"\n[bold]File: {filepath.name} (Project: {project_name})[/bold]"
+                    )
+                    out_console.print(f"[dim]Path: {filepath}[/dim]\n")
+
+                    diff_lines = list(
+                        difflib.unified_diff(
+                            original_content.splitlines(keepends=True),
+                            modified_content.splitlines(keepends=True),
+                            fromfile=f"{filepath.name} (original)",
+                            tofile=f"{filepath.name} (modified)",
+                        )
+                    )
+
+                    diff_text = "".join(diff_lines)
+                    syntax = Syntax(
+                        diff_text, "diff", theme="monokai", line_numbers=False
+                    )
+                    out_console.print(
+                        Panel(
+                            syntax,
+                            title="[bold]Changes Preview[/bold]",
+                            border_style="blue",
+                        )
+                    )
+
+                    if not Confirm.ask(f"Apply these changes to {project_name}?"):
+                        continue
+
+                # Write back the modified content
+                filepath.write_text(modified_content)
+                modified_count += 1
+                out_console.print(
+                    f"  ✓ Modified: {project_name} ({filepath.name})", style="green"
+                )
+            else:
+                out_console.print(
+                    f"  - No changes: {project_name} ({filepath.name})", style="yellow"
+                )
+
+        except Exception as e:
+            out_console.print(f"  ✗ Error processing {project_name}: {e}", style="red")
+
+    if modified_count > 0:
+        print_success_msg(f"Successfully modified {modified_count} project file(s)")
+    if modified_count == 0:
+        out_console.print("No replacements were made in any files", style="yellow")

--- a/src/jobflow_remote/config/manager.py
+++ b/src/jobflow_remote/config/manager.py
@@ -306,6 +306,28 @@ class ConfigManager:
 
         return project_names
 
+    def backup_project(self, project_name: str) -> None:
+        """
+        Create the backup of a project file using the naming convention
+        $FILENAME.bak.$N
+
+        Parameters
+        ----------
+        project_name
+            Name of the project to be removed.
+        """
+        project_data = self.get_project_data(project_name)
+        filepath = Path(project_data.filepath)
+        filename = filepath.name
+
+        i = 1
+        while True:
+            new_filepath = filepath.parent / f"{filename}.bak.{i}"
+            if not new_filepath.exists():
+                break
+            i += 1
+        shutil.copy2(filepath, new_filepath)
+
     def set_worker(
         self,
         name: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def tmp_dir():
     old_cwd = os.getcwd()
     new_path = tempfile.mkdtemp()
     os.chdir(new_path)
-    yield
+    yield Path(new_path)
     os.chdir(old_cwd)
     shutil.rmtree(new_path)
 

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -219,3 +219,201 @@ def test_list_exec_config(job_controller, run_check_cli) -> None:
 def test_list_workers(job_controller, run_check_cli) -> None:
     output = ["Name", "type", "info", "test_local_worker", "test_local_worker_2"]
     run_check_cli(["project", "worker", "list", "-v"], required_out=output)
+
+
+def test_edit_replace(
+    job_controller, random_project_name, monkeypatch, tmp_dir, run_check_cli
+) -> None:
+    from monty.serialization import loadfn
+
+    from jobflow_remote import SETTINGS
+    from jobflow_remote.config.manager import ConfigManager
+
+    cm_orig = ConfigManager()
+    original_project = cm_orig.get_project()
+
+    with monkeypatch.context() as m:
+        m.setattr(SETTINGS, "projects_folder", str(tmp_dir))
+
+        # cases with empty projects folder
+        run_check_cli(
+            ["project", "edit", "replace", "old_text", "new_text"],
+            required_out=f"The selected project {random_project_name} does not exist or could not be parsed",
+            error=True,
+        )
+
+        run_check_cli(
+            ["project", "edit", "replace", "old_text", "new_text", "--all"],
+            required_out="No valid project files found",
+            error=True,
+        )
+
+        # create some projects
+        cm_patch = ConfigManager()
+        proj1 = original_project.copy()
+        proj1.name = "test_project_1"
+        proj1.workers["test_local_worker"].work_dir = "/path/to/old_workdir"
+        proj1.workers["test_local_worker"].resources = {"old_resource": "value"}
+        proj1.queue.store["collection_name"] = "old_collection"
+        cm_patch.create_project(proj1)
+
+        proj2 = original_project.copy()
+        proj2.name = "test_project_2"
+        proj2.workers["test_local_worker"].work_dir = "/different/old_workdir"
+        proj2.workers["test_local_worker"].resources = {"some_resource": "value"}
+        proj2.queue.store["collection_name"] = "old_collection"
+        cm_patch.create_project(proj2)
+
+        proj3 = original_project.copy()
+        proj3.name = "test_project_3"
+        proj3.workers["test_local_worker"].work_dir = "/different/old_workdir"
+        proj3.workers["test_local_worker"].resources = {
+            "different_key": "different_value"
+        }
+        proj3.queue.store["collection_name"] = "different_collection"
+        cm_patch.create_project(proj3)
+
+        m.setattr(SETTINGS, "project", "test_project_1")
+
+        # Replace in single project with confirmation
+        run_check_cli(
+            ["project", "edit", "replace", "old_workdir", "new_workdir"],
+            required_out=[
+                "Apply these changes to test_project_1?",
+                "✓ Modified: test_project_1",
+            ],
+            cli_input="y",
+        )
+
+        updated_project1 = loadfn(tmp_dir / "test_project_1.yaml")
+        assert (
+            "new_workdir"
+            in updated_project1["workers"]["test_local_worker"]["work_dir"]
+        )
+        assert (
+            "old_workdir"
+            not in updated_project1["workers"]["test_local_worker"]["work_dir"]
+        )
+
+        # Replace in single project with no confirmation
+        run_check_cli(
+            ["project", "edit", "replace", "old_resource", "new_resource"],
+            required_out=["Apply these changes to test_project_1?"],
+            cli_input="n",
+        )
+
+        project1_check = loadfn(tmp_dir / "test_project_1.yaml")
+        assert (
+            "old_resource"
+            in project1_check["workers"]["test_local_worker"]["resources"]
+        )
+        assert (
+            "new_resource"
+            not in project1_check["workers"]["test_local_worker"]["resources"]
+        )
+
+        # --force
+        run_check_cli(
+            ["project", "edit", "replace", "old_resource", "new_resource", "--force"],
+            required_out="✓ Modified: test_project_1",
+            excluded_out="Apply these changes",
+        )
+
+        updated_project1_force = loadfn(tmp_dir / "test_project_1.yaml")
+        assert (
+            "new_resource"
+            in updated_project1_force["workers"]["test_local_worker"]["resources"]
+        )
+        assert (
+            "old_resource"
+            not in updated_project1_force["workers"]["test_local_worker"]["resources"]
+        )
+
+        # Replace with --all, mixed responses
+        run_check_cli(
+            ["project", "edit", "replace", "old_collection", "new_collection", "--all"],
+            required_out=[
+                "Apply these changes to test_project_1?",
+                "Apply these changes to test_project_2?",
+                "- No changes: test_project_3",
+                "✓ Modified: test_project_1",
+            ],
+            cli_input="y\nn",
+        )
+
+        final_project1 = loadfn(tmp_dir / "test_project_1.yaml")
+        final_project2 = loadfn(tmp_dir / "test_project_2.yaml")
+        final_project3 = loadfn(tmp_dir / "test_project_3.yaml")
+
+        assert "new_collection" in final_project1["queue"]["store"]["collection_name"]
+        assert (
+            "old_collection" in final_project2["queue"]["store"]["collection_name"]
+        )  # Should not change
+        assert (
+            "different_collection"
+            in final_project3["queue"]["store"]["collection_name"]
+        )  # Should not change
+
+        # --all --force
+        run_check_cli(
+            [
+                "project",
+                "edit",
+                "replace",
+                "localhost",
+                "127.0.0.1",
+                "--all",
+                "--force",
+            ],
+            required_out=[
+                "✓ Modified: test_project_1",
+                "✓ Modified: test_project_2",
+                "✓ Modified: test_project_3",
+                "Successfully modified 3 project file(s)",
+            ],
+            excluded_out="Apply these changes",
+        )
+
+        for proj_file in [
+            "test_project_1.yaml",
+            "test_project_2.yaml",
+            "test_project_3.yaml",
+        ]:
+            proj_data = loadfn(tmp_dir / proj_file)
+            assert "127.0.0.1" in proj_data["queue"]["store"]["host"]
+            assert "localhost" not in proj_data["queue"]["store"]["host"]
+
+        # Try to replace something that is not present in the files
+        run_check_cli(
+            [
+                "project",
+                "edit",
+                "replace",
+                "nonexistent_text",
+                "replacement_text",
+                "--all",
+                "--force",
+            ],
+            required_out=[
+                "- No changes: test_project_1",
+                "- No changes: test_project_2",
+                "- No changes: test_project_3",
+                "No replacements were made in any files",
+            ],
+        )
+
+        # Project with invalid YAML to test error handling
+        invalid_project_path = tmp_dir / "invalid_project.yaml"
+        invalid_project_path.write_text(
+            "name: invalid_project\nworkers:\n  - this is not valid yaml structure:\n      bad_indent"
+        )
+
+        run_check_cli(
+            ["project", "edit", "replace", "test", "TEST", "--all", "--force"],
+            required_out=[
+                "✓ Modified: test_project_1",
+                "✓ Modified: test_project_2",
+                "✓ Modified: test_project_3",
+            ],
+            excluded_out="invalid_project",
+        )

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -285,6 +285,8 @@ def test_edit_replace(
             cli_input="y",
         )
 
+        assert (tmp_dir / "test_project_1.yaml.bak.1").exists()
+
         updated_project1 = loadfn(tmp_dir / "test_project_1.yaml")
         assert (
             "new_workdir"
@@ -312,12 +314,22 @@ def test_edit_replace(
             not in project1_check["workers"]["test_local_worker"]["resources"]
         )
 
-        # --force
+        # --force, no backup
         run_check_cli(
-            ["project", "edit", "replace", "old_resource", "new_resource", "--force"],
+            [
+                "project",
+                "edit",
+                "replace",
+                "old_resource",
+                "new_resource",
+                "--force",
+                "--no-backup",
+            ],
             required_out="✓ Modified: test_project_1",
             excluded_out="Apply these changes",
         )
+        assert (tmp_dir / "test_project_1.yaml.bak.1").exists()
+        assert not (tmp_dir / "test_project_1.yaml.bak.2").exists()
 
         updated_project1_force = loadfn(tmp_dir / "test_project_1.yaml")
         assert (
@@ -340,6 +352,9 @@ def test_edit_replace(
             ],
             cli_input="y\nn",
         )
+
+        assert (tmp_dir / "test_project_1.yaml.bak.1").exists()
+        assert (tmp_dir / "test_project_1.yaml.bak.2").exists()
 
         final_project1 = loadfn(tmp_dir / "test_project_1.yaml")
         final_project2 = loadfn(tmp_dir / "test_project_2.yaml")
@@ -409,11 +424,28 @@ def test_edit_replace(
         )
 
         run_check_cli(
-            ["project", "edit", "replace", "test", "TEST", "--all", "--force"],
+            [
+                "project",
+                "edit",
+                "replace",
+                "new_collection",
+                "old_collection",
+                "--all",
+                "--force",
+            ],
             required_out=[
                 "✓ Modified: test_project_1",
-                "✓ Modified: test_project_2",
-                "✓ Modified: test_project_3",
             ],
             excluded_out="invalid_project",
+        )
+
+        # Invalid modification
+        run_check_cli(
+            ["project", "edit", "replace", "workers", "wrong_field"],
+            required_out=[
+                "WARNING: The modification to the project file will result in an invalid file/project",
+                "wrong_field",
+                "No replacements were made in any files",
+            ],
+            cli_input="n",
         )


### PR DESCRIPTION
Small addition to the CLI. Command to replace some content directly in the project yaml files. 
The command `jf project edit replace xxx yyy` will replace all the occurrences of the string `xxx` with `yyy`. 
By default acts only on the current active project, but can also act on all the correctly parsed project files. It also shows a diff of the changes applied before proceeding.
Convenient for example in case of upgrade of conda environment and needing to switch many projects consistently.

I wonder if it would be worth to add a `--regex` option where the first string can also be a regex.