### PR TITLE
Report option for jf flow info

### DIFF
--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -12,6 +12,7 @@ from jobflow_remote.cli.formatting import (
     format_flow_info,
     get_flow_info_table,
     get_flow_report_components,
+    get_single_flow_report_components,
     header_name_data_getter_map,
 )
 from jobflow_remote.cli.jf import app
@@ -297,6 +298,14 @@ def flow_info(
             help="Reverse the sorting order of the jobs",
         ),
     ] = False,
+    print_report: Annotated[
+        bool,
+        typer.Option(
+            "--report",
+            "-rep",
+            help="Show a summary report of the Flow status",
+        ),
+    ] = False,
 ) -> None:
     """Provide detailed information on a Flow."""
 
@@ -320,6 +329,9 @@ def flow_info(
 
     with loading_spinner():
         jc = get_job_controller()
+        with_jobs_info: bool | list[str] = True
+        if report:
+            with_jobs_info = ["start_time", "end_time"]
 
         flows_info = jc.get_flows_info(
             job_ids=job_ids,
@@ -328,19 +340,22 @@ def flow_info(
             sort=db_sort,
             jobs_sort=db_jobs_sort,
             limit=1,
-            with_jobs_info=True,
+            with_jobs_info=with_jobs_info,
         )
     if not flows_info:
         exit_with_error_msg("No data matching the request")
 
-    out_console.print(
-        format_flow_info(
-            flows_info[0],
-            verbosity=verbosity,
-            output_keys=output_keys,
-            stored_data_keys=stored_data_keys,
+    if print_report:
+        out_console.print(*get_single_flow_report_components(flows_info[0]))
+    else:
+        out_console.print(
+            format_flow_info(
+                flows_info[0],
+                verbosity=verbosity,
+                output_keys=output_keys,
+                stored_data_keys=stored_data_keys,
+            )
         )
-    )
 
 
 @app_flow.command()

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -19,7 +19,7 @@ from rich.text import Text
 from jobflow_remote.cli.utils import ReprStr, fmt_datetime, render_scope_jfr
 from jobflow_remote.jobs.state import FlowState, JobState
 from jobflow_remote.remote.data import get_job_path
-from jobflow_remote.utils.data import convert_utc_time
+from jobflow_remote.utils.data import convert_utc_time, get_h_m_s
 
 if TYPE_CHECKING:
     from packaging.version import Version
@@ -88,6 +88,7 @@ def format_run_time(ji: JobInfo) -> str:
         return ""
     m, s = divmod(run_time, 60)
     h, m = divmod(m, 60)
+    h, m, s = get_h_m_s(run_time)
     return prefix + f"{h:g}:{m:02g}"
 
 
@@ -623,8 +624,7 @@ def get_single_flow_report_components(flow_info: FlowInfo) -> list[RenderableTyp
             convert_utc_time(end_time).strftime(fmt_datetime) + f" [{time.tzname[0]}]",
         )
         total_time = (end_time - start_time).total_seconds()
-        hours, remainder = divmod(total_time, 3600)
-        minutes, seconds = divmod(remainder, 60)
+        hours, minutes, seconds = get_h_m_s(total_time)
         header_table.add_row(
             "Total Time", f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
         )
@@ -636,8 +636,7 @@ def get_single_flow_report_components(flow_info: FlowInfo) -> list[RenderableTyp
         )
         # Show elapsed time for non-completed flows
         elapsed_time = (datetime.datetime.utcnow() - start_time).total_seconds()
-        hours, remainder = divmod(elapsed_time, 3600)
-        minutes, seconds = divmod(remainder, 60)
+        hours, minutes, seconds = get_h_m_s(elapsed_time)
         header_table.add_row(
             "Elapsed Time", f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
         )
@@ -646,8 +645,7 @@ def get_single_flow_report_components(flow_info: FlowInfo) -> list[RenderableTyp
     if flow_info.jobs_info:
         total_job_run_time = sum(job.run_time or 0 for job in flow_info.jobs_info)
         if total_job_run_time > 0:
-            hours, remainder = divmod(total_job_run_time, 3600)
-            minutes, seconds = divmod(remainder, 60)
+            hours, minutes, seconds = get_h_m_s(total_job_run_time)
             header_table.add_row(
                 "Total Job Run Time",
                 f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}",

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -579,6 +579,169 @@ def get_flow_report_components(report: FlowsReport) -> list[RenderableType]:
     return components
 
 
+def get_single_flow_report_components(flow_info: FlowInfo) -> list[RenderableType]:
+    """
+    Generate report rich components for a single Flow.
+
+    Parameters
+    ----------
+    flow_info
+        The FlowInfo object containing information about the Flow.
+
+    Returns
+    -------
+    list[RenderableType]
+        List of Rich components for display.
+    """
+    components = []
+
+    # Flow Header with basic information
+    header_table = Table(
+        title=f"Flow Report: {flow_info.name}",
+        title_style="bold green",
+        show_header=False,
+    )
+    header_table.add_column("", style="cyan", justify="right")
+    header_table.add_column("", style="white", justify="left")
+
+    header_table.add_row("Flow ID", flow_info.flow_id)
+    header_table.add_row("Flow State", flow_info.state.name)
+    header_table.add_row("Number of Jobs", str(len(flow_info.job_ids)))
+
+    # Calculate timing information
+    start_time = flow_info.created_on
+    header_table.add_row(
+        "Start Time",
+        convert_utc_time(start_time).strftime(fmt_datetime) + f" [{time.tzname[0]}]",
+    )
+
+    # If flow is completed, calculate total time
+    if flow_info.state == FlowState.COMPLETED:
+        end_time = flow_info.updated_on
+        header_table.add_row(
+            "Complete Time",
+            convert_utc_time(end_time).strftime(fmt_datetime) + f" [{time.tzname[0]}]",
+        )
+        total_time = (end_time - start_time).total_seconds()
+        hours, remainder = divmod(total_time, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        header_table.add_row(
+            "Total Time", f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
+        )
+    else:
+        header_table.add_row(
+            "Last Updated",
+            convert_utc_time(flow_info.updated_on).strftime(fmt_datetime)
+            + f" [{time.tzname[0]}]",
+        )
+        # Show elapsed time for non-completed flows
+        elapsed_time = (datetime.datetime.utcnow() - start_time).total_seconds()
+        hours, remainder = divmod(elapsed_time, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        header_table.add_row(
+            "Elapsed Time", f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
+        )
+
+    # Calculate sum of job execution times
+    if flow_info.jobs_info:
+        total_job_run_time = sum(job.run_time or 0 for job in flow_info.jobs_info)
+        if total_job_run_time > 0:
+            hours, remainder = divmod(total_job_run_time, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            header_table.add_row(
+                "Total Job Run Time",
+                f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}",
+            )
+
+    components.append(header_table)
+
+    # Job States Distribution
+    if flow_info.jobs_info:
+        # Count job states
+        state_counts: dict[JobState, int] = {}
+        for job in flow_info.jobs_info:
+            state = job.state
+            state_counts[state] = state_counts.get(state, 0) + 1
+
+        # Create job states table
+        states_table = Table(title="Job States Distribution", title_style="bold green")
+        states_table.add_column("State", style="cyan", justify="left")
+        states_table.add_column("Count", style="white", justify="center")
+        states_table.add_column("Percentage", style="white", justify="right")
+
+        total_jobs = len(flow_info.jobs_info)
+
+        for state in JobState:
+            if state in state_counts:
+                count = state_counts[state]
+                percentage = (count / total_jobs) * 100
+
+                # Color code the state name based on state
+                if state in (JobState.FAILED, JobState.REMOTE_ERROR):
+                    state_str = f"[red]{state.name}[/red]"
+                elif state == JobState.COMPLETED:
+                    state_str = f"[green]{state.name}[/green]"
+                elif state == JobState.RUNNING:
+                    state_str = f"[cyan]{state.name}[/cyan]"
+                elif state in (
+                    JobState.PAUSED,
+                    JobState.STOPPED,
+                    JobState.USER_STOPPED,
+                ):
+                    state_str = f"[yellow]{state.name}[/yellow]"
+                else:
+                    state_str = state.name
+
+                states_table.add_row(
+                    Text.from_markup(state_str), str(count), f"{percentage:.1f}%"
+                )
+
+        components.append(states_table)
+
+        # Flow advancement
+        # Consider all the states after the Job has started as "running"
+        running_states = (
+            JobState.RUNNING,
+            JobState.BATCH_RUNNING,
+            JobState.RUN_FINISHED,
+            JobState.DOWNLOADED,
+        )
+        completed_count = sum(
+            1 for j in flow_info.jobs_info if j.state == JobState.COMPLETED
+        )
+        failed_count = sum(
+            1
+            for j in flow_info.jobs_info
+            if j.state in (JobState.FAILED, JobState.REMOTE_ERROR)
+        )
+        running_count = sum(1 for j in flow_info.jobs_info if j.state in running_states)
+        queued_count = sum(
+            1
+            for j in flow_info.jobs_info
+            if j.state in (JobState.SUBMITTED, JobState.BATCH_SUBMITTED)
+        )
+        pending_count = (
+            total_jobs - completed_count - failed_count - running_count - queued_count
+        )
+
+        progress_panel = Panel.fit(
+            Text.from_markup(
+                f"[green]Completed: {completed_count}[/green] | "
+                f"[cyan]Running: {running_count}[/cyan] | "
+                f"[blue]Queued: {queued_count}[/blue] | "
+                f"[yellow]Pending: {pending_count}[/yellow] | "
+                f"[red]Failed: {failed_count}[/red]\n"
+                f"Progress: {completed_count}/{total_jobs} ({(completed_count/total_jobs)*100:.1f}%)"
+            ),
+            title="Flow Progress",
+            title_align="left",
+            border_style="green",
+        )
+        components.append(progress_panel)
+
+    return components
+
+
 def format_upgrade_actions(actions: list[UpgradeAction]):
     msg = ""
     for action in actions:

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -219,10 +219,17 @@ def get_utc_offset(timezone: str):
     utc_offset = now.utcoffset()
 
     # Extract hours and minutes
-    hours, remainder = divmod(utc_offset.total_seconds(), 3600)
-    minutes = remainder // 60
+    hours, minutes, _ = get_h_m_s(utc_offset.total_seconds())
 
     return f"{int(hours):+03d}:{int(minutes):02d}"
+
+
+def get_h_m_s(
+    total_seconds: float,
+) -> tuple[float, float, float]:
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return hours, minutes, seconds
 
 
 # TODO imported this from jobflow remote for backward compatibility.

--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -173,7 +173,7 @@ def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     )
 
 
-def test_flow_info(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+def test_flow_info(job_controller, two_flows_four_jobs, run_check_cli, runner) -> None:
     columns = ["DB id", "Name", "State", "Job id", "(Index)", "Worker"]
     outputs = columns + [f"add{i}" for i in range(1, 3)] + ["READY", "WAITING"]
     excluded = [f"add{i}" for i in range(3, 5)] + ["{'f1_metadata': 'some_info'}"]
@@ -222,6 +222,33 @@ def test_flow_info(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     assert table_flow_info_vvv == table_job_list_vvv
 
     run_check_cli(["flow", "info", "-j", "3", "-v"], required_out=["Metadata: {}"])
+
+    run_check_cli(
+        ["flow", "info", "-j", "1", "--report"],
+        required_out=[
+            "Flow Report: f1",
+            "Completed: 0 | Running: 0 | Queued: 0 | Pending: 2 | Failed: 0",
+            "READY",
+            "WAITING",
+            "Elapsed Time",
+        ],
+        excluded_out="COMPLETED",
+    )
+
+    runner.run_one_job(db_id="1")
+    runner.run_one_job(db_id="2")
+
+    run_check_cli(
+        ["flow", "info", "-j", "1", "--report"],
+        required_out=[
+            "Flow Report: f1",
+            "Progress: 2/2 (100.0%)",
+            "COMPLETED",
+            "Total Time",
+            "Total Job Run Time",
+        ],
+        excluded_out=["Elapsed Time", "READY"],
+    )
 
 
 def test_report(job_controller, run_check_cli) -> None:


### PR DESCRIPTION
For big Flows `jf flow info` is difficult to use because too many jobs are present. Here a `--report` option is introduced that just gives a summary of the jobs states and execution progress. I initially thought of adding this as an option for `jf flow report` by allowing to pass the flow id, but in the end I would have needed to have all the same options as in `jf flow info` and made the thing much more complicated both at the API and code level.

Here is an example of how it looks:
<img width="465" height="339" alt="Screenshot 2025-11-11 alle 11 03 46" src="https://github.com/user-attachments/assets/4429cdad-4a2e-451c-8523-808b1318db70" />
