### PR TITLE
Fix job names in tests to prevent some random test failures

### DIFF
--- a/tests/db/cli/test_flow.py
+++ b/tests/db/cli/test_flow.py
@@ -12,7 +12,7 @@ def test_flows_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     from jobflow_remote.testing import add
 
     columns = ["DB id", "Name", "State", "Flow id", "Num Jobs", "Last updated"]
-    outputs = columns + [f"f{i}" for i in range(1, 3)] + ["READY"]
+    outputs = columns + [f"flow_{i}" for i in range(1, 3)] + ["READY"]
 
     run_check_cli(["flow", "list"], required_out=outputs)
     run_check_cli(["flow", "list", "--count"], required_out="Number of Flows: 2")
@@ -175,8 +175,8 @@ def test_delete(job_controller, two_flows_four_jobs, run_check_cli) -> None:
 
 def test_flow_info(job_controller, two_flows_four_jobs, run_check_cli, runner) -> None:
     columns = ["DB id", "Name", "State", "Job id", "(Index)", "Worker"]
-    outputs = columns + [f"add{i}" for i in range(1, 3)] + ["READY", "WAITING"]
-    excluded = [f"add{i}" for i in range(3, 5)] + ["{'f1_metadata': 'some_info'}"]
+    outputs = columns + [f"add_job{i}" for i in range(1, 3)] + ["READY", "WAITING"]
+    excluded = [f"add_job{i}" for i in range(3, 5)] + ["{'f1_metadata': 'some_info'}"]
     res_flow_info = run_check_cli(
         ["flow", "info", "-j", "1", "--jobs-sort", "db_id"],
         required_out=outputs,
@@ -226,7 +226,7 @@ def test_flow_info(job_controller, two_flows_four_jobs, run_check_cli, runner) -
     run_check_cli(
         ["flow", "info", "-j", "1", "--report"],
         required_out=[
-            "Flow Report: f1",
+            "Flow Report: flow_1",
             "Completed: 0 | Running: 0 | Queued: 0 | Pending: 2 | Failed: 0",
             "READY",
             "WAITING",
@@ -241,7 +241,7 @@ def test_flow_info(job_controller, two_flows_four_jobs, run_check_cli, runner) -
     run_check_cli(
         ["flow", "info", "-j", "1", "--report"],
         required_out=[
-            "Flow Report: f1",
+            "Flow Report: flow_1",
             "Progress: 2/2 (100.0%)",
             "COMPLETED",
             "Total Time",

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -6,7 +6,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
 
     # split "job id" from "index", because it can be sent to a new line
     columns = ["DB id", "Name", "State", "Job id", "(Index)", "Worker", "Last updated"]
-    outputs = columns + [f"add{i}" for i in range(1, 5)] + ["READY", "WAITING"]
+    outputs = columns + [f"add_job{i}" for i in range(1, 5)] + ["READY", "WAITING"]
 
     run_check_cli(["job", "list"], required_out=outputs)
     run_check_cli(["job", "list", "--count"], required_out="Number of jobs: 4")
@@ -22,15 +22,15 @@ def test_jobs_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
         ["job", "list", "--color"],
         required_out=outputs,
         required_out_colored=[
-            "[green]add1[/green]",
-            "[green]add2[/green]",
-            "[red]add3[/red]",
-            "[red]add4[/red]",
+            "[green]add_job1[/green]",
+            "[green]add_job2[/green]",
+            "[red]add_job3[/red]",
+            "[red]add_job4[/red]",
         ],
     )
 
-    outputs = ["add1", "READY"]
-    excluded = [f"add{i}" for i in range(2, 5)]
+    outputs = ["add_job1", "READY"]
+    excluded = [f"add_job{i}" for i in range(2, 5)]
     run_check_cli(
         ["job", "list", "-did", "1"], required_out=outputs, excluded_out=excluded
     )
@@ -80,7 +80,7 @@ def test_jobs_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     )
 
     outputs = ["WAITING", "READY", "State", "DB id", "whatever"]
-    excluded = ["add1", "add2", "Name", "Job id"]
+    excluded = ["add_job1", "add_job2", "Name", "Job id"]
     run_check_cli(
         ["job", "list", "-o", "state,db_id", "-sdk", "whatever"],
         required_out=outputs,
@@ -156,7 +156,7 @@ def test_jobs_list_settings(
         m.setattr(SETTINGS, "cli_job_list_columns", ["state", "db_id"])
 
         outputs = ["WAITING", "READY", "State", "DB id"]
-        excluded = ["add1", "add2", "Name", "Job id"]
+        excluded = ["add_job1", "add_job2", "Name", "Job id"]
         run_check_cli(
             ["job", "list"],
             required_out=outputs,
@@ -165,7 +165,7 @@ def test_jobs_list_settings(
 
         # using -v will lead to a very large table which isn't fully displayed
         columns = ["DB", "id", "Name", "Sta", "Job", "id", "Wor", "Last", "Loc"]
-        outputs = columns + [f"add{i}" for i in range(1, 5)] + ["REA", "WAI"]
+        outputs = columns + [f"add_job{i}" for i in range(1, 5)] + ["REA", "WAI"]
         run_check_cli(
             ["job", "list", "-v"],
             required_out=outputs,
@@ -178,7 +178,7 @@ def test_job_info(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     from jobflow_remote import submit_flow
     from jobflow_remote.testing import add
 
-    outputs = ["name = 'add1'", "state = 'READY'"]
+    outputs = ["name = 'add_job1'", "state = 'READY'"]
     excluded_n = ["run_dir = None", "start_time = None"]
     excluded = [*excluded_n, "job = {"]
     run_check_cli(["job", "info", "1"], required_out=outputs, excluded_out=excluded)
@@ -224,7 +224,7 @@ def test_job_info_by_pid(job_controller, two_flows_four_jobs, run_check_cli):
     )
 
     # Test successful retrieval of job info by process ID
-    outputs = ["name = 'add1'", "state = 'READY'", f"'process_id': '{test_pid}'"]
+    outputs = ["name = 'add_job1'", "state = 'READY'", f"'process_id': '{test_pid}'"]
     run_check_cli(["job", "info", "--pid", str(test_pid)], required_out=outputs)
 
     # Test with invalid process ID
@@ -374,7 +374,9 @@ def test_queue_out(job_controller, one_job, run_check_cli) -> None:
     runner = Runner()
     runner.run_one_job(db_id="1")
 
-    run_check_cli(["job", "queue-out", "1"], required_out=["Queue output from", "add"])
+    run_check_cli(
+        ["job", "queue-out", "1"], required_out=["Queue output from", "add_job"]
+    )
 
     run_check_cli(
         ["job", "queue-out", "10"],
@@ -647,11 +649,11 @@ def test_queries(job_controller, two_flows_four_jobs, run_check_cli) -> None:
         required_out="Operation completed: 0 jobs modified",
     )
     run_check_cli(
-        ["job", "pause", "--name", "add1"],
+        ["job", "pause", "--name", "add_job1"],
         required_out="Operation completed: 1 jobs modified",
     )
     run_check_cli(
-        ["job", "resume", "--name", "add*"],
+        ["job", "resume", "--name", "add_job*"],
         required_out="Operation completed: 1 jobs modified",
     )
 

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -189,6 +189,7 @@ def one_job(random_project_name):
     from jobflow_remote.testing import add
 
     j = add(1, 5)
+    j.name = "add_job"
     flow = Flow([j])
     submit_flow(flow, worker="test_local_worker")
 
@@ -204,24 +205,24 @@ def two_flows_four_jobs(random_project_name):
     from jobflow_remote.testing import add
 
     add_first = add(1, 5)
-    add_first.name = "add1"
+    add_first.name = "add_job1"
     add_second = add(add_first.output, 5)
-    add_second.name = "add2"
+    add_second.name = "add_job2"
 
     add_first.update_metadata({"test_meta": 1})
 
     flow = Flow([add_first, add_second])
-    flow.name = "f1"
+    flow.name = "flow_1"
     flow.metadata["f1_metadata"] = "some_info"
     submit_flow(flow, worker="test_local_worker")
 
     add_third = add(1, 5)
-    add_third.name = "add3"
+    add_third.name = "add_job3"
     add_fourth = add(add_third.output, 5)
-    add_fourth.name = "add4"
+    add_fourth.name = "add_job4"
 
     flow2 = Flow([add_third, add_fourth])
-    flow2.name = "f2"
+    flow2.name = "flow_2"
     submit_flow(flow2, worker="test_local_worker")
 
     return [flow, flow2]

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -49,23 +49,23 @@ def test_queries(job_controller, runner) -> None:
     from jobflow_remote.testing import add
 
     add_first = add(1, 5)
-    add_first.name = "add1"
+    add_first.name = "add_job1"
     add_second = add(add_first.output, 5)
-    add_second.name = "add2"
+    add_second.name = "add_job2"
 
     add_first.update_metadata({"test_meta": 1})
 
     flow = Flow([add_first, add_second])
-    flow.name = "f1"
+    flow.name = "flow_1"
     submit_flow(flow, worker="test_local_worker")
 
     add_third = add(1, 5)
-    add_third.name = "add3"
+    add_third.name = "add_job3"
     add_fourth = add(add_third.output, 5)
-    add_fourth.name = "add4"
+    add_fourth.name = "add_job4"
 
     flow2 = Flow([add_third, add_fourth])
-    flow2.name = "f2"
+    flow2.name = "flow_2"
     submit_flow(flow2, worker="test_local_worker")
 
     date_create = datetime.datetime.now()
@@ -85,9 +85,9 @@ def test_queries(job_controller, runner) -> None:
 
     assert job_controller.count_jobs(metadata={"test_meta": 1}) == 1
 
-    assert job_controller.count_jobs(name="add") == 0
-    assert job_controller.count_jobs(name="add1") == 1
-    assert job_controller.count_jobs(name="add*") == 4
+    assert job_controller.count_jobs(name="add_job") == 0
+    assert job_controller.count_jobs(name="add_job1") == 1
+    assert job_controller.count_jobs(name="add_job*") == 4
 
     assert job_controller.count_jobs(flow_ids=flow.uuid) == 2
 
@@ -116,8 +116,8 @@ def test_queries(job_controller, runner) -> None:
     assert job_controller.count_flows(flow_ids=flow.uuid) == 1
     assert job_controller.count_flows(start_date=date_create) == 1
     assert job_controller.count_flows(end_date=date_create) == 1
-    assert job_controller.count_flows(name="f1") == 1
-    assert job_controller.count_flows(name="f*") == 2
+    assert job_controller.count_flows(name="flow_1") == 1
+    assert job_controller.count_flows(name="flow_*") == 2
     assert (
         job_controller.count_flows(query={"uuid": {"$in": (flow.uuid, flow2.uuid)}})
         == 2


### PR DESCRIPTION
Renamed add1, add2, ... to add_job1 etc... as well as f1 to flow_1 to prevent random clashes in the tests (e.g. add1 could be found in the uuid while it is supposed to be excluded).