### PR TITLE
Allow jf job set-state for many Jobs at once

### DIFF
--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -68,7 +68,6 @@ from jobflow_remote.cli.utils import (
     hide_progress,
     loading_spinner,
     out_console,
-    print_success_msg,
     str_to_dict,
 )
 from jobflow_remote.jobs.report import JobsReport
@@ -287,30 +286,55 @@ def job_info(
 
 @app_job.command()
 def set_state(
-    state: job_state_arg,
-    job_db_id: job_db_id_arg,
+    new_state: job_state_arg,
+    job_db_id: job_db_id_arg = None,
     job_index: job_index_arg = None,
+    job_id: job_ids_indexes_opt = None,
+    db_id: db_ids_opt = None,
+    flow_id: flow_ids_opt = None,
+    state: job_state_opt = None,
+    start_date: start_date_opt = None,
+    end_date: end_date_opt = None,
+    name: name_opt = None,
+    metadata: metadata_opt = None,
+    days: days_opt = None,
+    hours: hours_opt = None,
+    worker_name: worker_name_opt = None,
+    custom_query: query_opt = None,
+    verbosity: verbosity_opt = 0,
+    wait: wait_lock_opt = None,
+    break_lock: break_lock_opt = False,
 ) -> None:
     """
-    Sets the state of a Job to an arbitrary value.
+    Sets the state of one or more Jobs to an arbitrary value.
     WARNING: No checks. This can lead to inconsistencies in the DB. Use with care.
     """
-    db_id, job_id = get_job_db_ids(job_db_id, job_index)
 
-    with loading_spinner():
-        jc = get_job_controller()
+    jc = get_job_controller()
 
-        succeeded = jc.set_job_state(
-            state=state,
-            job_id=job_id,
-            job_index=job_index,
-            db_id=db_id,
-        )
-
-    if not succeeded:
-        exit_with_error_msg("Could not change the job state")
-
-    print_success_msg()
+    execute_multi_jobs_cmd(
+        state=new_state,
+        single_cmd=jc.set_job_state,
+        multi_cmd=jc.set_jobs_state,
+        job_db_id=job_db_id,
+        job_index=job_index,
+        job_ids=job_id,
+        db_ids=db_id,
+        flow_ids=flow_id,
+        states=state,
+        start_date=start_date,
+        end_date=end_date,
+        name=name,
+        metadata=metadata,
+        workers=worker_name,
+        custom_query=custom_query,
+        days=days,
+        hours=hours,
+        verbosity=verbosity,
+        wait=wait,
+        break_lock=break_lock,
+        interactive=True,
+    )
 
 
 @app_job.command()

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1953,7 +1953,12 @@ class JobController:
             job_lock_kwargs=job_lock_kwargs,
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
-            # lock_job_flow already checks that the locked document is not none, both for job and flow
+            # lock_job_flow already checks that the locked document is not none, both for job and flow.
+            # Check required to let mypy know
+            if job_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
+            if flow_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
 
             job_state = JobState(job_doc["state"])
@@ -2024,6 +2029,11 @@ class JobController:
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow
+            # Check required to let mypy know
+            if job_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
+            if flow_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
@@ -2173,6 +2183,11 @@ class JobController:
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow
+            # Check required to let mypy know
+            if job_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
+            if flow_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
@@ -5105,6 +5120,11 @@ class JobController:
             job_lock_kwargs=job_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow
+            # Check required to let mypy know
+            if job_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
+            if flow_lock.locked_document is None:
+                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
 
             # Update FlowDoc

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1396,7 +1396,7 @@ class JobController:
         Returns
         -------
         str
-            The db_id of the updated Job. None if the Job was not updated.
+            The db_id of the updated Job.
         """
         sleep = None
         if wait:
@@ -1410,24 +1410,115 @@ class JobController:
             sleep=sleep,
             max_wait=wait,
             projection=projection,
+            get_locked_doc=True,
         ) as lock:
             doc = lock.locked_document
-            if doc:
-                if (
-                    acceptable_states
-                    and JobState(doc["state"]) not in acceptable_states
-                ):
-                    raise ValueError(
-                        f"Job in state {doc['state']}. The action cannot be performed"
+            if not doc:
+                if lock.unavailable_document:
+                    raise JobLockedError(
+                        f"The Job matching criteria {lock_filter} is locked."
                     )
-                values = dict(values)
-                # values["updated_on"] = datetime.utcnow()
-                lock.update_on_release = (
-                    [{"$set": values}] if use_pipeline else {"$set": values}
+                raise ValueError(f"No Job matching criteria {lock_filter}")
+            if acceptable_states and JobState(doc["state"]) not in acceptable_states:
+                raise ValueError(
+                    f"Job in state {doc['state']}. The action cannot be performed"
                 )
-                return doc["db_id"]
+            values = dict(values)
+            # values["updated_on"] = datetime.utcnow()
+            lock.update_on_release = (
+                [{"$set": values}] if use_pipeline else {"$set": values}
+            )
+            return doc["db_id"]
 
-        return None
+    def set_jobs_state(
+        self,
+        state: JobState,
+        job_ids: tuple[str, int] | list[tuple[str, int]] | None = None,
+        db_ids: str | list[str] | None = None,
+        flow_ids: str | list[str] | None = None,
+        states: JobState | list[JobState] | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        name: str | None = None,
+        metadata: dict | None = None,
+        workers: str | list[str] | None = None,
+        custom_query: dict | None = None,
+        raise_on_error: bool = True,
+        wait: int | None = None,
+        break_lock: bool = False,
+    ) -> list[str]:
+        """
+        Set the state of multiple Jobs to an arbitrary JobState.
+
+        No check is performed! Any job can be set to any state.
+        Only for advanced users or for debugging purposes.
+
+        Parameters
+        ----------
+        state
+            The new state of the Jobs.
+        job_ids
+            One or more tuples, each containing the (uuid, index) pair of the
+            Jobs to retrieve.
+        db_ids
+            One or more db_ids of the Jobs to retrieve.
+        flow_ids
+            One or more Flow uuids to which the Jobs to retrieve belong. Can contain db_ids and uuids.
+        states
+            One or more states of the Jobs.
+        start_date
+            Filter Jobs that were updated_on after this date.
+            Should be in the machine local time zone. It will be converted to UTC.
+        end_date
+            Filter Jobs that were updated_on before this date.
+            Should be in the machine local time zone. It will be converted to UTC.
+        name
+            Pattern matching the name of Job. Default is an exact match, but all
+            conventions from python fnmatch can be used (e.g. *test*)
+        metadata
+            A dictionary of the values of the metadata to match. Should be an
+            exact match for all the values provided.
+        workers
+            One or more worker names.
+        custom_query
+            A generic query. Keys must not overlap with other specified query options.
+        raise_on_error
+            If True raise in case of error on one job error and stop the loop.
+            Otherwise, just log the error and proceed.
+        force
+            Bypass the limitation that only failed Jobs can be rerun.
+        wait
+            In case the Flow or Jobs that need to be updated are locked,
+            wait this time (in seconds) for the lock to be released.
+            Raise an error if lock is not released.
+        break_lock
+            Forcibly break the lock on locked documents. Use with care and
+            verify that the lock has been set by a process that is not running
+            anymore. Doing otherwise will likely lead to inconsistencies in the DB.
+
+        Returns
+        -------
+        list
+            List of db_ids of the updated Jobs.
+        """
+        return self._many_jobs_action(
+            method=self.set_job_state,
+            action_description="setting state",
+            state=state,
+            job_ids=job_ids,
+            db_ids=db_ids,
+            flow_ids=flow_ids,
+            states=states,
+            start_date=start_date,
+            end_date=end_date,
+            name=name,
+            metadata=metadata,
+            workers=workers,
+            custom_query=custom_query,
+            raise_on_error=raise_on_error,
+            wait=wait,
+            break_lock=break_lock,
+        )
 
     def set_job_state(
         self,
@@ -1448,6 +1539,8 @@ class JobController:
 
         Parameters
         ----------
+        state
+            The new state of the Job.
         db_id
             The db_id of the Job.
         job_id
@@ -1465,7 +1558,7 @@ class JobController:
         Returns
         -------
         str
-            The db_id of the updated Job. None if the Job was not updated.
+            The db_id of the updated Job.
         """
         values = {
             "state": state.value,
@@ -1860,9 +1953,8 @@ class JobController:
             job_lock_kwargs=job_lock_kwargs,
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
+            # lock_job_flow already checks that the locked document is not none, both for job and flow
             job_doc = job_lock.locked_document
-            if job_doc is None:
-                raise RuntimeError("No job document found in lock")
 
             job_state = JobState(job_doc["state"])
             if job_state in [JobState.SUBMITTED.value, JobState.RUNNING.value]:
@@ -1877,8 +1969,6 @@ class JobController:
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
             updated_states = {job_id: {job_index: JobState.USER_STOPPED}}
-            if flow_lock.locked_document is None:
-                raise RuntimeError("No document found in flow lock")
             self.update_flow_state(
                 flow_uuid=flow_lock.locked_document["uuid"],
                 updated_states=updated_states,
@@ -1887,8 +1977,6 @@ class JobController:
                 "$set": {"state": JobState.USER_STOPPED.value}
             }
             return_doc = job_lock.locked_document
-            if return_doc is None:
-                raise RuntimeError("No document found in final job lock")
 
             return return_doc["db_id"]
 
@@ -1935,23 +2023,18 @@ class JobController:
             job_lock_kwargs=job_lock_kwargs,
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
+            # lock_job_flow already checks that the locked document is not none, both for job and flow
             job_doc = job_lock.locked_document
-            if job_doc is None:
-                raise RuntimeError("No job document found in lock")
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
             updated_states = {job_id: {job_index: JobState.PAUSED}}
             flow_doc = flow_lock.locked_document
-            if flow_doc is None:
-                raise RuntimeError("No flow document found in lock")
             self.update_flow_state(
                 flow_uuid=flow_doc["uuid"],
                 updated_states=updated_states,
             )
             job_lock.update_on_release = {"$set": {"state": JobState.PAUSED.value}}
             return_doc = job_lock.locked_document
-            if return_doc is None:
-                raise RuntimeError("No document found in final job lock")
 
             return return_doc["db_id"]
 
@@ -2089,9 +2172,8 @@ class JobController:
             job_lock_kwargs=job_lock_kwargs,
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
+            # lock_job_flow already checks that the locked document is not none, both for job and flow
             job_doc = job_lock.locked_document
-            if job_doc is None:
-                raise RuntimeError("No job document found in lock")
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
             final_state = self._resume_job_locked(job_doc)
@@ -5022,11 +5104,8 @@ class JobController:
             break_lock=break_lock,
             job_lock_kwargs=job_lock_kwargs,
         ) as (job_lock, flow_lock):
+            # lock_job_flow already checks that the locked document is not none, both for job and flow
             job_doc = job_lock.locked_document
-            if job_doc is None:
-                raise RuntimeError("No job document found in lock")
-            if flow_lock.locked_document is None:
-                raise RuntimeError("No document found in flow lock")
 
             # Update FlowDoc
             flow_doc = FlowDoc.model_validate(flow_lock.locked_document)

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -6,9 +6,9 @@ import importlib.metadata
 import logging
 import shutil
 import traceback
-import typing
 import warnings
 from collections import defaultdict
+from collections.abc import MutableMapping
 from contextlib import ExitStack
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
@@ -1954,11 +1954,6 @@ class JobController:
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow.
-            # Check required to let mypy know
-            if job_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
-            if flow_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
 
             job_state = JobState(job_doc["state"])
@@ -2029,11 +2024,6 @@ class JobController:
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow
-            # Check required to let mypy know
-            if job_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
-            if flow_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
@@ -2183,11 +2173,6 @@ class JobController:
             flow_lock_kwargs=flow_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow
-            # Check required to let mypy know
-            if job_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
-            if flow_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
             job_id = job_doc["uuid"]
             job_index = job_doc["index"]
@@ -4643,6 +4628,7 @@ class JobController:
 
             set_output = lock.update_on_release
 
+            update_on_release: list | dict
             if lock.locked_document:
                 if not error:
                     next_step_time_limit = None
@@ -4660,9 +4646,12 @@ class JobController:
                             "remote.error": None,
                         }
                     }
