### PR TITLE
Remove support for python 3.9

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,15 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Other/Nonlisted Topic",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "fabric ~= 3.2",
     "flufl.lock ~= 8.0",
@@ -77,7 +78,7 @@ method = "git"
 default-tag = "0.0.1"
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/src/jobflow_remote/cli/admin.py
+++ b/src/jobflow_remote/cli/admin.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional, cast
+from typing import Annotated, cast
 
 import typer
 from packaging.version import parse as parse_version
@@ -66,7 +66,7 @@ def upgrade(
         ),
     ] = False,
     target: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--target",
             "-t",
@@ -170,7 +170,7 @@ def upgrade(
 @app_admin.command()
 def reset(
     validation: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(
             help=(
                 "If the number of flows in the DB exceed 25 it will be required to pass "
@@ -403,7 +403,7 @@ def create(
     direction: index_direction_arg = IndexDirection.ASC,
     foreground: foreground_index_opt = False,
     collection: Annotated[
-        Optional[DbCollection],
+        DbCollection | None,
         typer.Option(
             "--collection",
             "-c",

--- a/src/jobflow_remote/cli/backup.py
+++ b/src/jobflow_remote/cli/backup.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -37,7 +37,7 @@ def create(
         ),
     ] = False,
     mongo_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--mongo-path",
             "-m",
@@ -89,7 +89,7 @@ def restore(
         ),
     ] = ".",
     mongo_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--mongo-path",
             "-m",

--- a/src/jobflow_remote/cli/execution.py
+++ b/src/jobflow_remote/cli/execution.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -18,7 +18,7 @@ app.add_typer(app_execution)
 @app_execution.command()
 def run(
     run_dir: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(
             help="The path to the folder where the files of the job to run will be executed",
         ),
@@ -49,7 +49,7 @@ def run_batch(
         ),
     ],
     max_time: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             "--max-time",
             "-mt",
@@ -59,7 +59,7 @@ def run_batch(
         ),
     ] = None,
     max_wait: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             "--max-wait",
             "-mw",
@@ -69,7 +69,7 @@ def run_batch(
         ),
     ] = 60,
     max_jobs: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(
             "--max-jobs",
             "-mj",
@@ -77,7 +77,7 @@ def run_batch(
         ),
     ] = None,
     parallel_jobs: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(
             "--parallel-jobs",
             "-pj",
@@ -85,7 +85,7 @@ def run_batch(
         ),
     ] = None,
     sleep_time: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             "--sleep-time",
             "-st",

--- a/src/jobflow_remote/cli/flow.py
+++ b/src/jobflow_remote/cli/flow.py
@@ -1,6 +1,6 @@
 import contextlib
 from datetime import datetime
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from dateutil.tz import tzlocal
@@ -363,7 +363,7 @@ def graph(
     flow_db_id: flow_db_id_arg,
     job_id_flag: job_flow_id_flag_opt = False,
     label: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--label",
             "-l",
@@ -371,7 +371,7 @@ def graph(
         ),
     ] = "name",
     file_path: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--path",
             "-p",
@@ -444,7 +444,7 @@ def report(
         ),
     ] = ReportInterval.DAYS,
     num_intervals: Annotated[
-        Optional[int],
+        int | None,
         typer.Argument(
             help="The number of intervals to consider. Default depends on the interval type",
             metavar="NUM_INTERVALS",
@@ -641,7 +641,7 @@ app_flow.add_typer(app_flow_set)
 def store(
     flow_db_id: flow_db_id_arg,
     store: Annotated[
-        Optional[str],
+        str | None,
         typer.Argument(
             help="The name of the Store to be set. If empty will set the default JobStore",
             metavar="STORE",

--- a/src/jobflow_remote/cli/gui.py
+++ b/src/jobflow_remote/cli/gui.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -8,7 +8,7 @@ from jobflow_remote.cli.jf import app
 @app.command()
 def gui(
     port: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(
             "--port",
             "-p",

--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Union
+from typing import Annotated
 
 import typer
 from rich.text import Text
@@ -26,7 +26,7 @@ app = JFRTyper(
 ADDITIONAL_LOGGERS = []
 
 
-def add_cli_logger_names(loggers: Union[str, list[str]]):
+def add_cli_logger_names(loggers: str | list[str]):
     # global ADDITIONAL_LOGGERS
 
     if isinstance(loggers, str):

--- a/src/jobflow_remote/cli/jfr_typer.py
+++ b/src/jobflow_remote/cli/jfr_typer.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import typer
 from typer.models import CommandFunctionType

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -1,7 +1,7 @@
 import io
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 from dateutil.tz import tzlocal
@@ -799,7 +799,7 @@ def report(
         ),
     ] = ReportInterval.DAYS,
     num_intervals: Annotated[
-        Optional[int],
+        int | None,
         typer.Argument(
             help="The number of intervals to consider. Default depends on the interval type",
             metavar="NUM_INTERVALS",
@@ -827,7 +827,7 @@ def todir(
     job_db_id: job_db_id_arg = None,
     job_index: job_index_arg = None,
     shell: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--shell",
             "-s",

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated, Optional
+from typing import Annotated
 
 import click
 import typer
@@ -43,7 +43,7 @@ tree_opt = Annotated[
 ]
 
 job_ids_indexes_opt = Annotated[
-    Optional[list[str]],
+    list[str] | None,
     typer.Option(
         "--job-id",
         "-jid",
@@ -55,7 +55,7 @@ job_ids_indexes_opt = Annotated[
 
 
 job_ids_opt = Annotated[
-    Optional[list[str]],
+    list[str] | None,
     typer.Option(
         "--job-id",
         "-jid",
@@ -66,7 +66,7 @@ job_ids_opt = Annotated[
 
 
 db_ids_opt = Annotated[
-    Optional[list[str]],
+    list[str] | None,
     typer.Option(
         "--db-id",
         "-did",
@@ -76,7 +76,7 @@ db_ids_opt = Annotated[
 
 
 flow_ids_opt = Annotated[
-    Optional[list[str]],
+    list[str] | None,
     typer.Option(
         "--flow-id",
         "-fid",
@@ -86,7 +86,7 @@ flow_ids_opt = Annotated[
 
 
 job_state_opt = Annotated[
-    Optional[list[JobState]],
+    list[JobState] | None,
     typer.Option(
         "--state",
         "-s",
@@ -96,7 +96,7 @@ job_state_opt = Annotated[
 
 
 flow_state_opt = Annotated[
-    Optional[list[FlowState]],
+    list[FlowState] | None,
     typer.Option(
         "--state",
         "-s",
@@ -106,7 +106,7 @@ flow_state_opt = Annotated[
 
 
 batch_state_opt = Annotated[
-    Optional[list[BatchState]],
+    list[BatchState] | None,
     typer.Option(
         "--state",
         "-s",
@@ -116,7 +116,7 @@ batch_state_opt = Annotated[
 
 
 name_opt = Annotated[
-    Optional[str],
+    str | None,
     typer.Option(
         "--name",
         "-n",
@@ -128,7 +128,7 @@ name_opt = Annotated[
 
 
 worker_name_opt = Annotated[
-    Optional[list[str]],
+    list[str] | None,
     typer.Option(
         "--worker",
         "-wk",
@@ -141,7 +141,7 @@ job_state_arg = Annotated[JobState, typer.Argument(help="One of the job states")
 
 
 start_date_opt = Annotated[
-    Optional[datetime],
+    datetime | None,
     typer.Option(
         "--start-date",
         "-sdate",
@@ -152,7 +152,7 @@ start_date_opt = Annotated[
 
 
 end_date_opt = Annotated[
-    Optional[datetime],
+    datetime | None,
     typer.Option(
         "--end-date",
         "-edate",
@@ -162,7 +162,7 @@ end_date_opt = Annotated[
 
 
 days_opt = Annotated[
-    Optional[int],
+    int | None,
     typer.Option(
         "--days",
         "-ds",
@@ -172,7 +172,7 @@ days_opt = Annotated[
 
 
 hours_opt = Annotated[
-    Optional[int],
+    int | None,
     typer.Option(
         "--hours",
         "-hs",
@@ -248,7 +248,7 @@ job_db_id_arg = Annotated[
     ),
 ]
 job_index_arg = Annotated[
-    Optional[int],
+    int | None,
     typer.Argument(
         help="The index of the job. If not defined the job with the largest index is selected",
         metavar="INDEX",
@@ -256,7 +256,7 @@ job_index_arg = Annotated[
 ]
 
 job_index_opt = Annotated[
-    Optional[int],
+    int | None,
     typer.Option(
         "--index",
         "-i",
@@ -435,7 +435,7 @@ index_key_arg = Annotated[
 ]
 
 index_direction_arg = Annotated[
-    Optional[IndexDirection],
+    IndexDirection | None,
     typer.Argument(
         help="The direction of the index",
         metavar="DIRECTION",
@@ -452,7 +452,7 @@ count_opt = Annotated[
 
 
 stored_data_keys_opt = Annotated[
-    Optional[list[str]],
+    list[str] | None,
     typer.Option(
         "--stored-data-key",
         "-sdk",
@@ -460,7 +460,7 @@ stored_data_keys_opt = Annotated[
     ),
 ]
 cli_output_keys_opt = Annotated[
-    Optional[str],
+    str | None,
     typer.Option(
         "--output",
         "-o",
@@ -476,12 +476,10 @@ class DictType(dict):
     pass
 
 
-# Similarly, Python 3.10 union types are not supported,
-# e.g., `str | None` vs `Optional[str]`
-# ruff enforces PEP 604
-# but will leave things in if they are explicit type aliases
-OptionalStr = Optional[str]
-OptionalDictType = Optional[DictType]
+# Python 3.10+ union types are fully supported now
+# These type aliases are kept for backward compatibility with typer's click integration
+OptionalStr = str | None
+OptionalDictType = DictType | None
 
 
 class DictTypeParser(click.ParamType):

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -19,7 +19,7 @@ from jobflow_remote.jobs.state import BatchState, FlowState, JobState
 def deprecated_option(old_name: str, new_name: str):
     """Callback that warns about deprecated options and exits."""
 
-    def callback(value: Optional[str]):
+    def callback(value: str | None):
         from jobflow_remote.cli.utils import exit_with_error_msg
 
         if value:

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -10,7 +10,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import typer
 from click import ClickException
@@ -26,7 +26,7 @@ from jobflow_remote.config.base import ProjectUndefinedError
 from jobflow_remote.jobs.daemon import DaemonError, DaemonManager, DaemonStatus
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
     from cProfile import Profile
 
     from rich.console import ConsoleRenderable
@@ -484,7 +484,7 @@ def execute_multi_jobs_cmd(
                 modified_ids = single_cmd(
                     job_id=job_id, job_index=job_index, db_id=db_id, **kwargs
                 )
-                if not isinstance(modified_ids, (list, tuple)):
+                if not isinstance(modified_ids, list | tuple):
                     modified_ids = [] if modified_ids is None else [modified_ids]
                 if not modified_ids:
                     exit_with_error_msg("Could not perform the requested operation")
@@ -631,7 +631,7 @@ def get_command_tree(
         command_str = f"[bold green]{command_name}[/bold green]"
         if (
             show_docs
-            and isinstance(command, (TyperCommand, TyperGroup))
+            and isinstance(command, TyperCommand | TyperGroup)
             and command.help
         ):
             command_str += f": {command.help}"

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import abc
 import logging
 import traceback
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal
 
 from jobflow import JobStore
 from maggma.stores import MongoStore
@@ -54,7 +56,7 @@ class RunnerOptions(BaseModel):
         7200,
         description="Delay between subsequent pings to the running runner document.",
     )
-    lock_timeout: Optional[float] = Field(
+    lock_timeout: float | None = Field(
         86400,
         description="Time to consider the lock on a document expired and can be overridden (seconds)",
     )
@@ -134,21 +136,21 @@ class BatchConfig(BaseModel):
         description="Absolute path to a folder where the batch jobs will be executed. This refers to the jobs submitted"
         "to the queue. Jobflow's Job will still be executed in the standard folders."
     )
-    max_jobs_per_batch: Optional[int] = Field(
+    max_jobs_per_batch: int | None = Field(
         None, description="Maximum number of jobs executed in a single batch process"
     )
-    max_wait: Optional[float] = Field(
+    max_wait: float | None = Field(
         60,
         description="Maximum time to wait before stopping if no new jobs are available to run (seconds)",
     )
-    max_time: Optional[float] = Field(
+    max_time: float | None = Field(
         None,
         description="Maximum time after which a job will not start more jobs (seconds). To help avoid hitting the walltime",
     )
-    parallel_jobs: Optional[int] = Field(
+    parallel_jobs: int | None = Field(
         None, description="Number of jobs executed in parallel in the same process"
     )
-    sleep_time: Optional[float] = Field(
+    sleep_time: float | None = Field(
         None,
         description="Sleep time when no submitted job is available to run before checking again (seconds)",
     )
@@ -162,7 +164,7 @@ class WorkerBase(BaseModel):
         description="The discriminator field to determine the worker type"
     )
 
-    scheduler_type: Union[str, dict] = Field(
+    scheduler_type: str | dict = Field(
         description="Type of the scheduler. Either a string depending on the values supported by QToolKit "
         "or a serialized representation of a (subclass of) BaseSchedulerIO"
     )
@@ -170,20 +172,20 @@ class WorkerBase(BaseModel):
         description="Absolute path of the directory of the worker where subfolders for "
         "executing the calculation will be created"
     )
-    resources: Optional[dict] = Field(
+    resources: dict | None = Field(
         None,
         description="A dictionary defining the default resources requested to the "
         "scheduler. Used to fill in the QToolKit template",
     )
-    pre_run: Optional[str] = Field(
+    pre_run: str | None = Field(
         None,
         description="String with commands that will be executed before the execution of the Job",
     )
-    post_run: Optional[str] = Field(
+    post_run: str | None = Field(
         None,
         description="String with commands that will be executed after the execution of the Job",
     )
-    execution_cmd: Optional[str] = Field(
+    execution_cmd: str | None = Field(
         None,
         description="String with commands to execute the Job on the worker. By default will be "
         "set to `jf -fe execution run {}`. The `{}` part will be used to insert the path to "
@@ -195,16 +197,16 @@ class WorkerBase(BaseModel):
         description="Timeout for the execution of the commands in the worker "
         "(e.g. submitting a job)",
     )
-    max_jobs: Optional[int] = Field(
+    max_jobs: int | None = Field(
         None,
         description="The maximum number of jobs that can be submitted to the queue.",
         ge=0,
     )
-    batch: Optional[BatchConfig] = Field(
+    batch: BatchConfig | None = Field(
         None,
         description="Options for batch execution. If define the worker will be considered a batch worker",
     )
-    scheduler_username: Optional[str] = Field(
+    scheduler_username: str | None = Field(
         None,
         description="If defined, the list of jobs running on the worker will be fetched based on the"
         "username instead that from the list of job ids. May be necessary for some "
@@ -215,7 +217,7 @@ class WorkerBase(BaseModel):
         description="Sanitize the output of commands in case of failures due to spurious text produced"
         "by the worker shell.",
     )
-    delay_download: Optional[int] = Field(
+    delay_download: int | None = Field(
         default=None,
         description="Amount of seconds to wait to start the download after the Runner marked a Job "
         "as RUN_FINISHED. To account for delays in the writing of the file on the worker file system"
@@ -225,7 +227,7 @@ class WorkerBase(BaseModel):
 
     @field_validator("scheduler_type")
     @classmethod
-    def check_scheduler_type(cls, scheduler_type: Union[str, dict]) -> Union[str, dict]:
+    def check_scheduler_type(cls, scheduler_type: str | dict) -> str | dict:
         """Validator to set the default of scheduler_type."""
         if isinstance(scheduler_type, str) and scheduler_type not in scheduler_mapping:
             raise ValueError(f"Unknown scheduler type {scheduler_type}")
@@ -249,7 +251,7 @@ class WorkerBase(BaseModel):
 
     @field_validator("execution_cmd")
     @classmethod
-    def check_execution_cmd(cls, v) -> Optional[str]:
+    def check_execution_cmd(cls, v) -> str | None:
         if v is not None and "{}" not in v:
             raise ValueError(
                 "`execution_cmd` must contain a '{}' part to allow setting "
@@ -342,21 +344,21 @@ class ConnectionData(BaseModel):
     """
 
     host: str = Field(description="The host to which to connect")
-    user: Optional[str] = Field(None, description="Login username")
-    port: Optional[int] = Field(None, description="Port number")
-    password: Optional[str] = Field(None, description="Login password")
-    key_filename: Optional[Union[str, list[str]]] = Field(
+    user: str | None = Field(None, description="Login username")
+    port: int | None = Field(None, description="Port number")
+    password: str | None = Field(None, description="Login password")
+    key_filename: str | list[str] | None = Field(
         None,
         description="The filename, or list of filenames, of optional private key(s) "
         "and/or certs to try for authentication",
     )
-    passphrase: Optional[str] = Field(
+    passphrase: str | None = Field(
         None, description="Passphrase used for decrypting private keys"
     )
-    gateway: Optional[Union[str, "ConnectionData"]] = Field(
+    gateway: str | ConnectionData | None = Field(
         None, description="A shell command string to use as a proxy or gateway"
     )
-    connect_kwargs: Optional[dict] = Field(
+    connect_kwargs: dict | None = Field(
         None,
         description="Other keyword arguments passed to paramiko.client.SSHClient.connect",
     )
@@ -392,39 +394,39 @@ class RemoteWorker(WorkerBase):
         "remote", description="The discriminator field to determine the worker type"
     )
     host: str = Field(description="The host to which to connect")
-    user: Optional[str] = Field(None, description="Login username")
-    port: Optional[int] = Field(None, description="Port number")
-    password: Optional[str] = Field(None, description="Login password")
-    key_filename: Optional[Union[str, list[str]]] = Field(
+    user: str | None = Field(None, description="Login username")
+    port: int | None = Field(None, description="Port number")
+    password: str | None = Field(None, description="Login password")
+    key_filename: str | list[str] | None = Field(
         None,
         description="The filename, or list of filenames, of optional private key(s) "
         "and/or certs to try for authentication",
     )
-    passphrase: Optional[str] = Field(
+    passphrase: str | None = Field(
         None, description="Passphrase used for decrypting private keys"
     )
-    gateway: Optional[Union[str, ConnectionData]] = Field(
+    gateway: str | ConnectionData | None = Field(
         None, description="A shell command string to use as a proxy or gateway"
     )
-    forward_agent: Optional[bool] = Field(
+    forward_agent: bool | None = Field(
         None, description="Whether to enable SSH agent forwarding"
     )
-    connect_timeout: Optional[int] = Field(
+    connect_timeout: int | None = Field(
         None, description="Connection timeout, in seconds"
     )
-    connect_kwargs: Optional[dict] = Field(
+    connect_kwargs: dict | None = Field(
         None,
         description="Other keyword arguments passed to paramiko.client.SSHClient.connect",
     )
-    inline_ssh_env: Optional[bool] = Field(
+    inline_ssh_env: bool | None = Field(
         None,
         description="Whether to send environment variables 'inline' as prefixes in "
         "front of command strings",
     )
-    keepalive: Optional[int] = Field(
+    keepalive: int | None = Field(
         60, description="Keepalive value in seconds passed to paramiko's transport"
     )
-    shell_cmd: Optional[str] = Field(
+    shell_cmd: str | None = Field(
         "bash",
         description="The shell command used to execute the command remotely. If None "
         "the command is executed directly",
@@ -487,22 +489,20 @@ class RemoteWorker(WorkerBase):
         )
 
 
-WorkerConfig = Annotated[Union[LocalWorker, RemoteWorker], Field(discriminator="type")]
+WorkerConfig = Annotated[LocalWorker | RemoteWorker, Field(discriminator="type")]
 
 
 class ExecutionConfig(BaseModel):
     """Configuration to be set before and after the execution of a Job."""
 
-    modules: Optional[list[str]] = Field(
-        None, description="list of modules to be loaded"
-    )
-    export: Optional[dict[str, Any]] = Field(
+    modules: list[str] | None = Field(None, description="list of modules to be loaded")
+    export: dict[str, Any] | None = Field(
         None, description="dictionary with variable to be exported"
     )
-    pre_run: Optional[str] = Field(
+    pre_run: str | None = Field(
         None, description="Other commands to be executed before the execution of a job"
     )
-    post_run: Optional[str] = Field(
+    post_run: str | None = Field(
         None, description="Commands to be executed after the execution of a job"
     )
     model_config = ConfigDict(extra="forbid")
@@ -533,7 +533,7 @@ class QueueConfig(BaseModel):
         description="The name of the collection containing batches information. "
         "Taken from the same database as the one defined in the store",
     )
-    db_id_prefix: Optional[str] = Field(
+    db_id_prefix: str | None = Field(
         None,
         description="a string defining the prefix added to the integer ID associated "
         "to each Job in the database",
@@ -564,23 +564,23 @@ class Project(BaseModel):
     """The configurations of a Project."""
 
     name: str = Field(description="The name of the project")
-    base_dir: Optional[str] = Field(
+    base_dir: str | None = Field(
         None,
         description="The base directory containing the project related files. Default "
         "is a folder with the project name inside the projects folder",
         validate_default=True,
     )
-    tmp_dir: Optional[str] = Field(
+    tmp_dir: str | None = Field(
         None,
         description="Folder where remote files are copied. Default a 'tmp' folder in base_dir",
         validate_default=True,
     )
-    log_dir: Optional[str] = Field(
+    log_dir: str | None = Field(
         None,
         description="Folder containing all the logs. Default a 'log' folder in base_dir",
         validate_default=True,
     )
-    daemon_dir: Optional[str] = Field(
+    daemon_dir: str | None = Field(
         None,
         description="Folder containing daemon related files. Default to a 'daemon' "
         "folder in base_dir",
@@ -611,22 +611,22 @@ class Project(BaseModel):
         validate_default=True,
         validation_alias=AliasChoices("jobstore", "JOB_STORE"),
     )
-    remote_jobstore: Optional[dict] = Field(
+    remote_jobstore: dict | None = Field(
         None,
         description="The JobStore used for the data transfer between the Runner"
         "and the workers. Can be a string with the standard values",
     )
-    metadata: Optional[dict] = Field(
+    metadata: dict | None = Field(
         None, description="A dictionary with metadata associated to the project"
     )
-    optional_jobstores: Optional[dict[str, dict]] = Field(
+    optional_jobstores: dict[str, dict] | None = Field(
         default_factory=dict,
         description="A dictionary of optional JobStores that can be use to store "
         "outputs instead of the default jobstore. The key is the name used to "
         "refer to the JobStore.",
     )
 
-    def get_jobstore(self, name: Optional[str] = None) -> Optional[JobStore]:
+    def get_jobstore(self, name: str | None = None) -> JobStore | None:
         """
         Generate an instance of the JobStore based on the configuration.
 

--- a/src/jobflow_remote/config/jobconfig.py
+++ b/src/jobflow_remote/config/jobconfig.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from jobflow_remote.config import ConfigManager
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from jobflow import Flow, Job, JobStore
     from qtoolkit.core.data_objects import QResources
 

--- a/src/jobflow_remote/config/settings.py
+++ b/src/jobflow_remote/config/settings.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Optional
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -19,7 +18,7 @@ class JobflowRemoteSettings(BaseSettings):
     projects_folder: str = Field(
         DEFAULT_PROJECTS_FOLDER, description="Location of the projects files."
     )
-    project: Optional[str] = Field(None, description="The name of the project used.")
+    project: str | None = Field(None, description="The name of the project used.")
     cli_full_exc: bool = Field(
         default=False,
         description="If True prints the full stack trace of the exception when raised in the CLI.",
@@ -30,7 +29,7 @@ class JobflowRemoteSettings(BaseSettings):
     cli_log_level: LogLevel = Field(
         LogLevel.WARN, description="The level set for logging in the CLI"
     )
-    cli_job_list_columns: Optional[list[str]] = Field(
+    cli_job_list_columns: list[str] | None = Field(
         default=None,
         description="The list of columns to show in the `jf job list` command. For available "
         "options check the corresponding help: `jf job list -h`.",

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -12,7 +12,7 @@ import time
 from enum import Enum
 from pathlib import Path
 from string import Template
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 from xmlrpc.client import Fault
 
 import psutil
@@ -29,7 +29,7 @@ from jobflow_remote.jobs.jobcontroller import JobController
 from jobflow_remote.utils.db import MongoLock, RunnerLockedError
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
 logger = logging.getLogger(__name__)
 

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from functools import cached_property
-from typing import Any, Optional, Union
+from typing import Any
 
 from jobflow import Flow, Job
 from monty.json import jsanitize
@@ -24,11 +24,11 @@ BATCH_INFO_FILENAME = "batch_info.json"
 
 def get_initial_job_doc_dict(
     job: Job,
-    parents: Optional[list[str]],
+    parents: list[str] | None,
     db_id: str,
     worker: str,
-    exec_config: Optional[ExecutionConfig],
-    resources: Optional[Union[dict, QResources]],
+    exec_config: ExecutionConfig | None,
+    resources: dict | QResources | None,
     priority: int,
 ) -> dict:
     """
@@ -85,7 +85,7 @@ def get_initial_job_doc_dict(
 
 
 def get_initial_flow_doc_dict(
-    flow: Flow, job_dicts: list[dict], jobstore: Optional[str] = None
+    flow: Flow, job_dicts: list[dict], jobstore: str | None = None
 ) -> dict:
     """
     Generate a serialized FlowDoc for initial insertion in the DB.
@@ -155,13 +155,13 @@ class RemoteInfo(BaseModel):
     """Model with data describing the remote state of a Job."""
 
     step_attempts: int = 0
-    queue_state: Optional[QState] = None
-    process_id: Optional[str] = None
-    retry_time_limit: Optional[datetime] = None
-    error: Optional[str] = None
+    queue_state: QState | None = None
+    process_id: str | None = None
+    retry_time_limit: datetime | None = None
+    error: str | None = None
     prerun_cleanup: bool = False
-    queue_out: Optional[str] = None
-    queue_err: Optional[str] = None
+    queue_out: str | None = None
+    queue_err: str | None = None
 
 
 def _validate_job_state(value: Any) -> Any:
@@ -173,6 +173,7 @@ def _validate_job_state(value: Any) -> Any:
     try:
         JobState(value)
     except DeprecatedStateError:
+        print("XXXX")
         raise
     except Exception:
         pass
@@ -194,25 +195,25 @@ class JobInfo(BaseModel):
     created_on: datetime
     updated_on: datetime
     remote: RemoteInfo = RemoteInfo()
-    parents: Optional[list[str]] = None
-    previous_state: Optional[JobState] = None
-    error: Optional[str] = None
-    lock_id: Optional[str] = None
-    lock_time: Optional[datetime] = None
-    run_dir: Optional[str] = None
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
+    parents: list[str] | None = None
+    previous_state: JobState | None = None
+    error: str | None = None
+    lock_id: str | None = None
+    lock_time: datetime | None = None
+    run_dir: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
     priority: int = 0
-    metadata: Optional[dict] = None
-    stored_data: Optional[dict] = None
-    hosts: Optional[list[str]] = None
+    metadata: dict | None = None
+    stored_data: dict | None = None
+    hosts: list[str] | None = None
 
     @property
     def is_locked(self) -> bool:
         return self.lock_id is not None
 
     @property
-    def run_time(self) -> Optional[float]:
+    def run_time(self) -> float | None:
         """
         Calculate the run time based on start and end time.
 
@@ -227,7 +228,7 @@ class JobInfo(BaseModel):
         return None
 
     @property
-    def estimated_run_time(self) -> Optional[float]:
+    def estimated_run_time(self) -> float | None:
         """
         Estimate the current run time based on the start time and the current time.
 
@@ -237,7 +238,9 @@ class JobInfo(BaseModel):
             The estimated run time in seconds.
         """
         if self.start_time:
-            return (datetime.utcnow() - self.start_time).total_seconds()
+            # needs to be timezone aware to compute the difference
+            start_time = self.start_time.replace(tzinfo=timezone.utc)
+            return (datetime.now(timezone.utc) - start_time).total_seconds()
 
         return None
 
@@ -311,23 +314,21 @@ class JobDoc(BaseModel):
     # among the parents, all the index will still be parents.
     # Note that for just the uuid this condition is not true: JobDocs with
     # the same uuid but different indexes may have different parents
-    parents: Optional[list[str]] = None
-    previous_state: Optional[JobState] = None
-    error: Optional[str] = None  # TODO is there a better way to serialize it?
-    lock_id: Optional[str] = None
-    lock_time: Optional[datetime] = None
-    run_dir: Optional[str] = None
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
-    created_on: datetime = Field(default_factory=datetime.utcnow)
-    updated_on: datetime = Field(default_factory=datetime.utcnow)
+    parents: list[str] | None = None
+    previous_state: JobState | None = None
+    error: str | None = None  # TODO is there a better way to serialize it?
+    lock_id: str | None = None
+    lock_time: datetime | None = None
+    run_dir: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    created_on: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_on: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     priority: int = 0
-    # store: Optional[JobStore] = None
-    exec_config: Optional[Union[ExecutionConfig, str]] = None
-    resources: Optional[Union[QResources, dict]] = None
+    exec_config: ExecutionConfig | str | None = None
+    resources: QResources | dict | None = None
 
-    stored_data: Optional[dict] = None
-    # history: Optional[list[str]] = None
+    stored_data: dict | None = None
 
     def as_db_dict(self) -> dict:
         """
@@ -373,10 +374,10 @@ class FlowDoc(BaseModel):
     jobs: list[str]
     state: FlowState
     name: str
-    lock_id: Optional[str] = None
-    lock_time: Optional[datetime] = None
-    created_on: datetime = Field(default_factory=datetime.utcnow)
-    updated_on: datetime = Field(default_factory=datetime.utcnow)
+    lock_id: str | None = None
+    lock_time: datetime | None = None
+    created_on: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_on: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: dict = Field(default_factory=dict)
     # parents need to include both the uuid and the index.
     # When dynamically replacing a Job with a Flow some new Jobs will
@@ -387,7 +388,7 @@ class FlowDoc(BaseModel):
     parents: dict[str, dict[str, list[str]]] = Field(default_factory=dict)
     # ids correspond to db_id, uuid, index for each JobDoc
     ids: list[tuple[str, str, int]] = Field(default_factory=list)
-    jobstore: Optional[str] = None
+    jobstore: str | None = None
 
     def as_db_dict(self) -> dict:
         """
@@ -455,11 +456,11 @@ class BatchDoc(BaseModel):
     batch_state: BatchState
     worker: str
     jobs: dict = Field(default_factory=dict)
-    created_on: datetime = Field(default_factory=datetime.utcnow)
-    updated_on: datetime = Field(default_factory=datetime.utcnow)
-    start_time: Optional[datetime] = None
-    end_time: Optional[datetime] = None
-    last_ping_time: Optional[datetime] = None
+    created_on: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_on: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+    last_ping_time: datetime | None = None
 
     def as_db_dict(self) -> dict:
         """
@@ -521,7 +522,7 @@ class FlowInfo(BaseModel):
     parents: list[list[str]]
     hosts: list[list[str]]
     flow_metadata: dict
-    jobs_info: Optional[list[JobInfo]] = None
+    jobs_info: list[JobInfo] | None = None
 
     @classmethod
     def from_query_dict(cls, d) -> "FlowInfo":
@@ -554,7 +555,7 @@ class FlowInfo(BaseModel):
                 jobs_info.append(JobInfo.from_query_output(job_doc))
         else:
             db_ids, job_ids, job_indexes = list(  # type:ignore[assignment]
-                zip(*d["ids"])
+                zip(*d["ids"], strict=False)
             )
             # parents could be determined in this case as well from the Flow document.
             # However, to match the correct order it would require lopping over them.
@@ -584,7 +585,9 @@ class FlowInfo(BaseModel):
     def ids_mapping(self) -> dict[str, dict[int, str]]:
         d: dict = defaultdict(dict)
 
-        for db_id, job_id, index in zip(self.db_ids, self.job_ids, self.job_indexes):
+        for db_id, job_id, index in zip(
+            self.db_ids, self.job_ids, self.job_indexes, strict=False
+        ):
             d[job_id][int(index)] = db_id
 
         return dict(d)
@@ -637,7 +640,7 @@ def get_reset_job_base_dict() -> dict:
         "remote.queue_out": None,
         "remote.queue_err": None,
         "error": None,
-        "updated_on": datetime.utcnow(),
+        "updated_on": datetime.now(timezone.utc),
         "start_time": None,
         "end_time": None,
         "stored_data": None,

--- a/src/jobflow_remote/jobs/data.py
+++ b/src/jobflow_remote/jobs/data.py
@@ -555,7 +555,7 @@ class FlowInfo(BaseModel):
                 jobs_info.append(JobInfo.from_query_output(job_doc))
         else:
             db_ids, job_ids, job_indexes = list(  # type:ignore[assignment]
-                zip(*d["ids"], strict=False)
+                zip(*d["ids"], strict=True)
             )
             # parents could be determined in this case as well from the Flow document.
             # However, to match the correct order it would require lopping over them.
@@ -586,7 +586,7 @@ class FlowInfo(BaseModel):
         d: dict = defaultdict(dict)
 
         for db_id, job_id, index in zip(
-            self.db_ids, self.job_ids, self.job_indexes, strict=False
+            self.db_ids, self.job_ids, self.job_indexes, strict=True
         ):
             d[job_id][int(index)] = db_id
 

--- a/src/jobflow_remote/jobs/graph.py
+++ b/src/jobflow_remote/jobs/graph.py
@@ -26,7 +26,7 @@ def get_graph(flow: FlowInfo, label: str = "name") -> DiGraph:
         graph.add_node(db_id, **job_prop)
 
     # Add edges based on parents
-    for child_node, parents in zip(flow.db_ids, flow.parents, strict=False):
+    for child_node, parents in zip(flow.db_ids, flow.parents, strict=True):
         for parent_uuid in parents:
             for parent_node in ids_mapping[parent_uuid].values():
                 graph.add_edge(parent_node, child_node)
@@ -47,7 +47,7 @@ def get_graph_elements(flow: FlowInfo):
     # edges based on parents
     edges = [
         (parent_node, child_node)
-        for child_node, parents in zip(flow.db_ids, flow.parents, strict=False)
+        for child_node, parents in zip(flow.db_ids, flow.parents, strict=True)
         for parent_uuid in parents
         for parent_node in ids_mapping[parent_uuid].values()
     ]

--- a/src/jobflow_remote/jobs/graph.py
+++ b/src/jobflow_remote/jobs/graph.py
@@ -26,7 +26,7 @@ def get_graph(flow: FlowInfo, label: str = "name") -> DiGraph:
         graph.add_node(db_id, **job_prop)
 
     # Add edges based on parents
-    for child_node, parents in zip(flow.db_ids, flow.parents):
+    for child_node, parents in zip(flow.db_ids, flow.parents, strict=False):
         for parent_uuid in parents:
             for parent_node in ids_mapping[parent_uuid].values():
                 graph.add_edge(parent_node, child_node)
@@ -47,7 +47,7 @@ def get_graph_elements(flow: FlowInfo):
     # edges based on parents
     edges = [
         (parent_node, child_node)
-        for child_node, parents in zip(flow.db_ids, flow.parents)
+        for child_node, parents in zip(flow.db_ids, flow.parents, strict=False)
         for parent_uuid in parents
         for parent_node in ids_mapping[parent_uuid].values()
     ]

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -13,7 +13,7 @@ from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import jobflow
 import pymongo
@@ -83,15 +83,14 @@ from jobflow_remote.utils.db import (
 from jobflow_remote.utils.remote import SharedHosts, safe_remove_job_files
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Sequence
+    from collections.abc import Callable, Generator, Sequence
     from enum import Enum
-    from typing import Union
 
     from maggma.stores import MongoStore
     from monty.json import MSONable
 
-    obj_type = Union[str, Enum, type[MSONable], list[Union[Enum, str, type[MSONable]]]]
-    load_type = Union[bool, dict[str, Union[bool, obj_type]]]
+    obj_type = str | Enum | type[MSONable] | list[Enum | str | type[MSONable]]
+    load_type = bool | dict[str, bool | obj_type]
 
 
 logger = logging.getLogger(__name__)
@@ -288,7 +287,7 @@ class JobController:
             A dictionary with the query to be applied to a collection
             containing JobDocs.
         """
-        if job_ids and not any(isinstance(ji, (list, tuple)) for ji in job_ids):
+        if job_ids and not any(isinstance(ji, list | tuple) for ji in job_ids):
             # without these cast mypy is confused about the type
             job_ids = cast(list[tuple[str, int]], [job_ids])
         db_ids = [db_ids] if isinstance(db_ids, str) else db_ids or []
@@ -403,11 +402,11 @@ class JobController:
             A dictionary with the query to be applied to a collection
             containing FlowDocs.
         """
-        if job_ids is not None and not isinstance(job_ids, (list, tuple)):
+        if job_ids is not None and not isinstance(job_ids, list | tuple):
             job_ids = [job_ids]
-        if db_ids is not None and not isinstance(db_ids, (list, tuple)):
+        if db_ids is not None and not isinstance(db_ids, list | tuple):
             db_ids = [db_ids]
-        if flow_ids is not None and not isinstance(flow_ids, (list, tuple)):
+        if flow_ids is not None and not isinstance(flow_ids, list | tuple):
             flow_ids = [flow_ids]
         if isinstance(states, FlowState):
             states = [states]
@@ -859,7 +858,7 @@ class JobController:
         for db_id in queried_dbs_ids:
             try:
                 job_updated_ids = method(db_id=db_id, **method_kwargs)
-                if not isinstance(job_updated_ids, (list, tuple)):
+                if not isinstance(job_updated_ids, list | tuple):
                     job_updated_ids = (
                         [] if job_updated_ids is None else [job_updated_ids]
                     )
@@ -3667,7 +3666,7 @@ class JobController:
         first_id = doc_next_id["next_id"]
         db_ids = []
         for (job, parents), db_id_int in zip(
-            jobs_list, range(first_id, first_id + n_jobs)
+            jobs_list, range(first_id, first_id + n_jobs), strict=False
         ):
             prefix = self.project.queue.db_id_prefix or ""
             db_id = f"{prefix}{db_id_int}"
@@ -3808,7 +3807,7 @@ class JobController:
         flow_updates["$set"] = {}
         ids_to_push = []
         for (job, parents), db_id_int in zip(
-            jobs_list, range(first_id, first_id + n_new_jobs)
+            jobs_list, range(first_id, first_id + n_new_jobs), strict=False
         ):
             prefix = self.project.queue.db_id_prefix or ""
             db_id = f"{prefix}{db_id_int}"
@@ -3838,8 +3837,8 @@ class JobController:
                 {"$push": {"parents": {"$each": leaf_uuids}}},
             )
 
-        # flow_dict["updated_on"] = datetime.utcnow()
-        flow_updates["$set"]["updated_on"] = datetime.utcnow()
+        # flow_dict["updated_on"] = datetime.now(timezone.utc)
+        flow_updates["$set"]["updated_on"] = datetime.now(timezone.utc)
 
         # TODO, this could be replaced by the actual change, instead of the replace
         self.flows.update_one({"uuid": flow_dict["uuid"]}, flow_updates)
@@ -3890,7 +3889,7 @@ class JobController:
             {
                 "$set": {
                     "state": JobState.CHECKED_OUT.value,
-                    "updated_on": datetime.utcnow(),
+                    "updated_on": datetime.now(timezone.utc),
                 }
             },
             projection=["uuid", "index"],
@@ -3917,7 +3916,7 @@ class JobController:
         updated_cond = {
             "$cond": {
                 "if": {"$eq": ["$state", "READY"]},
-                "then": datetime.utcnow(),
+                "then": datetime.now(timezone.utc),
                 "else": "$updated_on",
             }
         }
@@ -4189,7 +4188,7 @@ class JobController:
                 {
                     "$set": {
                         "state": JobState.READY.value,
-                        "updated_on": datetime.utcnow(),
+                        "updated_on": datetime.now(timezone.utc),
                     }
                 },
             )
@@ -4362,7 +4361,7 @@ class JobController:
         """
         ping_result = self.auxiliary.find_one_and_update(
             {"running_runner.last_pinged": {"$exists": True}},
-            {"$set": {"running_runner.last_pinged": datetime.utcnow()}},
+            {"$set": {"running_runner.last_pinged": datetime.now(timezone.utc)}},
             upsert=False,
         )
 
@@ -4425,7 +4424,7 @@ class JobController:
             "$cond": {
                 "if": {"$eq": ["$state", flow_state.value]},
                 "then": "$updated_on",
-                "else": datetime.utcnow(),
+                "else": datetime.now(timezone.utc),
             }
         }
         self.flows.find_one_and_update(
@@ -4510,7 +4509,9 @@ class JobController:
             An instance of MongoLock.
         """
         db_filter = dict(query)
-        db_filter["remote.retry_time_limit"] = {"$not": {"$gt": datetime.utcnow()}}
+        db_filter["remote.retry_time_limit"] = {
+            "$not": {"$gt": datetime.now(timezone.utc)}
+        }
 
         if "sort" not in kwargs:
             kwargs["sort"] = [
@@ -4536,12 +4537,7 @@ class JobController:
                 error = f"Remote error: {e.msg}"
                 cause = e.__cause__
                 if cause:
-                    # this is required for support of python 3.9. In 3.10 the API
-                    # changed and format_exception(e) could be used instead.
-                    # Do that if/when support for 3.9 is dropped.
-                    trace = traceback.format_exception(
-                        type(cause), cause, cause.__traceback__
-                    )
+                    trace = traceback.format_exception(cause)
                     error += "\ncaused by:\n" + "".join(trace)
                 no_retry = e.no_retry
             except Exception:
@@ -4554,7 +4550,7 @@ class JobController:
                 if not error:
                     next_step_time_limit = None
                     if next_step_delay:
-                        next_step_time_limit = datetime.utcnow() + timedelta(
+                        next_step_time_limit = datetime.now(timezone.utc) + timedelta(
                             seconds=next_step_delay
                         )
                     # When succeeded don't set remote.queue_out/remote.queue_err to
@@ -4595,7 +4591,9 @@ class JobController:
                         step_attempts += 1
                         ind = min(step_attempts, len(delta_retry)) - 1
                         delta = delta_retry[ind]
-                        retry_time_limit = datetime.utcnow() + timedelta(seconds=delta)
+                        retry_time_limit = datetime.now(timezone.utc) + timedelta(
+                            seconds=delta
+                        )
                         update_on_release = {
                             "$set": {
                                 "remote.step_attempts": step_attempts,
@@ -4606,7 +4604,7 @@ class JobController:
                             }
                         }
                 if "$set" in update_on_release:
-                    update_on_release["$set"]["updated_on"] = datetime.utcnow()
+                    update_on_release["$set"]["updated_on"] = datetime.now(timezone.utc)
 
                 lock.update_on_release = update_on_release
 
@@ -4779,7 +4777,7 @@ class JobController:
             The uuid of the Flow to update.
         """
         self.flows.find_one_and_update(
-            {"nodes": uuid}, {"$set": {"updated_on": datetime.utcnow()}}
+            {"nodes": uuid}, {"$set": {"updated_on": datetime.now(timezone.utc)}}
         )
 
     def _cancel_queue_process(self, job_doc: dict) -> None:
@@ -5082,7 +5080,7 @@ class JobController:
                     "parents": flow_doc.parents,
                 }
             }
-            flow_update["$set"]["updated_on"] = datetime.utcnow()
+            flow_update["$set"]["updated_on"] = datetime.now(timezone.utc)
 
             # Set flow update to be applied on lock release
             flow_lock.update_on_release = flow_update
@@ -5303,6 +5301,7 @@ class JobController:
             for std_name, collection in zip(
                 standard_collection_names,
                 [self.jobs, self.flows, self.auxiliary, self.batches],
+                strict=False,
             ):
                 doc_count[std_name] = pymongo_dump(
                     collection=collection, output_path=dir_path, compress=compress
@@ -5316,6 +5315,7 @@ class JobController:
                     self.auxiliary_collection,
                     self.batches_collection,
                 ],
+                strict=False,
             ):
                 doc_count[std_name] = mongodump_from_store(
                     store=self.queue_store,
@@ -5334,6 +5334,7 @@ class JobController:
                 self.auxiliary_collection,
                 self.batches_collection,
             ],
+            strict=False,
         ):
             if collection_name != std_name:
                 full_dir_path = dir_path / self.queue_store.database
@@ -5398,6 +5399,7 @@ class JobController:
                 self.batches_collection,
             ],
             [self.jobs, self.flows, self.batches],
+            strict=False,
         ):
             count = collection.count_documents({})
             if count > 0:
@@ -5421,6 +5423,7 @@ class JobController:
                 self.auxiliary_collection,
             ],
             [self.jobs, self.flows, self.batches, self.auxiliary],
+            strict=False,
         ):
             file_name = f"{name}.bson"
             # compress may be set automatically in the restore functions, but if

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -3666,7 +3666,7 @@ class JobController:
         first_id = doc_next_id["next_id"]
         db_ids = []
         for (job, parents), db_id_int in zip(
-            jobs_list, range(first_id, first_id + n_jobs), strict=False
+            jobs_list, range(first_id, first_id + n_jobs), strict=True
         ):
             prefix = self.project.queue.db_id_prefix or ""
             db_id = f"{prefix}{db_id_int}"
@@ -3807,7 +3807,7 @@ class JobController:
         flow_updates["$set"] = {}
         ids_to_push = []
         for (job, parents), db_id_int in zip(
-            jobs_list, range(first_id, first_id + n_new_jobs), strict=False
+            jobs_list, range(first_id, first_id + n_new_jobs), strict=True
         ):
             prefix = self.project.queue.db_id_prefix or ""
             db_id = f"{prefix}{db_id_int}"
@@ -5301,7 +5301,7 @@ class JobController:
             for std_name, collection in zip(
                 standard_collection_names,
                 [self.jobs, self.flows, self.auxiliary, self.batches],
-                strict=False,
+                strict=True,
             ):
                 doc_count[std_name] = pymongo_dump(
                     collection=collection, output_path=dir_path, compress=compress
@@ -5315,7 +5315,7 @@ class JobController:
                     self.auxiliary_collection,
                     self.batches_collection,
                 ],
-                strict=False,
+                strict=True,
             ):
                 doc_count[std_name] = mongodump_from_store(
                     store=self.queue_store,
@@ -5334,7 +5334,7 @@ class JobController:
                 self.auxiliary_collection,
                 self.batches_collection,
             ],
-            strict=False,
+            strict=True,
         ):
             if collection_name != std_name:
                 full_dir_path = dir_path / self.queue_store.database
@@ -5423,7 +5423,7 @@ class JobController:
                 self.auxiliary_collection,
             ],
             [self.jobs, self.flows, self.batches, self.auxiliary],
-            strict=False,
+            strict=True,
         ):
             file_name = f"{name}.bson"
             # compress may be set automatically in the restore functions, but if

--- a/src/jobflow_remote/jobs/report.py
+++ b/src/jobflow_remote/jobs/report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
+from datetime import timezone as timezone_mod
 from typing import TYPE_CHECKING
 
 from jobflow_remote.jobs.data import JobInfo, projection_job_info
@@ -103,7 +104,7 @@ class JobsReport:
         JobsReport
             A report of the job states.
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone_mod.utc)
 
         state_counts = job_controller.count_jobs_states(list(JobState))
 

--- a/src/jobflow_remote/jobs/run.py
+++ b/src/jobflow_remote/jobs/run.py
@@ -8,6 +8,7 @@ import subprocess
 import threading
 import time
 import traceback
+from datetime import timezone
 from multiprocessing import Manager, Process
 from typing import TYPE_CHECKING
 
@@ -54,7 +55,7 @@ def run_remote_job(run_dir: str | Path = ".") -> None:
     """Run the job."""
     initialize_remote_run_log()
 
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(timezone.utc)
     with cd(run_dir):
         error = None
         try:
@@ -107,7 +108,7 @@ def run_remote_job(run_dir: str | Path = ".") -> None:
                 "response": response,
                 "error": error,
                 "start_time": start_time,
-                "end_time": datetime.datetime.utcnow(),
+                "end_time": datetime.datetime.now(timezone.utc),
             }
             dumpfn(output, OUT_FILENAME)
         except Exception:
@@ -118,7 +119,7 @@ def run_remote_job(run_dir: str | Path = ".") -> None:
                 "response": None,
                 "error": error,
                 "start_time": start_time,
-                "end_time": datetime.datetime.utcnow(),
+                "end_time": datetime.datetime.now(timezone.utc),
             }
             dumpfn(output, OUT_FILENAME)
         finally:
@@ -128,7 +129,10 @@ def run_remote_job(run_dir: str | Path = ".") -> None:
 def ping(start_time, interval=600, filename=BATCH_INFO_FILENAME):
     while True:
         dumpfn(
-            {"start_time": start_time, "last_ping_time": datetime.datetime.utcnow()},
+            {
+                "start_time": start_time,
+                "last_ping_time": datetime.datetime.now(timezone.utc),
+            },
             fn=filename,
         )
         time.sleep(interval)
@@ -149,7 +153,7 @@ def run_batch_jobs(
     batch_info_fname: str | Path = BATCH_INFO_FILENAME,
 ) -> None:
     # Here we assume that we are in the batch work directory where a batch process is executed/submitted
-    start_time = datetime.datetime.utcnow()
+    start_time = datetime.datetime.now(timezone.utc)
     dumpfn({"start_time": start_time}, batch_info_fname)
 
     threading.Thread(
@@ -205,8 +209,8 @@ def run_batch_jobs(
     dumpfn(
         {
             "start_time": start_time,
-            "last_ping_time": datetime.datetime.utcnow(),
-            "end_time": datetime.datetime.utcnow(),
+            "last_ping_time": datetime.datetime.now(timezone.utc),
+            "end_time": datetime.datetime.now(timezone.utc),
         },
         batch_info_fname,
     )

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -11,7 +11,7 @@ import time
 import traceback
 import uuid
 from collections import OrderedDict, defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -987,7 +987,7 @@ class Runner:
         db_filter = {
             "state": {"$in": [JobState.SUBMITTED.value, JobState.RUNNING.value]},
             "lock_id": None,
-            "remote.retry_time_limit": {"$not": {"$gt": datetime.utcnow()}},
+            "remote.retry_time_limit": {"$not": {"$gt": datetime.now(timezone.utc)}},
         }
         if filter:
             db_filter.update(filter)
@@ -1041,7 +1041,7 @@ class Runner:
                     and doc["state"] == JobState.SUBMITTED.value
                 ):
                     next_state = JobState.RUNNING
-                    start_time = datetime.utcnow()
+                    start_time = datetime.now(timezone.utc)
                     logger.debug(
                         f"remote job with id {remote_doc['process_id']} is running"
                     )
@@ -1231,7 +1231,7 @@ class Runner:
                     set_output = {
                         "$set": {
                             "state": JobState.BATCH_RUNNING.value,
-                            "start_time": datetime.utcnow(),
+                            "start_time": datetime.now(timezone.utc),
                             "remote.process_id": self.batch_get_process_id(
                                 batch_processes, batch_uid, worker_name, worker
                             ),

--- a/src/jobflow_remote/jobs/upgrade.py
+++ b/src/jobflow_remote/jobs/upgrade.py
@@ -5,7 +5,7 @@ import functools
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from packaging.version import Version
 from packaging.version import parse as parse_version
@@ -13,6 +13,8 @@ from packaging.version import parse as parse_version
 import jobflow_remote
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from pymongo.client_session import ClientSession
 
     from jobflow_remote.jobs.jobcontroller import JobController
@@ -37,7 +39,7 @@ class UpgradeAction:
     required: bool = False
 
 
-@dataclass
+@dataclass(kw_only=True)
 class UpgradeCondition:
     """Generic upgrade condition"""
 
@@ -58,19 +60,15 @@ class UpgradeCondition:
         return result
 
 
-@dataclass
+@dataclass(kw_only=True)
 class NoDocumentsIn(UpgradeCondition):
     """Condition that checks that there is no document in a given collection matching the specified query."""
 
-    collection: str | None = None
+    collection: str | None
     query: dict | None = None
     description: str | None = None
 
     def __post_init__(self):
-        # Here done this way as it does not work with python 3.9. When we drop python 3.9, we could
-        # use kw_only=True in the dataclass decorator.
-        if self.collection is None:
-            raise RuntimeError("The 'collection' argument is mandatory")
         if self.description is None:
             q_str = f" matching {self.query}" if self.query else ""
             self.description = f"There should be no document in the '{self.collection}' collection{q_str}"

--- a/src/jobflow_remote/remote/data.py
+++ b/src/jobflow_remote/remote/data.py
@@ -413,7 +413,7 @@ class MinimalFileStore(Store):
                  a single field, or None if the Store's key
                  field is to be used
         """
-        if not isinstance(docs, (list, tuple)):
+        if not isinstance(docs, list | tuple):
             docs = [docs]
 
         self.data.extend(docs)

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -49,7 +49,7 @@ class LocalHost(BaseHost):
         exit_code : int
             Exit code of the command.
         """
-        if isinstance(command, (list, tuple)):
+        if isinstance(command, list | tuple):
             command = " ".join(command)
         command = self.sanitize_command(command)
         workdir = str(workdir) if workdir else Path.cwd()

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -8,7 +8,7 @@ import traceback
 import warnings
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import fabric
 from fabric import Config
@@ -17,6 +17,9 @@ from paramiko.auth_strategy import AuthSource
 from paramiko.ssh_exception import SSHException
 
 from jobflow_remote.remote.host.base import BaseHost
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -176,10 +179,11 @@ class RemoteHost(BaseHost):
         """
         self._check_connected()
 
-        if isinstance(command, (list, tuple)):
+        if isinstance(command, list | tuple):
             command = " ".join(command)
 
-        command = self.sanitize_command(command)
+        # cast for mypy
+        command = str(self.sanitize_command(command))
 
         # TODO: check if this works:
         if not workdir:
@@ -356,10 +360,9 @@ class RemoteHost(BaseHost):
         # if the code gets here one of the errors that could be due to drop of the
         # connection occurred. Try to close and reopen the connection and retry
         # one more time
-        # Call to traceback.format_exception compatible with python 3.9
         logger.warning(
             f"Error while trying to execute a command on host {self.host}:\n"
-            f"{''.join(traceback.format_exception(type(error), error, error.__traceback__))}"
+            f"{''.join(traceback.format_exception(error))}"
             "Probably due to the connection dropping. "
             "Will reopen the connection and retry."
         )

--- a/src/jobflow_remote/remote/queue.py
+++ b/src/jobflow_remote/remote/queue.py
@@ -109,7 +109,7 @@ class QueueManager:
         return ""
 
     def get_pre_run(self, pre_run: str | list[str] | None) -> str:
-        if isinstance(pre_run, (list, tuple)):
+        if isinstance(pre_run, list | tuple):
             return "\n".join(pre_run)
         return pre_run
 
@@ -135,7 +135,7 @@ class QueueManager:
         raise ValueError("commands should be a str or a list of str.")
 
     def get_post_run(self, post_run: str | list[str] | None) -> str:
-        if isinstance(post_run, (list, tuple)):
+        if isinstance(post_run, list | tuple):
             return "\n".join(post_run)
         return post_run
 

--- a/src/jobflow_remote/testing/__init__.py
+++ b/src/jobflow_remote/testing/__init__.py
@@ -1,8 +1,9 @@
 """A series of toy workflows that can be used for testing."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, NoReturn, Optional, Union
+from typing import NoReturn
 
 from jobflow import Job, JobConfig, Maker, OnMissing, Response, job
 from qtoolkit.io.shell import ShellIO
@@ -28,10 +29,10 @@ def write_file(n) -> None:
 
 @job
 def arithmetic(
-    a: Union[float, list[float]],
-    b: Union[float, list[float]],
-    op: Optional[Callable] = None,
-) -> Optional[float]:
+    a: float | list[float],
+    b: float | list[float],
+    op: Callable | None = None,
+) -> float | None:
     if op:
         return op(a, b)
 

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -58,7 +58,7 @@ def deep_merge_dict(
 
 
 def remove_none(obj):
-    if isinstance(obj, (list, tuple, set)):
+    if isinstance(obj, list | tuple | set):
         return type(obj)(remove_none(x) for x in obj if x is not None)
     if isinstance(obj, dict):
         return type(obj)(
@@ -70,7 +70,7 @@ def remove_none(obj):
 
 
 def check_dict_keywords(obj: Any, keywords: list[str]) -> bool:
-    if isinstance(obj, (list, tuple, set)):
+    if isinstance(obj, list | tuple | set):
         return any(check_dict_keywords(x, keywords) for x in obj)
     if isinstance(obj, dict):
         for k, v in obj.items():

--- a/src/jobflow_remote/utils/db.py
+++ b/src/jobflow_remote/utils/db.py
@@ -8,7 +8,7 @@ import subprocess
 import time
 import warnings
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING, Any
@@ -254,7 +254,7 @@ class MongoLock:
     def acquire(self) -> None:
         """Acquire the lock."""
         # Set the lock expiration time
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         db_filter = copy.deepcopy(dict(self.filter))
 
         projection = self.projection

--- a/src/jobflow_remote/webgui/webgui.py
+++ b/src/jobflow_remote/webgui/webgui.py
@@ -664,6 +664,7 @@ def trends(proj_name: str, what: str, interval: str = "days", ni: int = 7):
                 jfreport.trends.completed,
                 jfreport.trends.failed,
                 jfreport.trends.remote_error,
+                strict=False,
             )
         ],
         cls="trend-table",

--- a/src/jobflow_remote/webgui/webgui.py
+++ b/src/jobflow_remote/webgui/webgui.py
@@ -664,7 +664,7 @@ def trends(proj_name: str, what: str, interval: str = "days", ni: int = 7):
                 jfreport.trends.completed,
                 jfreport.trends.failed,
                 jfreport.trends.remote_error,
-                strict=False,
+                strict=True,
             )
         ],
         cls="trend-table",

--- a/tests/db/cli/test_admin.py
+++ b/tests/db/cli/test_admin.py
@@ -20,7 +20,7 @@ def test_reset(job_controller, one_job, run_check_cli) -> None:
     for _ in range(26):
         f = Flow(add(1, 2))
         submit_flow(f, worker="test_local_worker")
-        time.sleep(0.001)
+        time.sleep(0.01)
 
     run_check_cli(
         ["admin", "reset"],

--- a/tests/db/jobs/test_submit.py
+++ b/tests/db/jobs/test_submit.py
@@ -20,7 +20,7 @@ def test_submit_optional_jobstore(job_controller, runner) -> None:
 
     submit_flow(flow, worker="test_local_worker", jobstore="other_jobstore")
 
-    runner.run_all_jobs(max_seconds=10)
+    runner.run_all_jobs(max_seconds=20)
     assert job_controller.count_jobs(states=JobState.COMPLETED) == 2
 
     with pytest.raises(ValueError, match=".*has no outputs.*"):

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -154,7 +154,7 @@ def test_run_batch_multi_fail(
         if (
             len(
                 job_controller.get_jobs_info(
-                    job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
+                    job_ids=list(zip(job_ids, [1] * len(job_ids), strict=True)),
                     states=JobState.BATCH_RUNNING,
                 )
             )
@@ -179,7 +179,7 @@ def test_run_batch_multi_fail(
     assert (
         len(
             job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=True)),
                 states=JobState.BATCH_RUNNING,
             )
         )
@@ -223,7 +223,7 @@ def test_run_batch_multi_fail(
         if all(
             ji.state == JobState.REMOTE_ERROR
             for ji in job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False))
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=True))
             )
         ):
             break
@@ -251,7 +251,7 @@ def test_run_batch_multi_fail(
         if (
             len(
                 job_controller.get_jobs_info(
-                    job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
+                    job_ids=list(zip(job_ids, [1] * len(job_ids), strict=True)),
                     states=JobState.BATCH_RUNNING,
                 )
             )
@@ -275,7 +275,7 @@ def test_run_batch_multi_fail(
     assert (
         len(
             job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=True)),
                 states=JobState.BATCH_RUNNING,
             )
         )
@@ -284,7 +284,7 @@ def test_run_batch_multi_fail(
     assert (
         len(
             job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=True)),
                 states=JobState.BATCH_SUBMITTED,
             )
         )

--- a/tests/integration/test_advanced_options.py
+++ b/tests/integration/test_advanced_options.py
@@ -154,7 +154,7 @@ def test_run_batch_multi_fail(
         if (
             len(
                 job_controller.get_jobs_info(
-                    job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                    job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
                     states=JobState.BATCH_RUNNING,
                 )
             )
@@ -179,7 +179,7 @@ def test_run_batch_multi_fail(
     assert (
         len(
             job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
                 states=JobState.BATCH_RUNNING,
             )
         )
@@ -223,7 +223,7 @@ def test_run_batch_multi_fail(
         if all(
             ji.state == JobState.REMOTE_ERROR
             for ji in job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids)))
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False))
             )
         ):
             break
@@ -251,7 +251,7 @@ def test_run_batch_multi_fail(
         if (
             len(
                 job_controller.get_jobs_info(
-                    job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                    job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
                     states=JobState.BATCH_RUNNING,
                 )
             )
@@ -275,7 +275,7 @@ def test_run_batch_multi_fail(
     assert (
         len(
             job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
                 states=JobState.BATCH_RUNNING,
             )
         )
@@ -284,7 +284,7 @@ def test_run_batch_multi_fail(
     assert (
         len(
             job_controller.get_jobs_info(
-                job_ids=list(zip(job_ids, [1] * len(job_ids))),
+                job_ids=list(zip(job_ids, [1] * len(job_ids), strict=False)),
                 states=JobState.BATCH_SUBMITTED,
             )
         )


### PR DESCRIPTION
Remove support for python 3.9. 
Most changes by pyupgrade. switched from `utcnow` to `now(timezone.utc)` for datetime creation.