### PR TITLE
Replace --force with --yes

### DIFF
--- a/src/jobflow_remote/cli/admin.py
+++ b/src/jobflow_remote/cli/admin.py
@@ -16,13 +16,14 @@ from jobflow_remote.cli.types import (
     end_date_opt,
     flow_ids_opt,
     flow_state_opt,
-    force_opt,
+    force_opt_deprecated,
     foreground_index_opt,
     index_direction_arg,
     index_key_arg,
     job_ids_indexes_opt,
     job_state_opt,
     start_date_opt,
+    yes_opt,
 )
 from jobflow_remote.cli.utils import (
     IndexDirection,
@@ -175,7 +176,8 @@ def reset(
             help="Also delete all the documents in the current store",
         ),
     ] = False,
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
 ) -> None:
     """
     Reset the jobflow database.
@@ -185,7 +187,7 @@ def reset(
 
     check_stopped_runner(error=True)
 
-    if not force:
+    if not yes_all:
         cm = get_config_manager()
         project_name = cm.get_project_data().project.name
         text = Text.from_markup(
@@ -216,7 +218,8 @@ def unlock(
     state: job_state_opt = None,
     start_date: start_date_opt = None,
     end_date: end_date_opt = None,
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
 ) -> None:
     """
     Forcibly removes the lock from the documents of the selected jobs.