-                    update_on_release = deep_merge_dict(
-                        succeeded_update, set_output or {}
-                    )
+                    if isinstance(set_output, list):
+                        update_on_release = [*set_output, succeeded_update]
+                    else:
+                        update_on_release = deep_merge_dict(
+                            succeeded_update, set_output or {}
+                        )
                 else:
                     step_attempts = doc["remote"]["step_attempts"]
                     no_retry = no_retry or step_attempts >= max_step_attempts
@@ -4700,7 +4689,10 @@ class JobController:
                                 "remote.queue_err": queue_err,
                             }
                         }
-                if "$set" in update_on_release:
+                if (
+                    isinstance(update_on_release, MutableMapping)
+                    and "$set" in update_on_release
+                ):
                     update_on_release["$set"]["updated_on"] = datetime.now(timezone.utc)
 
                 lock.update_on_release = update_on_release
@@ -4998,7 +4990,7 @@ class JobController:
         return self.batches.insert_one(batch_doc_dict)
 
     def update_job_in_batch(
-        self, job_id: str, job_index: int, batch_uid: str, worker: str, info: typing.Any
+        self, job_id: str, job_index: int, batch_uid: str, worker: str, info: Any
     ):
         self.batches.update_one(
             {"batch_uid": batch_uid},
@@ -5120,11 +5112,6 @@ class JobController:
             job_lock_kwargs=job_lock_kwargs,
         ) as (job_lock, flow_lock):
             # lock_job_flow already checks that the locked document is not none, both for job and flow
