### PR TITLE
Add warn option

### DIFF
--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -76,6 +76,15 @@ def main(
             hidden=True,
         ),
     ] = False,
+    warn: Annotated[
+        bool,
+        typer.Option(
+            "--warn",
+            "-w",
+            help="Print warning messages regarding the parsing of the files in the projects folder.",
+            is_eager=True,
+        ),
+    ] = False,
     print_tree: tree_opt = False,  # If selected will print the tree of the CLI and exit
 ) -> None:
     """The controller CLI for jobflow-remote."""
@@ -97,7 +106,7 @@ def main(
 
     # initialize the ConfigManager only once, to avoid parsing the configuration
     # files multiple times when the command is executed.
-    initialize_config_manager()
+    initialize_config_manager(warn=warn)
     cm = get_config_manager()
     if project:
         SETTINGS.project = project

--- a/src/jobflow_remote/cli/jf.py
+++ b/src/jobflow_remote/cli/jf.py
@@ -76,11 +76,11 @@ def main(
             hidden=True,
         ),
     ] = False,
-    warn: Annotated[
+    warn_project: Annotated[
         bool,
         typer.Option(
-            "--warn",
-            "-w",
+            "--warn-project",
+            "-wp",
             help="Print warning messages regarding the parsing of the files in the projects folder.",
             is_eager=True,
         ),
@@ -106,7 +106,7 @@ def main(
 
     # initialize the ConfigManager only once, to avoid parsing the configuration
     # files multiple times when the command is executed.
-    initialize_config_manager(warn=warn)
+    initialize_config_manager(warn=warn_project)
     cm = get_config_manager()
     if project:
         SETTINGS.project = project

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -81,9 +81,7 @@ def list_projects(
     for pn in sorted(full_project_list):
         out_console.print(f" - {pn}", style="green" if pn == project_name else None)
 
-    not_parsed_projects = set(full_project_list).difference(cm.projects_data) | set(
-        erroneous_files
-    )
+    not_parsed_projects = set(full_project_list).difference(cm.projects_data)
     if not_parsed_projects:
         out_console.print(
             "The following project names exist in files in the project folder, "
@@ -91,9 +89,17 @@ def list_projects(
             f"{', '.join(not_parsed_projects)}.",
             style="yellow",
         )
+    if erroneous_files:
+        out_console.print(
+            "The following files exist in the project folder, "
+            "but could not properly parsed as projects: "
+            f"{', '.join(erroneous_files)}.",
+            style="yellow",
+        )
+    if (not_parsed_projects or erroneous_files) and not warn:
         from jobflow_remote import SETTINGS
 
-        if SETTINGS.cli_suggestions and not warn:
+        if SETTINGS.cli_suggestions:
             out_console.print(
                 "Run the command with -w option to see the parsing errors",
                 style="yellow",

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -70,7 +70,9 @@ def list_projects(
     except ConfigError:
         pass
 
-    full_project_list = cm.project_names_from_files()
+    full_project_list, erroneous_files = cm.project_names_from_files(
+        suppress_warnings=True
+    )
 
     if not full_project_list:
         exit_with_warning_msg(f"No project available in {cm.projects_folder}")
@@ -79,7 +81,9 @@ def list_projects(
     for pn in sorted(full_project_list):
         out_console.print(f" - {pn}", style="green" if pn == project_name else None)
 
-    not_parsed_projects = set(full_project_list).difference(cm.projects_data)
+    not_parsed_projects = set(full_project_list).difference(cm.projects_data) | set(
+        erroneous_files
+    )
     if not_parsed_projects:
         out_console.print(
             "The following project names exist in files in the project folder, "
@@ -89,7 +93,7 @@ def list_projects(
         )
         from jobflow_remote import SETTINGS
 
-        if SETTINGS.cli_suggestions:
+        if SETTINGS.cli_suggestions and not warn:
             out_console.print(
                 "Run the command with -w option to see the parsing errors",
                 style="yellow",

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -22,7 +22,7 @@ from rich.tree import Tree
 from typer.core import TyperCommand, TyperGroup
 
 from jobflow_remote import ConfigManager, JobController
-from jobflow_remote.config.base import ProjectUndefinedError
+from jobflow_remote.config.base import ProjectParsingError, ProjectUndefinedError
 from jobflow_remote.jobs.daemon import DaemonError, DaemonManager, DaemonStatus
 
 if TYPE_CHECKING:
@@ -314,6 +314,11 @@ def cli_error_handler(func):
             exit_with_error_msg(
                 "The active project could not be determined and it is required to execute this command. Please "
                 "check the formatting of your YAML."
+            )
+        except ProjectParsingError:
+            exit_with_error_msg(
+                "The active projects config file could not be parsed. Please check the formatting of your YAML. "
+                "You can use the command 'jf project list -w' to get the parsing errors."
             )
         except Exception as e:
             from jobflow_remote import SETTINGS

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -315,11 +315,12 @@ def cli_error_handler(func):
                 "The active project could not be determined and it is required to execute this command. Please "
                 "check the formatting of your YAML."
             )
-        except ProjectParsingError:
-            exit_with_error_msg(
-                "The active projects config file could not be parsed. Please check the formatting of your YAML. "
-                "You can use the command 'jf project list -w' to get the parsing errors."
+        except ProjectParsingError as exc:
+            msg = (
+                f"{getattr(exc, 'message', str(exc))}. "
+                f"You can use the command 'jf project list -w' to get the parsing errors."
             )
+            exit_with_error_msg(msg)
         except Exception as e:
             from jobflow_remote import SETTINGS
 

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -754,3 +754,7 @@ class ConfigError(Exception):
 
 class ProjectUndefinedError(ConfigError):
     """Exception raised if the Project has not been defined or could not be determined."""
+
+
+class ProjectParsingError(ConfigError):
+    """Exception raised if the Project does not exist or could not be parsed."""

--- a/src/jobflow_remote/config/manager.py
+++ b/src/jobflow_remote/config/manager.py
@@ -17,6 +17,7 @@ from jobflow_remote.config.base import (
     ConfigError,
     ExecutionConfig,
     Project,
+    ProjectParsingError,
     ProjectUndefinedError,
     WorkerBase,
 )
@@ -165,7 +166,7 @@ class ConfigManager:
         project_name = self.select_project_name(project_name)
 
         if project_name not in self.projects_data:
-            raise ConfigError(
+            raise ProjectParsingError(
                 f"The selected project {project_name} does not exist "
                 "or could not be parsed correctly"
             )
@@ -274,20 +275,28 @@ class ConfigManager:
         self.dump_project(project_data)
         self.projects_data[project_data.project.name] = project_data
 
-    def project_names_from_files(self) -> list[str]:
+    def project_names_from_files(
+        self, *, suppress_warnings: bool = False
+    ) -> tuple[list[str], list[str]]:
         """
-        Parses all the prasable files and only checks for the "name" attribute to
+        Parses all the parsable files and only checks for the "name" attribute to
         return a list of potential project file names.
 
         Useful in case some projects cannot be properly parsed, but the full list
         needs to be returned.
 
+        Parameters
+        ----------
+        suppress_warnings
+            If set to True, suppress warnings related to the parsing of the files in the projects folder.
+
         Returns
         -------
-        list
-            List of project names.
+        tuple
+            List of project names + List of erroneous files
         """
         project_names = []
+        erroneous_files = []
         for ext in self.projects_ext:
             for filepath in glob.glob(str(self.projects_folder / f"*.{ext}")):
                 try:
@@ -299,12 +308,15 @@ class ConfigManager:
                     if "name" in d:
                         project_names.append(d["name"])
                 except Exception:
-                    logger.warning(
-                        f"File {filepath} could not be parsed as a Project. Error: {traceback.format_exc()}"
-                    )
-                    continue
+                    erroneous_files.append(
+                        Path(filepath).stem
+                    )  # assume that this is the name of the project
+                    if not suppress_warnings:
+                        logger.warning(
+                            f"File {filepath} could not be parsed as a Project. Error: {traceback.format_exc()}"
+                        )
 
-        return project_names
+        return project_names, erroneous_files
 
     def backup_project(self, project_name: str) -> None:
         """

--- a/src/jobflow_remote/config/manager.py
+++ b/src/jobflow_remote/config/manager.py
@@ -308,9 +308,7 @@ class ConfigManager:
                     if "name" in d:
                         project_names.append(d["name"])
                 except Exception:
-                    erroneous_files.append(
-                        Path(filepath).stem
-                    )  # assume that this is the name of the project
+                    erroneous_files.append(Path(filepath).name)
                     if not suppress_warnings:
                         logger.warning(
                             f"File {filepath} could not be parsed as a Project. Error: {traceback.format_exc()}"

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -238,7 +238,7 @@ def test_edit_replace(
         # cases with empty projects folder
         run_check_cli(
             ["project", "edit", "replace", "old_text", "new_text"],
-            required_out=f"The selected project {random_project_name} does not exist or could not be parsed",
+            required_out="The active projects config file could not be parsed. Please check the formatting of your YAML. You can use the command 'jf project list -w' to get the parsing errors.",
             error=True,
         )
 

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -238,7 +238,8 @@ def test_edit_replace(
         # cases with empty projects folder
         run_check_cli(
             ["project", "edit", "replace", "old_text", "new_text"],
-            required_out="The active projects config file could not be parsed. Please check the formatting of your YAML. You can use the command 'jf project list -w' to get the parsing errors.",
+            required_out=f"The selected project {random_project_name} does not exist or could not be parsed correctly."
+            f" You can use the command 'jf project list -w' to get the parsing errors.",
             error=True,
         )
 


### PR DESCRIPTION
While creating our config files, quite often we introduce unwanted issues. Given that jobflow-remote is not able to parse those files, there is only a generic error message:

```
An Error occurred during the command execution: ConfigError The selected project my_project does not exist or could not be parsed correctly
```

We found it would be quite useful to see the full error message. I propose a change to enable the printing of the warning message.