### PR TITLE
Update `set_run_config` to allow multiple changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.10"
 dependencies = [
     "fabric ~= 3.2",
     "flufl.lock ~= 8.0",
-    "jobflow >= 0.1.19",
+    "jobflow >= 0.2.1",
     "psutil >= 5.9,< 8.0",
     "pydantic ~= 2.4",
     "pymongo < 4.11",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-jobflow==0.1.19
+jobflow==0.2.1
 pydantic==2.12.4
 pymongo==4.10.1
 fabric==3.2.2

--- a/src/jobflow_remote/config/jobconfig.py
+++ b/src/jobflow_remote/config/jobconfig.py
@@ -22,6 +22,7 @@ def set_run_config(
     priority: int | None = None,
     worker: str | None = None,
     dynamic: bool = True,
+    overwrite: bool = False,
 ) -> Flow | Job:
     """
     Modify in place a Flow or a Job by setting the properties in the
@@ -62,6 +63,8 @@ def set_run_config(
     dynamic
         The updates will be propagated to Jobs/Flows dynamically generated at
         runtime.
+    overwrite
+        If True the whole JobConfig of the Job is replaced. Legacy behaviour.
 
     Returns
     -------
@@ -70,21 +73,37 @@ def set_run_config(
     """
     if not exec_config and not resources and not worker and priority is None:
         return flow_or_job
-    config: dict = {"manager_config": {}}
-    if exec_config is not None:
-        config["manager_config"]["exec_config"] = exec_config
-    if resources is not None:
-        config["manager_config"]["resources"] = resources
-    if worker is not None:
-        config["manager_config"]["worker"] = worker
-    if priority is not None:
-        config["manager_config"]["priority"] = priority
+
+    if overwrite:
+        dict_mod = False
+        config: dict = {"manager_config": {}}
+        if exec_config is not None:
+            config["manager_config"]["exec_config"] = exec_config
+        if resources is not None:
+            config["manager_config"]["resources"] = resources
+        if worker is not None:
+            config["manager_config"]["worker"] = worker
+        if priority is not None:
+            config["manager_config"]["priority"] = priority
+    else:
+        dict_mod = True
+        config_set: dict = {}
+        if exec_config is not None:
+            config_set["manager_config->exec_config"] = exec_config
+        if resources is not None:
+            config_set["manager_config->resources"] = resources
+        if worker is not None:
+            config_set["manager_config->worker"] = worker
+        if priority is not None:
+            config_set["manager_config->priority"] = priority
+        config = {"_set": config_set}
 
     flow_or_job.update_config(
         config=config,
         name_filter=name_filter,
         function_filter=function_filter,
         dynamic=dynamic,
+        dict_mod=dict_mod,
     )
 
     return flow_or_job

--- a/tests/db/config/test_jobconfig.py
+++ b/tests/db/config/test_jobconfig.py
@@ -5,46 +5,112 @@ def test_set_run_config(job_controller):
     from jobflow_remote.config.jobconfig import set_run_config
     from jobflow_remote.testing import add
 
-    j1 = add(1, 2)
-    flow1 = Flow([j1])
-    submit_flow(flow1, worker="test_local_worker")
+    for overwrite in (False, True):
+        j1 = add(1, 2)
+        flow1 = Flow([j1])
+        submit_flow(flow1, worker="test_local_worker")
 
-    doc = job_controller.get_job_doc(job_id=j1.uuid)
-    assert doc.worker == "test_local_worker"
-    assert doc.priority == 0
-    assert doc.exec_config is None
-    assert doc.resources is None
+        doc = job_controller.get_job_doc(job_id=j1.uuid)
+        assert doc.worker == "test_local_worker"
+        assert doc.priority == 0
+        assert doc.exec_config is None
+        assert doc.resources is None
 
-    j2_1 = add(1, 2)
-    j2_1.name = "to_modify"
-    j2_2 = add(j2_1.output, 2)
-    flow2 = Flow([j2_1, j2_2])
+        j2_1 = add(1, 2)
+        j2_1.name = "to_modify"
+        j2_2 = add(j2_1.output, 2)
+        flow2 = Flow([j2_1, j2_2])
 
-    flow2 = set_run_config(
-        flow2,
-        exec_config="test",
-        worker="test_local_worker_2",
-        priority=5,
-        resources={"test_res": 1},
-        name_filter="to_modify",
-    )
+        flow2 = set_run_config(
+            flow2,
+            exec_config="test",
+            worker="test_local_worker_2",
+            priority=5,
+            resources={"test_res": 1},
+            name_filter="to_modify",
+            overwrite=overwrite,
+        )
 
-    assert j2_1.config.manager_config["exec_config"] == "test"
-    assert j2_1.config.manager_config["worker"] == "test_local_worker_2"
-    assert j2_1.config.manager_config["priority"] == 5
-    assert j2_1.config.manager_config["resources"] == {"test_res": 1}
-    assert not j2_2.config.manager_config
+        assert j2_1.config.manager_config["exec_config"] == "test"
+        assert j2_1.config.manager_config["worker"] == "test_local_worker_2"
+        assert j2_1.config.manager_config["priority"] == 5
+        assert j2_1.config.manager_config["resources"] == {"test_res": 1}
+        assert not j2_2.config.manager_config
 
-    submit_flow(flow2, worker="test_local_worker")
-    doc1 = job_controller.get_job_doc(job_id=j2_1.uuid)
-    doc2 = job_controller.get_job_doc(job_id=j2_2.uuid)
+        submit_flow(flow2, worker="test_local_worker")
+        doc1 = job_controller.get_job_doc(job_id=j2_1.uuid)
+        doc2 = job_controller.get_job_doc(job_id=j2_2.uuid)
 
-    assert doc1.worker == "test_local_worker_2"
-    assert doc1.priority == 5
-    assert doc1.exec_config == "test"
-    assert doc1.resources == {"test_res": 1}
+        assert doc1.worker == "test_local_worker_2"
+        assert doc1.priority == 5
+        assert doc1.exec_config == "test"
+        assert doc1.resources == {"test_res": 1}
 
-    assert doc2.worker == "test_local_worker"
-    assert doc2.priority == 0
-    assert doc2.exec_config is None
-    assert doc2.resources is None
+        assert doc2.worker == "test_local_worker"
+        assert doc2.priority == 0
+        assert doc2.exec_config is None
+        assert doc2.resources is None
+
+        # test multiple changes
+        j3_1 = add(1, 2)
+        j3_1.name = "to_modify"
+        j3_2 = add(j3_1.output, 2)
+        flow3 = Flow([j3_1, j3_2])
+
+        flow3 = set_run_config(
+            flow3,
+            exec_config="test",
+            worker="test_local_worker_2",
+            priority=5,
+            resources={"test_res": 1},
+            name_filter="to_modify",
+            overwrite=overwrite,
+        )
+
+        assert j3_1.config.manager_config["exec_config"] == "test"
+        assert j3_1.config.manager_config["worker"] == "test_local_worker_2"
+        assert j3_1.config.manager_config["priority"] == 5
+        assert j3_1.config.manager_config["resources"] == {"test_res": 1}
+        assert not j3_2.config.manager_config
+
+        flow3 = set_run_config(
+            flow3,
+            priority=10,
+            resources={"test_res": 5},
+            name_filter=None,
+            overwrite=overwrite,
+        )
+        submit_flow(flow3, worker="test_local_worker")
+        doc1 = job_controller.get_job_doc(job_id=j3_1.uuid)
+        doc2 = job_controller.get_job_doc(job_id=j3_2.uuid)
+        if overwrite:
+            for j in (j3_1, j3_2):
+                assert j.config.manager_config.get("exec_config") is None
+                assert j.config.manager_config.get("worker") is None
+                assert j.config.manager_config["priority"] == 10
+                assert j.config.manager_config["resources"] == {"test_res": 5}
+            for doc in (doc1, doc2):
+                assert doc.worker == "test_local_worker"
+                assert doc.priority == 10
+                assert doc.exec_config is None
+                assert doc.resources == {"test_res": 5}
+
+        else:
+            assert j3_1.config.manager_config.get("exec_config") == "test"
+            assert j3_1.config.manager_config.get("worker") == "test_local_worker_2"
+            assert j3_1.config.manager_config["priority"] == 10
+            assert j3_1.config.manager_config["resources"] == {"test_res": 5}
+            assert j3_2.config.manager_config.get("exec_config") is None
+            assert j3_2.config.manager_config.get("worker") is None
+            assert j3_2.config.manager_config["priority"] == 10
+            assert j3_2.config.manager_config["resources"] == {"test_res": 5}
+
+            assert doc1.worker == "test_local_worker_2"
+            assert doc1.priority == 10
+            assert doc1.exec_config == "test"
+            assert doc1.resources == {"test_res": 5}
+
+            assert doc2.worker == "test_local_worker"
+            assert doc2.priority == 10
+            assert doc2.exec_config is None
+            assert doc2.resources == {"test_res": 5}

--- a/tests/db/config/test_jobconfig.py
+++ b/tests/db/config/test_jobconfig.py
@@ -1,116 +1,122 @@
-def test_set_run_config(job_controller):
+import pytest
+
+
+@pytest.mark.parametrize(
+    "overwrite",
+    [True, False],
+)
+def test_set_run_config(job_controller, overwrite):
     from jobflow import Flow
 
     from jobflow_remote import submit_flow
     from jobflow_remote.config.jobconfig import set_run_config
     from jobflow_remote.testing import add
 
-    for overwrite in (False, True):
-        j1 = add(1, 2)
-        flow1 = Flow([j1])
-        submit_flow(flow1, worker="test_local_worker")
+    j1 = add(1, 2)
+    flow1 = Flow([j1])
+    submit_flow(flow1, worker="test_local_worker")
 
-        doc = job_controller.get_job_doc(job_id=j1.uuid)
-        assert doc.worker == "test_local_worker"
-        assert doc.priority == 0
-        assert doc.exec_config is None
-        assert doc.resources is None
+    doc = job_controller.get_job_doc(job_id=j1.uuid)
+    assert doc.worker == "test_local_worker"
+    assert doc.priority == 0
+    assert doc.exec_config is None
+    assert doc.resources is None
 
-        j2_1 = add(1, 2)
-        j2_1.name = "to_modify"
-        j2_2 = add(j2_1.output, 2)
-        flow2 = Flow([j2_1, j2_2])
+    j2_1 = add(1, 2)
+    j2_1.name = "to_modify"
+    j2_2 = add(j2_1.output, 2)
+    flow2 = Flow([j2_1, j2_2])
 
-        flow2 = set_run_config(
-            flow2,
-            exec_config="test",
-            worker="test_local_worker_2",
-            priority=5,
-            resources={"test_res": 1},
-            name_filter="to_modify",
-            overwrite=overwrite,
-        )
+    flow2 = set_run_config(
+        flow2,
+        exec_config="test",
+        worker="test_local_worker_2",
+        priority=5,
+        resources={"test_res": 1},
+        name_filter="to_modify",
+        overwrite=overwrite,
+    )
 
-        assert j2_1.config.manager_config["exec_config"] == "test"
-        assert j2_1.config.manager_config["worker"] == "test_local_worker_2"
-        assert j2_1.config.manager_config["priority"] == 5
-        assert j2_1.config.manager_config["resources"] == {"test_res": 1}
-        assert not j2_2.config.manager_config
+    assert j2_1.config.manager_config["exec_config"] == "test"
+    assert j2_1.config.manager_config["worker"] == "test_local_worker_2"
+    assert j2_1.config.manager_config["priority"] == 5
+    assert j2_1.config.manager_config["resources"] == {"test_res": 1}
+    assert not j2_2.config.manager_config
 
-        submit_flow(flow2, worker="test_local_worker")
-        doc1 = job_controller.get_job_doc(job_id=j2_1.uuid)
-        doc2 = job_controller.get_job_doc(job_id=j2_2.uuid)
+    submit_flow(flow2, worker="test_local_worker")
+    doc1 = job_controller.get_job_doc(job_id=j2_1.uuid)
+    doc2 = job_controller.get_job_doc(job_id=j2_2.uuid)
+
+    assert doc1.worker == "test_local_worker_2"
+    assert doc1.priority == 5
+    assert doc1.exec_config == "test"
+    assert doc1.resources == {"test_res": 1}
+
+    assert doc2.worker == "test_local_worker"
+    assert doc2.priority == 0
+    assert doc2.exec_config is None
+    assert doc2.resources is None
+
+    # test multiple changes
+    j3_1 = add(1, 2)
+    j3_1.name = "to_modify"
+    j3_2 = add(j3_1.output, 2)
+    flow3 = Flow([j3_1, j3_2])
+
+    flow3 = set_run_config(
+        flow3,
+        exec_config="test",
+        worker="test_local_worker_2",
+        priority=5,
+        resources={"test_res": 1},
+        name_filter="to_modify",
+        overwrite=overwrite,
+    )
+
+    assert j3_1.config.manager_config["exec_config"] == "test"
+    assert j3_1.config.manager_config["worker"] == "test_local_worker_2"
+    assert j3_1.config.manager_config["priority"] == 5
+    assert j3_1.config.manager_config["resources"] == {"test_res": 1}
+    assert not j3_2.config.manager_config
+
+    flow3 = set_run_config(
+        flow3,
+        priority=10,
+        resources={"test_res": 5},
+        name_filter=None,
+        overwrite=overwrite,
+    )
+    submit_flow(flow3, worker="test_local_worker")
+    doc1 = job_controller.get_job_doc(job_id=j3_1.uuid)
+    doc2 = job_controller.get_job_doc(job_id=j3_2.uuid)
+    if overwrite:
+        for j in (j3_1, j3_2):
+            assert j.config.manager_config.get("exec_config") is None
+            assert j.config.manager_config.get("worker") is None
+            assert j.config.manager_config["priority"] == 10
+            assert j.config.manager_config["resources"] == {"test_res": 5}
+        for doc in (doc1, doc2):
+            assert doc.worker == "test_local_worker"
+            assert doc.priority == 10
+            assert doc.exec_config is None
+            assert doc.resources == {"test_res": 5}
+
+    else:
+        assert j3_1.config.manager_config.get("exec_config") == "test"
+        assert j3_1.config.manager_config.get("worker") == "test_local_worker_2"
+        assert j3_1.config.manager_config["priority"] == 10
+        assert j3_1.config.manager_config["resources"] == {"test_res": 5}
+        assert j3_2.config.manager_config.get("exec_config") is None
+        assert j3_2.config.manager_config.get("worker") is None
+        assert j3_2.config.manager_config["priority"] == 10
+        assert j3_2.config.manager_config["resources"] == {"test_res": 5}
 
         assert doc1.worker == "test_local_worker_2"
-        assert doc1.priority == 5
+        assert doc1.priority == 10
         assert doc1.exec_config == "test"
-        assert doc1.resources == {"test_res": 1}
+        assert doc1.resources == {"test_res": 5}
 
         assert doc2.worker == "test_local_worker"
-        assert doc2.priority == 0
+        assert doc2.priority == 10
         assert doc2.exec_config is None
-        assert doc2.resources is None
-
-        # test multiple changes
-        j3_1 = add(1, 2)
-        j3_1.name = "to_modify"
-        j3_2 = add(j3_1.output, 2)
-        flow3 = Flow([j3_1, j3_2])
-
-        flow3 = set_run_config(
-            flow3,
-            exec_config="test",
-            worker="test_local_worker_2",
-            priority=5,
-            resources={"test_res": 1},
-            name_filter="to_modify",
-            overwrite=overwrite,
-        )
-
-        assert j3_1.config.manager_config["exec_config"] == "test"
-        assert j3_1.config.manager_config["worker"] == "test_local_worker_2"
-        assert j3_1.config.manager_config["priority"] == 5
-        assert j3_1.config.manager_config["resources"] == {"test_res": 1}
-        assert not j3_2.config.manager_config
-
-        flow3 = set_run_config(
-            flow3,
-            priority=10,
-            resources={"test_res": 5},
-            name_filter=None,
-            overwrite=overwrite,
-        )
-        submit_flow(flow3, worker="test_local_worker")
-        doc1 = job_controller.get_job_doc(job_id=j3_1.uuid)
-        doc2 = job_controller.get_job_doc(job_id=j3_2.uuid)
-        if overwrite:
-            for j in (j3_1, j3_2):
-                assert j.config.manager_config.get("exec_config") is None
-                assert j.config.manager_config.get("worker") is None
-                assert j.config.manager_config["priority"] == 10
-                assert j.config.manager_config["resources"] == {"test_res": 5}
-            for doc in (doc1, doc2):
-                assert doc.worker == "test_local_worker"
-                assert doc.priority == 10
-                assert doc.exec_config is None
-                assert doc.resources == {"test_res": 5}
-
-        else:
-            assert j3_1.config.manager_config.get("exec_config") == "test"
-            assert j3_1.config.manager_config.get("worker") == "test_local_worker_2"
-            assert j3_1.config.manager_config["priority"] == 10
-            assert j3_1.config.manager_config["resources"] == {"test_res": 5}
-            assert j3_2.config.manager_config.get("exec_config") is None
-            assert j3_2.config.manager_config.get("worker") is None
-            assert j3_2.config.manager_config["priority"] == 10
-            assert j3_2.config.manager_config["resources"] == {"test_res": 5}
-
-            assert doc1.worker == "test_local_worker_2"
-            assert doc1.priority == 10
-            assert doc1.exec_config == "test"
-            assert doc1.resources == {"test_res": 5}
-
-            assert doc2.worker == "test_local_worker"
-            assert doc2.priority == 10
-            assert doc2.exec_config is None
-            assert doc2.resources == {"test_res": 5}
+        assert doc2.resources == {"test_res": 5}


### PR DESCRIPTION
Currently, if multiple calls of `set_run_config` apply to the same Job the `JobConfig` is overwritten every time and thus only the last one is taken into account. 
Switch to use dict_mod updates so that each all updates will be considered. 

Requires https://github.com/materialsproject/jobflow/pull/817 to be merged (and a new release of jobflow).