-            # Check required to let mypy know
-            if job_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
-            if flow_lock.locked_document is None:
-                raise RuntimeError("No job document found in lock")
             job_doc = job_lock.locked_document
 
             # Update FlowDoc

--- a/src/jobflow_remote/utils/data.py
+++ b/src/jobflow_remote/utils/data.py
@@ -6,7 +6,7 @@ import uuid
 from collections.abc import Mapping, MutableMapping
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, TypeVar
 from uuid import UUID
 
 import maggma.stores  # required to enable subclass searching
@@ -15,14 +15,16 @@ from dateutil.tz import gettz
 from maggma.core.store import Store
 from monty.json import MontyDecoder
 
+M = TypeVar("M", bound=MutableMapping)
+
 
 def deep_merge_dict(
-    d1: MutableMapping,
+    d1: M,
     d2: Mapping,
     path: list[str] | None = None,
     raise_on_conflicts: bool = True,
     inplace: bool = True,
-) -> MutableMapping:
+) -> M:
     """
     Merge a dictionary d2 into a dictionary d1 recursively.
 

--- a/src/jobflow_remote/utils/db.py
+++ b/src/jobflow_remote/utils/db.py
@@ -153,8 +153,8 @@ class MongoLock:
         self.filter = filter or {}
         self.update = update
         self.break_lock = break_lock
-        self.locked_document = None
-        self.unavailable_document = None
+        self.locked_document: dict | None = None
+        self.unavailable_document: dict | None = None
         self.lock_id = lock_id or suuid()
         self.kwargs = kwargs
         self._update_on_release: dict | list = {}
@@ -335,7 +335,8 @@ class MongoLock:
             return
 
         # Release the lock by removing the unique identifier and lock expiration time
-        update: list | dict = {"$set": {self.LOCK_KEY: None, self.LOCK_TIME_KEY: None}}
+        base_update: dict = {"$set": {self.LOCK_KEY: None, self.LOCK_TIME_KEY: None}}
+        update: list | dict = base_update
         # TODO maybe set on release only if no exception was raised?
         if self.update_on_release:
             # if an exception raised inside the context manager do not update the document
@@ -345,9 +346,9 @@ class MongoLock:
                     f"The update_on_release {self.update_on_release} will not be applied."
                 )
             elif isinstance(self.update_on_release, list):
-                update = [update, *self.update_on_release]
+                update = [base_update, *self.update_on_release]
             else:
-                update = deep_merge_dict(update, self.update_on_release)
+                update = deep_merge_dict(base_update, self.update_on_release)
         logger.debug(f"release lock with update: {update}")
 
         # if an exception raised inside the context manager do not delete the document

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -247,13 +247,50 @@ def test_set_state(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     from jobflow_remote.jobs.state import JobState
 
     run_check_cli(
-        ["job", "set-state", "UPLOADED", "1"], required_out="operation completed"
+        ["job", "set-state", "UPLOADED", two_flows_four_jobs[0][0].uuid],
+        required_out="Operation completed: 1 jobs modified",
     )
-    assert job_controller.set_job_state(JobState.UPLOADED, db_id="1")
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[0][0].uuid).state
+        == JobState.UPLOADED
+    )
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[0][1].uuid).state
+        == JobState.WAITING
+    )
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[1][0].uuid).state
+        == JobState.READY
+    )
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[1][1].uuid).state
+        == JobState.WAITING
+    )
     run_check_cli(
         ["job", "set-state", "UPLOADED", "10"],
-        required_out="Could not change the job state",
-        error=True,
+        required_out="No Job matching criteria",
+    )
+
+    run_check_cli(
+        ["job", "set-state", "COMPLETED", "--state", "WAITING"],
+        required_out="Operation completed: 2 jobs modified",
+    )
+
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[0][0].uuid).state
+        == JobState.UPLOADED
+    )
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[0][1].uuid).state
+        == JobState.COMPLETED
+    )
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[1][0].uuid).state
+        == JobState.READY
+    )
+    assert (
+        job_controller.get_job_info(job_id=two_flows_four_jobs[1][1].uuid).state
+        == JobState.COMPLETED
     )
 
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -630,6 +630,7 @@ def test_set_job_run_properties(job_controller, one_job) -> None:
 
 def test_set_job_doc_properties(job_controller, one_job) -> None:
     from jobflow_remote.jobs.state import JobState
+    from jobflow_remote.utils.db import JobLockedError
 
     # error missing input
     with pytest.raises(
@@ -647,6 +648,25 @@ def test_set_job_doc_properties(job_controller, one_job) -> None:
             values={"job.metadata.x": "y"},
             job_id=one_job[0].uuid,
             acceptable_states=[JobState.COMPLETED],
+        )
+
+    # error missing job
+    with pytest.raises(ValueError, match="No Job matching criteria"):
+        job_controller.set_job_doc_properties(
+            values={"job.metadata.x": "y"},
+            job_id="wrong_uuid",
+        )
+    # error locked job
+    with (
+        pytest.raises(JobLockedError, match="The Job matching criteria.*is locked"),
+        job_controller.lock_job(
+            filter={"uuid": one_job[0].uuid, "index": one_job[0].index}
+        ),
+    ):
+        job_controller.set_job_doc_properties(
+            values={"job.metadata.x": "y"},
+            job_id=one_job[0].uuid,
+            job_index=one_job[0].index,
         )
 
     job_controller.set_job_doc_properties(


### PR DESCRIPTION
Following [this discussion](https://matsci.org/t/create-jobs-immune-to-stop-children/65765/10), increase the options for `jf job set-state` to modify multiple Jobs with a single command.

Slight update of `set_job_doc_properties` and cleanup of some other job related methods in JobController.