@@ -227,7 +230,7 @@ def unlock(
 
     jc = get_job_controller()
 
-    if not force:
+    if not yes_all:
         with loading_spinner(processing=False) as progress:
             progress.add_task(
                 description="Checking the number of locked documents...", total=None
@@ -275,7 +278,8 @@ def unlock_flow(
     state: flow_state_opt = None,
     start_date: start_date_opt = None,
     end_date: end_date_opt = None,
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
 ) -> None:
     """
     Forcibly removes the lock from the documents of the selected jobs.
@@ -286,7 +290,7 @@ def unlock_flow(
 
     jc = get_job_controller()
 
-    if not force:
+    if not yes_all:
         with loading_spinner(processing=False) as progress:
             progress.add_task(
                 description="Checking the number of locked documents...", total=None

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -29,7 +29,7 @@ from jobflow_remote.cli.types import (
     flow_db_id_arg,
     flow_ids_opt,
     flow_state_opt,
-    force_opt,
+    force_opt_deprecated,
     hours_opt,
     job_flow_id_flag_opt,
     job_ids_opt,
@@ -153,7 +153,8 @@ def delete(
     name: name_opt = None,
     days: days_opt = None,
     hours: hours_opt = None,
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
     max_limit: Annotated[
         int,
         typer.Option(
@@ -220,7 +221,7 @@ def delete(
     if not flows_info:
         exit_with_warning_msg("No flows matching criteria")
 
-    if flows_info and not force:
+    if flows_info and not yes_all:
         if verbosity:
             preamble = Text.from_markup(
                 f"[red]This operation will [bold]delete the following {len(flows_info)} Flow(s)[/bold][/red]"
@@ -499,7 +500,7 @@ def clean(
             help="Do not check if runner is active",
         ),
     ] = False,
-    yes: yes_opt = False,
+    yes_all: yes_opt = False,
     all_states: Annotated[
         bool,
         typer.Option(
@@ -540,7 +541,7 @@ def clean(
     if not flows_info:
         exit_with_warning_msg("No flows matching criteria")
 
-    if not yes:
+    if not yes_all:
         if verbosity:
             preamble = Text.from_markup(
                 f"[red]This operation will [bold]delete the files of the following {len(flows_info)} Flow(s)[/bold][/red]"
@@ -601,13 +602,13 @@ def clean(
                 out_console.print(f" - {ji.db_id} - {ji.state}")
         else:
             confirmed = False
-            if not yes:
+            if not yes_all:
                 text = (
                     "The number of skipped jobs is too large to be printed, the list can be "
                     "dumped to the `skipped_cleanup.dat` file. Do you want to create the file?"
                 )
                 confirmed = Confirm.ask(text, default=False)
-            if yes or confirmed:
+            if yes_all or confirmed:
                 with open("skipped_cleanup.dat", "w") as f:
                     for ji in skipped_jobs:
                         f.writelines(f" - {ji.db_id} - {ji.state}")

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -12,10 +12,11 @@ from jobflow_remote.cli.formatting import get_exec_config_table, get_worker_tabl
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
-    force_opt,
+    force_opt_deprecated,
     serialize_file_format_opt,
     tree_opt,
     verbosity_opt,
+    yes_opt,
 )
 from jobflow_remote.cli.utils import (
     SerializeFileFormat,
@@ -322,7 +323,8 @@ def remove(
             help="Project related folders are not deleted",
         ),
     ] = False,
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
 ) -> None:
     """Remove a project from the projects' folder, including the related folders."""
     cm = get_config_manager()
@@ -332,7 +334,7 @@ def remove(
 
     p = cm.get_project(name)
 
-    if not keep_folders and not force:
+    if not keep_folders and not yes_all:
         msg = f"This will delete also the folders:\n\t{p.base_dir}\n\t{p.log_dir}\n\t{p.tmp_dir}\n\t{p.daemon_dir}\nProceed anyway?"
         if not Confirm.ask(msg):
             raise typer.Exit(0)
@@ -419,7 +421,8 @@ def replace(
             help="Apply replacement to all project files",
         ),
     ] = False,
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
     no_backup: Annotated[
         bool,
         typer.Option(
@@ -471,7 +474,7 @@ def replace(
 
             if original_content != modified_content:
                 # Show diff and ask for confirmation if not forced
-                if not force:
+                if not yes_all:
                     out_console.print(
                         f"\n[bold]File: {filepath.name} (Project: {project_name})[/bold]"
                     )

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -12,9 +12,10 @@ from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
     break_lock_opt,
-    force_opt,
+    force_opt_deprecated,
     log_level_opt,
     verbosity_opt,
+    yes_opt,
 )
 from jobflow_remote.cli.utils import (
     check_stopped_runner,
@@ -406,7 +407,8 @@ def foreground() -> None:
 
 @app_runner.command()
 def reset(
-    force: force_opt = False,
+    yes_all: yes_opt = False,
+    force_deprecated: force_opt_deprecated = False,
     break_lock: break_lock_opt = False,
 ) -> None:
     """
@@ -420,7 +422,7 @@ def reset(
     if running_runner in ("NO_DOCUMENT", None):
         exit_with_warning_msg("No running runner present in the database")
         raise typer.Exit(0)
-    if not force:
+    if not yes_all:
         text = Text.from_markup(
             "[red]This operation will remove the information about the current "
             "running runner from the database:[/red]\n"

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -15,6 +15,23 @@ from jobflow_remote.cli.utils import (
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import BatchState, FlowState, JobState
 
+
+def deprecated_option(old_name: str, new_name: str):
+    """Callback that warns about deprecated options and exits."""
+
+    def callback(value: Optional[str]):
+        from jobflow_remote.cli.utils import exit_with_error_msg
+
+        if value:
+            exit_with_error_msg(
+                f"Error: The '{old_name}' option is deprecated. "
+                f"Please use '{new_name}' instead.",
+            )
+        return value
+
+    return callback
+
+
 tree_opt = Annotated[
     bool,
     typer.Option(
@@ -256,7 +273,9 @@ flow_db_id_arg = Annotated[
     ),
 ]
 
-
+# This should not be used and has been replaced by yes_opt.
+# Do not remove for the time being as it may be still used by some other
+# package with plugins.
 force_opt = Annotated[
     bool,
     typer.Option(
@@ -265,6 +284,21 @@ force_opt = Annotated[
         help="No confirmation will be asked before proceeding",
     ),
 ]
+
+
+# Option to deprecate the usage of the --force option when used instead
+# of --yes. Can be removed in the future after a deprecation period.
+force_opt_deprecated = Annotated[
+    bool,
+    typer.Option(
+        "--force",
+        "-f",
+        help="No confirmation will be asked before proceeding",
+        callback=deprecated_option("--force", "--yes"),
+        hidden=True,
+    ),
+]
+
 
 yes_opt = Annotated[
     bool,

--- a/tests/db/cli/test_admin.py
+++ b/tests/db/cli/test_admin.py
@@ -42,6 +42,19 @@ def test_reset(job_controller, one_job, run_check_cli) -> None:
     )
     assert job_controller.count_jobs() == 0
 
+    run_check_cli(
+        ["admin", "reset", "--yes"],
+        required_out="The database was reset",
+    )
+
+    # To test the deprecated --force option. Remove the test when the option is removed
+    run_check_cli(
+        ["admin", "reset", "--force"],
+        excluded_out="The database was reset",
+        required_out=["deprecated", "--yes"],
+        error=True,
+    )
+
 
 def test_unlock(job_controller, one_job, run_check_cli) -> None:
     j = one_job.jobs[0]

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -314,7 +314,7 @@ def test_edit_replace(
             not in project1_check["workers"]["test_local_worker"]["resources"]
         )
 
-        # --force, no backup
+        # --yes, no backup
         run_check_cli(
             [
                 "project",
@@ -322,7 +322,7 @@ def test_edit_replace(
                 "replace",
                 "old_resource",
                 "new_resource",
-                "--force",
+                "--yes",
                 "--no-backup",
             ],
             required_out="✓ Modified: test_project_1",
@@ -369,7 +369,7 @@ def test_edit_replace(
             in final_project3["queue"]["store"]["collection_name"]
         )  # Should not change
 
-        # --all --force
+        # --all --yes
         run_check_cli(
             [
                 "project",
@@ -378,7 +378,7 @@ def test_edit_replace(
                 "localhost",
                 "127.0.0.1",
                 "--all",
-                "--force",
+                "--yes",
             ],
             required_out=[
                 "✓ Modified: test_project_1",
@@ -407,7 +407,7 @@ def test_edit_replace(
                 "nonexistent_text",
                 "replacement_text",
                 "--all",
-                "--force",
+                "--yes",
             ],
             required_out=[
                 "- No changes: test_project_1",
@@ -431,7 +431,7 @@ def test_edit_replace(
                 "new_collection",
                 "old_collection",
                 "--all",
-                "--force",
+                "--yes",
             ],
             required_out=[
                 "✓ Modified: test_project_1",


### PR DESCRIPTION
As discussed previously, we replace the `--force` option with `--yes` to skip confirmations. The `--force` option remains for actions that have a chance of disrupting the system.

The deprecated option will need to be removed in the future.

I did not modify the description of the `--yes` option for the moment. 