### PR TITLE
Runner updates

### DIFF
--- a/doc/source/dev/contributing.rst
+++ b/doc/source/dev/contributing.rst
@@ -5,11 +5,11 @@ Contributing to jobflow-remote
 We love your input! We want to make contributing to as easy and
 transparent as possible, whether it’s:
 
--  Reporting a bug
--  Discussing the current state of the code
--  Submitting a fix
--  Proposing or implementing new features
--  Becoming a maintainer
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing or implementing new features
+- Becoming a maintainer
 
 Reporting bugs, getting help, and discussion
 --------------------------------------------
@@ -23,12 +23,12 @@ If you are making a bug report, incorporate as many elements of the
 following as possible to ensure a timely response and avoid the need for
 followups:
 
--  A quick summary and/or background.
--  Steps to reproduce - be specific! **Provide sample code.**
--  What you expected would happen, compared to what actually happens.
--  The full stack trace of any errors you encounter.
--  Notes (possibly including why you think this might be happening, or
-   steps you tried that didn’t work).
+- A quick summary and/or background.
+- Steps to reproduce - be specific! **Provide sample code.**
+- What you expected would happen, compared to what actually happens.
+- The full stack trace of any errors you encounter.
+- Notes (possibly including why you think this might be happening, or
+  steps you tried that didn’t work).
 
 We love thorough bug reports as this means the development team can make
 quick and meaningful fixes. When we confirm your bug report, we’ll move
@@ -48,11 +48,11 @@ for more information on this procedure.
 
 The basic procedure for making a PR is:
 
--  Fork the repo and create your branch from main.
--  Commit your improvements to your branch and push to your Github fork
-   (repo).
--  When you’re finished, go to your fork and make a Pull Request. It
-   will automatically update if you need to make further changes.
+- Fork the repo and create your branch from main.
+- Commit your improvements to your branch and push to your Github fork
+  (repo).
+- When you’re finished, go to your fork and make a Pull Request. It will
+  automatically update if you need to make further changes.
 
 How to Make a Great Pull Request
 --------------------------------
@@ -60,22 +60,22 @@ How to Make a Great Pull Request
 We have a few tips for writing good PRs that are accepted into the main
 repo:
 
--  Use the Numpy Code style for all of your code. Find an example
-   `here <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy>`__.
--  Your code should have (4) spaces instead of tabs.
--  If needed, update the documentation.
--  **Write tests** for new features! Good tests are 100%, absolutely
-   necessary for good code. We use the python ``pytest`` framework – see
-   some of the other tests in this repo for examples, or review the
-   `Hitchhiker’s guide to
-   python <https://docs.python-guide.org/writing/tests>`__ for some good
-   resources on writing good tests.
--  Understand your contributions will fall under the same license as
-   this repo.
--  This project uses ``pre-commit`` for uniform linting across many
-   developers. You can install it through the extra dev dependencies
-   with ``pip install -e .[dev]`` and then run ``pre-commit install`` to
-   activate it for you local repository.
+- Use the Numpy Code style for all of your code. Find an example
+  `here <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html#example-numpy>`__.
+- Your code should have (4) spaces instead of tabs.
+- If needed, update the documentation.
+- **Write tests** for new features! Good tests are 100%, absolutely
+  necessary for good code. We use the python ``pytest`` framework – see
+  some of the other tests in this repo for examples, or review the
+  `Hitchhiker’s guide to
+  python <https://docs.python-guide.org/writing/tests>`__ for some good
+  resources on writing good tests.
+- Understand your contributions will fall under the same license as this
+  repo.
+- This project uses ``pre-commit`` for uniform linting across many
+  developers. You can install it through the extra dev dependencies with
+  ``pip install -e .[dev]`` and then run ``pre-commit install`` to
+  activate it for you local repository.
 
 When you submit your PR, our CI service will automatically run your
 tests. We welcome good discussion on the best ways to write your code,

--- a/doc/source/user/advancedoptions.rst
+++ b/doc/source/user/advancedoptions.rst
@@ -80,6 +80,8 @@ Given the strict connection requirements, this approach comes with some limitati
 * The Runner can only run with a single process, not in the split mode.
 
 
+.. _advancedoptions batch:
+
 Batch submission
 ================
 

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -23,6 +23,7 @@ details are found in :ref:`reference`.
    backup
    cli
    gui
+   troubleshooting
 
 .. toctree::
    :hidden:

--- a/doc/source/user/projectconf.rst
+++ b/doc/source/user/projectconf.rst
@@ -18,6 +18,7 @@ configured through environment variables or an additional configuration file.
     not attempt to refresh them during the execution. Whenever any configuration is changed
     the ``Runner`` should be restarted.
 
+.. _projectconf options:
 
 Project options
 ===============
@@ -258,7 +259,7 @@ other collections within the same database to  manage and track different aspect
 
 - **Flows collection**: keeps track of the state of Flows and their relationship to Jobs.
 - **Auxiliary collection**: stores additional internal metadata required by jobflow-remote.
-- **Batches collection**: stores information about *batch processes* (see :ref:`Batch submission`),
+- **Batches collection**: stores information about *batch processes* (see :ref:`advancedoptions batch`),
   including their state, associated worker, start and end times, and the list of Jobs
   executed within each batch. This collection allows for monitoring both active and
   past batch executions.

--- a/doc/source/user/runner.rst
+++ b/doc/source/user/runner.rst
@@ -92,8 +92,8 @@ or the command::
     jf runner shutdown
 
 relies on Supervisor to send a ``SIGTERM`` signal (a termination signal that allows
-the process to exit cleanly) to all the ``Runner`` processes. After this also the
-Supervisor process will be stopped. The two commands are equivalent and will result in
+the process to exit cleanly) to all the ``Runner`` processes. After this the
+Supervisor process will also be stopped. The two commands are equivalent and will result in
 a Runner in the ``shut_down`` state.
 
 Unless the ``--wait`` option is specified, the completion of the command will not imply
@@ -106,7 +106,7 @@ that all the ``Runner`` processes have been terminated.
 .. note::
     In older versions of jobflow-remote the ``jf runner stop`` command used to stop
     only the ``Runner`` processes, but leaving the Supervisor process active. Since version
-    1.0 this has been removed from the CLI to simply the handling of the runner.
+    1.0 this has been removed from the CLI to simplify the handling of the runner.
     If needed, the option is still available through the python API.
 
 Kill

--- a/doc/source/user/runner.rst
+++ b/doc/source/user/runner.rst
@@ -78,38 +78,36 @@ the steps 3 and 4.
     the project configuration is changed the ``Runner`` needed the runner needs
     to be restarted.
 
-.. _runner stop:
+.. _runner stop_shutdown:
 
-Stop
-----
+Stop - Shutdown
+---------------
 
 Executing the stop command::
 
     jf runner stop
 
+or the command::
+
+    jf runner shutdown
+
 relies on Supervisor to send a ``SIGTERM`` signal (a termination signal that allows
-the process to exit cleanly) to all the ``Runner`` processes.
-In this case the supervisor process will remain active. Unless the ``--wait`` option
-is specified, the completion of the command will not imply that all the ``Runner``
-processes have been terminated.
+the process to exit cleanly) to all the ``Runner`` processes. After this also the
+Supervisor process will be stopped. The two commands are equivalent and will result in
+a Runner in the ``shut_down`` state.
+
+Unless the ``--wait`` option is specified, the completion of the command will not imply
+that all the ``Runner`` processes have been terminated.
 
 .. warning::
     The ``Runner`` is designed to recognize the signal and **wait for the completion of
     the action being performed**, before actually exiting.
 
 .. note::
-    Since the supervisor process remains active, when starting the runner again after
-    a stop it is not possible to switch from a single process to a split configuration
-    or the other way round. It is necessary to shut down the whole daemon in that case.
-
-Shutdown
---------
-Shutting down the runner with the command::
-
-    jf runner shutdown
-
-is equivalent to the :ref:`runner stop`, except that also the Supervisor process will
-be stopped.
+    In older versions of jobflow-remote the ``jf runner stop`` command used to stop
+    only the ``Runner`` processes, but leaving the Supervisor process active. Since version
+    1.0 this has been removed from the CLI to simply the handling of the runner.
+    If needed, the option is still available through the python API.
 
 Kill
 ----

--- a/doc/source/user/troubleshooting.rst
+++ b/doc/source/user/troubleshooting.rst
@@ -45,8 +45,8 @@ When trying to start/stop the Runner, the system prompts an error stating that::
 
     A daemon runner process associated to this database may be already running
 
-or, alternatively, more than one set of daemon processes is mistakenly already
-running simultaneously.
+or, alternatively, more than one set of daemon processes is already
+running simultaneously (which should not happen).
 
 Key concepts about the Runner in these context are:
 
@@ -93,8 +93,17 @@ daemon record from the database by running::
 Lost daemon processes
 ---------------------
 
-If you discover that multiple daemons are actively running on different systems
-you will need to **manually terminate the lost processes**. This is because
+One way to discover if there are multiple Runners active associated to a database
+is to run the command::
+
+    jf runner info --pings
+
+that will list all the last pings from Runners. If you expect that the daemon
+is shut down but you keep seeing pings from some processes there might be an
+active Runner somewhere (note that the runner pings the database once every hour).
+
+If you discover that multiple daemons are actively running you will
+need to **manually terminate the lost processes**. This is because
 jobflow-remote may have lost control over them.
 
 Connect to the different machines and look for processes containing "runner"

--- a/doc/source/user/troubleshooting.rst
+++ b/doc/source/user/troubleshooting.rst
@@ -1,0 +1,116 @@
+.. _troubleshooting:
+
+
+***************
+Troubleshooting
+***************
+
+This section contains explanations and possible solutions for common issues
+that can be encountered when using jobflow-remote. The focus here is on a
+brief description of the problem and its potential solutions, with references to
+specific sections of the documentation for more in depth descriptions of
+the jobflow-remote components.
+
+Note that this section mainly addresses technical issues related to the setup or
+execution of jobflow-remote. For suggestions about how to deal with runtime errors
+consult the :ref:`errors` section.
+
+Changes to the Project not taken into account
+=============================================
+
+You may update the files containing the :ref:`projectconf`, but find that Jobs are
+failing because the changes are not being recognized. For example a new worker
+or a new execution configuration is added or modified, but after the the job fails
+reporting that such a new configuration or worker does not exist.
+
+The most likely explanation is that the **runner was not restarted
+after the file updates**. As detailed in the :ref:`runner` section, the
+Runner **reads the project configurations when the processes is started**
+and does not attempt to refresh them during the execution.
+
+The primary attempt to solve the issue is **restarting the Runner**.
+
+If the problem persist, or appears to occur randomly, it is possible that
+another Runner process has remained active and keeps operating on the database
+the outdated version of the Project configuration. In this case it is necessary
+to **identify the dangling process and kill it manually**. See also the
+:ref:`troubleshooting multi_daemon` section.
+
+.. _troubleshooting multi_daemon:
+
+Multiple active daemons
+=======================
+
+When trying to start/stop the Runner, the system prompts an error stating that::
+
+    A daemon runner process associated to this database may be already running
+
+or, alternatively, more than one set of daemon processes is mistakenly already
+running simultaneously.
+
+Key concepts about the Runner in these context are:
+
+* Each active Runner daemon (which is a set of processes) can run multiple subprocesses
+  to parallelize the execution of jobs.
+* **Jobflow-remote is designed to have only one active daemon set at any given time**.
+* The system employs safeguards (files in the project folder, database records) to
+  prevent multiple daemons from starting. However, a user can bypass these checks
+  (e.g., by using the jf runner reset command).
+
+For more detailed information read the full :ref:`runner` section of the documentation.
+
+Common scenarios leading to this issues can be:
+
+* A cluster front-end that has **multiple front-end nodes** sharing the same file system.
+* **Same project configuration** on two different physical machines that do not share the same
+  file system. For example a local workstation and a cluster frontend.
+* **Multiple projects pointing to the same "queue" database and collections** in the project
+  configuration (see the documentation for the :ref:`projectconf queuestore`. Note that
+  this is a misconfiguration: each Project should have a different Queue Store)
+
+Daemon already running warning
+------------------------------
+
+When the daemon is successfully started on one machine/project, any subsequent attempt to
+start it on another associated system will issue a warning that the Runner is already
+active elsewhere.
+
+In this scenario, it is critical to **identify where the other active daemon is running
+and shut it down** before starting it on your current machine. The error message mentioned
+above includes the hostname, project name, and start time of the other daemon to help
+you locate it.
+
+For additional information about the daemon process, run:
+
+    jf runner info
+
+If you have already verified that the daemon is **no longer active** in the other location
+(e.g. the machine it was on has been shut down), you can force the removal of the previous
+daemon record from the database by running::
+
+    jf runner reset
+
+Lost daemon processes
+---------------------
+
+If you discover that multiple daemons are actively running on different systems
+you will need to **manually terminate the lost processes**. This is because
+jobflow-remote may have lost control over them.
+
+Connect to the different machines and look for processes containing "runner"
+and "supervisor". The output of ``ps -ef | grep runner`` should list several
+processes similar to these (or a single one, if the daemon was started with the
+``--single`` flag)::
+
+    username    1850106 1850105  0 Nov24 ?        10:05:23 /bin/python /bin/jf -p test runner run -pid --checkout -log info
+    username    1850107 1850105  0 Nov24 ?        10:05:26 /bin/python /bin/jf -p test runner run -pid --complete -log info
+    username    1850108 1850105  0 Nov24 ?        10:05:28 /bin/python /bin/jf -p test runner run -pid --queue -log info
+    username    1850109 1850105  0 Nov24 ?        10:05:37 /bin/python /bin/jf -p test runner run -pid --transfer -log info
+
+The output of ``ps -ef | grep supervisor``, should list the parent process, similar
+to this::
+
+    username    1850105       1  0 Nov24 ?        10:00:36 /bin/python3.12 /bin/supervisord -c ~/.jfremote/test/daemon/supervisord.conf
+
+You must manually kill all these identified processes on the other machines
+before finally attempting to restart the Runner on your desired machine.

--- a/src/jobflow_remote/cli/formatting.py
+++ b/src/jobflow_remote/cli/formatting.py
@@ -792,3 +792,28 @@ def get_batch_processes_table(
         table.add_row(*row)
 
     return table
+
+
+def get_runner_pings_table(runner_pings: list[dict]) -> Table:
+    ping_keys = {
+        "daemon_id": lambda x: str(x),
+        "runner_id": lambda x: str(x),
+        "time": lambda x: convert_utc_time(x).strftime(fmt_datetime),
+        "hostname": lambda x: str(x),
+        "run_options": lambda x: str(x),
+        "project_name": lambda x: str(x),
+        "user": lambda x: str(x),
+    }
+    table = Table(title="Runner pings")
+    table.add_column("Daemon ID")
+    table.add_column("Runner ID")
+    table.add_column(f"Ping time{time_zone_str}")
+    table.add_column("Hostname")
+    table.add_column("Run options")
+    table.add_column("Project")
+    table.add_column("User")
+
+    for rp in reversed(runner_pings):
+        table.add_row(*[f(rp.get(k)) for k, f in ping_keys.items()])
+
+    return table

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -47,7 +47,7 @@ _running_daemon_error_msg = (
     "\nRun `jf runner info` to get more details about the active runner reported in the database.\n"
     "If you are [bold]absolutely sure that no other runner is active on another machine "
     "or for another project[/bold], clean the DB with `jf runner reset`.\n"
-    "[bold]If you are unsure about the meaning of this message check the documentation:[/bold] [link=https://matgenix.github.io/jobflow-remote/user/runner.html#running-daemon-check]https://matgenix.github.io/jobflow-remote/user/runner.html#running-daemon-check[/link]"
+    "[bold]If you are unsure about the meaning of this message check the documentation:[/bold] [link=https://matgenix.github.io/jobflow-remote/user/troubleshooting.html]https://matgenix.github.io/jobflow-remote/user/troubleshooting.html[/link]"
 )
 
 

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -462,12 +462,14 @@ def info(
                 "user",
                 "daemon_dir",
             ]
-            diffs = [d for d in data_to_check if running_runner_doc[d] != last_ping[d]]
-        if (
-            procs_info_dict
-            and procs_info_dict.get("supervisord", {}).get("pid")
-            != last_ping["daemon_id"]
-        ):
+            diffs = [
+                d
+                for d in data_to_check
+                if running_runner_doc.get(d) != last_ping.get(d)
+            ]
+        if procs_info_dict and str(
+            procs_info_dict.get("supervisord", {}).get("pid")
+        ) != str(last_ping["daemon_id"]):
             diffs.append("daemon_id")
 
         if diffs:

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -8,6 +8,7 @@ from rich.scope import render_scope
 from rich.table import Table
 from rich.text import Text
 
+from jobflow_remote.cli.formatting import get_runner_pings_table
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
@@ -102,6 +103,14 @@ def run(
             help="Activate the connection for interactive remote host",
         ),
     ] = False,
+    daemonized: Annotated[
+        bool,
+        typer.Option(
+            "--daemonized",
+            "-d",
+            help="If selected, indicates that the daemon is started inside a daemon. The parent PID will be added.",
+        ),
+    ] = False,
 ) -> None:
     """
     Execute the Runner in the foreground.
@@ -109,10 +118,14 @@ def run(
     Should be used by the daemon or for testing purposes.
     """
     runner_id = os.getpid() if set_pid else None
+    daemon_id = None
+    if daemonized:
+        daemon_id = os.getppid()
     runner = Runner(
         log_level=log_level,
         runner_id=str(runner_id),
         connect_interactive=connect_interactive,
+        daemon_id=str(daemon_id),
     )
     if not (transfer or complete or queue or checkout):
         transfer = complete = queue = checkout = True
@@ -374,7 +387,17 @@ def status() -> None:
 
 
 @app_runner.command()
-def info(verbosity: verbosity_opt = 0) -> None:
+def info(
+    verbosity: verbosity_opt = 0,
+    pings: Annotated[
+        bool,
+        typer.Option(
+            "--pings",
+            "-p",
+            help=("Also show all the ping entries"),
+        ),
+    ] = False,
+) -> None:
     """
     Fetch the information about the process of the daemon.
     Contain the supervisord process and the processes running the Runner.
@@ -419,6 +442,58 @@ def info(verbosity: verbosity_opt = 0) -> None:
         out_console.print(render_scope(running_runner_doc))
     else:
         out_console.print("No running runner defined in the DB")
+
+    # in any case fetch the data from the pings and warn if the last ping
+    # is not from the active runner.
+    pings_data = jc.get_runner_pings()
+
+    if pings:
+        out_console.print("")
+        pings_table = get_runner_pings_table(pings_data)
+        out_console.print(pings_table)
+
+    if pings_data:
+        last_ping = pings_data[-1]
+        diffs = []
+        if running_runner_doc:
+            data_to_check = [
+                "hostname",
+                "project_name",
+                "user",
+                "daemon_dir",
+            ]
+            diffs = [d for d in data_to_check if running_runner_doc[d] != last_ping[d]]
+        if (
+            procs_info_dict
+            and procs_info_dict.get("supervisord", {}).get("pid")
+            != last_ping["daemon_id"]
+        ):
+            diffs.append("daemon_id")
+
+        if diffs:
+            warn_msg = (
+                "There is an inconsistency between the actual runner information "
+                "and the last ping in the database.\n"
+                "This suggests that another runner process associated to this database "
+                "may be already running\n"
+            )
+            helper_sentences = {
+                "daemon_id": "running under another supervisor process",
+                "hostname": "active on another machine",
+                "project_name": "associated to another Project",
+                "user": "associated to another user",
+                "daemon_dir": "using a different project folder",
+            }
+            for d in diffs:
+                warn_msg += f"- It seems to be {helper_sentences[d]}: {last_ping[d]}\n"
+            warn_msg += f"- The last time it pinged the database was: {last_ping['time']} (UTC)\n"
+
+            warn_msg += (
+                "Run the command with the --pings option to get a list of all the last pings "
+                "from the runners in the database and consult the documentation "
+                "[link=https://matgenix.github.io/jobflow-remote/user/troubleshooting.html]https://matgenix.github.io/jobflow-remote/user/troubleshooting.html[/link]"
+            )
+            out_console.print(warn_msg, style="gold1")
 
 
 @app_runner.command()

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -44,7 +44,10 @@ app.add_typer(app_runner)
 
 
 _running_daemon_error_msg = (
-    "\nIf no runner is active on that machine clean the DB with `jf runner reset`"
+    "\nRun `jf runner info` to get more details about the active runner reported in the database.\n"
+    "If you are [bold]absolutely sure that no other runner is active on another machine "
+    "or for another project[/bold], clean the DB with `jf runner reset`.\n"
+    "[bold]If you are unsure about the meaning of this message check the documentation:[/bold] [link=https://matgenix.github.io/jobflow-remote/user/runner.html#running-daemon-check]https://matgenix.github.io/jobflow-remote/user/runner.html#running-daemon-check[/link]"
 )
 
 
@@ -177,7 +180,7 @@ def start(
             )
         except RunningDaemonError as e:
             exit_with_error_msg(
-                f"Error while starting the daemon: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                f"Error while starting the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
             )
         except DaemonError as e:
             exit_with_error_msg(
@@ -195,8 +198,8 @@ def start(
         dm.foreground_processes(print_function=out_console.print)
 
 
-@app_runner.command()
-def stop(
+@app_runner.command(hidden=True)
+def stop_processes(
     wait: Annotated[
         bool,
         typer.Option(
@@ -222,7 +225,7 @@ def stop(
             stop_sent = dm.stop(wait=wait, raise_on_error=True)
         except RunningDaemonError as e:
             exit_with_error_msg(
-                f"Error while stopping the daemon: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                f"Error while stopping the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
             )
         except DaemonError as e:
             exit_with_error_msg(
@@ -235,6 +238,26 @@ def stop(
             "The stop signal has been sent to the Runner. Run 'jf runner status' to verify if it stopped",
             style="yellow",
         )
+
+
+@app_runner.command()
+def stop(
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help=(
+                "Wait until the daemon has stopped. NOTE: this may take a while if a large file is being transferred!"
+            ),
+        ),
+    ] = False,
+) -> None:
+    """
+    Shuts down the supervisord process.
+    Note that the supervisord process will stop after all the runner processes have finished.
+    """
+    shutdown(wait=wait)
 
 
 @app_runner.command()
@@ -251,7 +274,7 @@ def kill() -> None:
             dm.kill(raise_on_error=True)
         except RunningDaemonError as e:
             exit_with_error_msg(
-                f"Error while killing the daemon: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                f"Error while killing the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
             )
         except DaemonError as e:
             exit_with_error_msg(
@@ -260,20 +283,31 @@ def kill() -> None:
 
 
 @app_runner.command()
-def shutdown() -> None:
+def shutdown(
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help=(
+                "Wait until the daemon has shut down. NOTE: this may take a while if a large file is being transferred!"
+            ),
+        ),
+    ] = False,
+) -> None:
     """
     Shuts down the supervisord process.
-    Note that if the daemon is running it will wait for the daemon to stop.
+    Note that the supervisord process will stop after all the runner processes have finished
     """
     cm = get_config_manager()
     dm = DaemonManager.from_project(cm.get_project())
     with loading_spinner(processing=False) as progress:
         progress.add_task(description="Shutting down supervisor...", total=None)
         try:
-            dm.shut_down(raise_on_error=True)
+            dm.shut_down(raise_on_error=True, wait=wait)
         except RunningDaemonError as e:
             exit_with_error_msg(
-                f"Error while shutting down supervisor: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                f"Error while shutting down supervisor:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
             )
         except DaemonError as e:
             exit_with_error_msg(
@@ -295,7 +329,7 @@ def restart() -> None:
             dm.restart(raise_on_error=True)
         except RunningDaemonError as e:
             exit_with_error_msg(
-                f"Error while restarting the daemon: {getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                f"Error while restarting the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
             )
         except DaemonError as e:
             exit_with_error_msg(

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -53,7 +53,7 @@ class RunnerOptions(BaseModel):
         "and running jobs (seconds). Only used if a batch worker is present",
     )
     delay_ping_db: float = Field(
-        7200,
+        3600,
         description="Delay between subsequent pings to the running runner document.",
     )
     lock_timeout: float | None = Field(

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -133,6 +133,7 @@ class DaemonStatus(Enum):
     """
 
     SHUT_DOWN = "SHUT_DOWN"
+    SHUTTING_DOWN = "SHUTTING_DOWN"
     STOPPED = "STOPPED"
     STOPPING = "STOPPING"
     PARTIALLY_RUNNING = "PARTIALLY_RUNNING"
@@ -343,7 +344,7 @@ class DaemonManager:
 
         return running
 
-    def check_status(self) -> DaemonStatus:
+    def check_status(self, raise_on_shutdown: bool = True) -> DaemonStatus:
         """
         Get the current status of the daemon based on the state of the supervisord
         process and the running processes.
@@ -384,9 +385,11 @@ class DaemonManager:
                 return DaemonStatus.SHUT_DOWN
 
             if exc.faultString == "SHUTDOWN_STATE":
-                raise DaemonError(
-                    "The daemon is likely shutting down and the actual state cannot be determined"
-                ) from exc
+                if raise_on_shutdown:
+                    raise DaemonError(
+                        "The daemon is likely shutting down and the actual state cannot be determined"
+                    ) from exc
+                return DaemonStatus.SHUTTING_DOWN
             raise
         if not proc_info:
             raise DaemonError(
@@ -824,7 +827,7 @@ class DaemonManager:
 
         raise DaemonError(f"Daemon status {status} could not be handled")
 
-    def shut_down(self, raise_on_error: bool = False) -> bool:
+    def shut_down(self, raise_on_error: bool = False, wait: bool = False) -> bool:
         """
         Shut down the supervisord process and all the processes of the daemon.
 
@@ -832,7 +835,8 @@ class DaemonManager:
         ----------
         raise_on_error
             If True, raise an exception if an error occurs.
-
+        wait
+            If True wait until the daemon has stopped.
         Returns
         -------
         bool
@@ -861,6 +865,19 @@ class DaemonManager:
                 if raise_on_error:
                     raise
                 return False
+            if wait:
+                while True:
+                    time.sleep(1)
+                    try:
+                        current_status = self.check_status(raise_on_shutdown=False)
+                    except Exception as exc:
+                        if raise_on_error:
+                            raise DaemonError(
+                                "Error while waiting for the daemon to shut down"
+                            ) from exc
+                        return False
+                    if current_status == DaemonStatus.SHUT_DOWN:
+                        break
             lock.update_on_release = {"$set": {"running_runner": None}}
             return True
 
@@ -1134,25 +1151,31 @@ class DaemonManager:
             "user",
             "daemon_dir",
         ]
-        for data in data_to_check:
-            if local_data[data] != db_data[data]:
-                break
-        else:
+        diffs = [d for d in data_to_check if local_data[d] != db_data[d]]
+
+        if not diffs:
             logger.info(
                 "The DB reports that there is a running runner and it corresponds to this machine"
             )
             return None
 
-        error = (
-            "A daemon runner process may be running on a different machine.\n"
-            "Here is the information retrieved from the database:\n"
-            f"- hostname: {db_data['hostname']}\n"
-            f"- project_name: {db_data['project_name']}\n"
-            f"- start_time: {db_data['start_time']}\n"
-            f"- last_pinged: {db_data['last_pinged']}\n"
-            f"- daemon_dir: {db_data['daemon_dir']}\n"
-            f"- user: {db_data['user']}"
+        error = "A daemon runner process associated to this database may be already running.\n"
+        helper_sentences = {
+            "hostname": "active on another machine",
+            "project_name": "associated to another Project",
+            "user": "associated to another user",
+            "daemon_dir": "using a different project folder",
+        }
+        for d in diffs:
+            error += (
+                f"- It seems to be {helper_sentences[d]}: {db_data[d]}"
+                f" (current {local_data[d]})\n"
+            )
+        error += (
+            f"- It was started at: {db_data['start_time']}\n"
+            f"- The last time it pinged the database was: {db_data['last_pinged']}\n"
         )
+
         if raise_on_error:
             raise RunningDaemonError(error)
         return error

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -4,7 +4,6 @@ import contextlib
 import datetime
 import getpass
 import logging
-import os
 import re
 import socket
 import subprocess
@@ -54,7 +53,7 @@ serverurl=unix://$sock_file
 
 [program:runner_daemon]
 priority=100
-command=jf -p $project runner run -pid -log $loglevel $connect_interactive
+command=jf -p $project runner run -pid -d -log $loglevel $connect_interactive
 autostart=true
 autorestart=false
 numprocs=1
@@ -83,7 +82,7 @@ serverurl=unix://$sock_file
 
 [program:runner_daemon_checkout]
 priority=100
-command=jf -p $project runner run -pid --checkout -log $loglevel $connect_interactive
+command=jf -p $project runner run -pid --checkout -d -log $loglevel $connect_interactive
 autostart=true
 autorestart=false
 numprocs=1
@@ -92,7 +91,7 @@ stopwaitsecs=86400
 
 [program:runner_daemon_transfer]
 priority=100
-command=jf -p $project runner run -pid --transfer -log $loglevel $connect_interactive
+command=jf -p $project runner run -pid --transfer -d -log $loglevel $connect_interactive
 autostart=true
 autorestart=false
 numprocs=$num_procs_transfer
@@ -101,7 +100,7 @@ stopwaitsecs=86400
 
 [program:runner_daemon_queue]
 priority=100
-command=jf -p $project runner run -pid --queue -log $loglevel $connect_interactive
+command=jf -p $project runner run -pid --queue -d -log $loglevel $connect_interactive
 autostart=true
 autorestart=false
 numprocs=1
@@ -110,7 +109,7 @@ stopwaitsecs=86400
 
 [program:runner_daemon_complete]
 priority=100
-command=jf -p $project runner run -pid --complete -log $loglevel $connect_interactive
+command=jf -p $project runner run -pid --complete -d -log $loglevel $connect_interactive
 autostart=true
 autorestart=false
 numprocs=$num_procs_complete
@@ -1042,10 +1041,7 @@ class DaemonManager:
         Generate a dictionary with the information about the runner and
         the system where it is being executed.
         """
-        try:
-            user = os.getlogin()
-        except OSError:
-            user = os.environ.get("USER", None)
+        user = getpass.getuser()
         # Note that this approach may give a different MAC address for the
         # same machine, if more than one network device is present (this
         # may also include local virtual machines). Consider replacing this
@@ -1071,8 +1067,8 @@ class DaemonManager:
             "user": user,
             "daemon_dir": self.project.daemon_dir,
             "project_name": self.project.name,
-            "start_time": datetime.datetime.now(),
-            "last_pinged": datetime.datetime.now(),
+            "start_time": datetime.datetime.now(datetime.timezone.utc),
+            "last_pinged": datetime.datetime.now(datetime.timezone.utc),
             "runner_options": self.project.runner.model_dump(mode="json"),
         }
 

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -3139,6 +3139,7 @@ class JobController:
         self.auxiliary.drop()
         self.auxiliary.insert_one({"next_id": 1})
         self.auxiliary.insert_one({"running_runner": None})
+        self.auxiliary.insert_one({"runner_pings": []})
         self.batches.drop()
         self.update_version_information()
         self.build_indexes(drop=True)
@@ -4432,22 +4433,65 @@ class JobController:
                 )
             lock.update_on_release = {"$set": {"running_runner": None}}
 
-    def ping_running_runner(self) -> bool:
+    def ping_running_runner(self, data: dict | None = None) -> tuple[bool, list]:
         """
         Ping the running_runner document, if exists and has been activated as a daemon.
+        Also add a ping in the runner_pings_doc auxiliary document
+
+        Parameters
+        ----------
+        data
+            A dictionary of data to be added to the ping information
 
         Returns
         -------
-        bool
-            True if the ping was successful.
+        dict
+            The content of the running_runner document, if present.
         """
+        ping_time = datetime.now(timezone.utc)
         ping_result = self.auxiliary.find_one_and_update(
             {"running_runner.last_pinged": {"$exists": True}},
-            {"$set": {"running_runner.last_pinged": datetime.now(timezone.utc)}},
+            {"$set": {"running_runner.last_pinged": ping_time}},
             upsert=False,
         )
 
-        return ping_result is not None
+        data = dict(data or {})
+        data["time"] = ping_time
+        runner_pings_doc = self.auxiliary.find_one_and_update(
+            {"runner_pings": {"$exists": True}},
+            {"$push": {"runner_pings": {"$each": [data], "$slice": -50}}},
+            return_document=pymongo.ReturnDocument.AFTER,
+            upsert=True,
+        )
+
+        return ping_result is not None, runner_pings_doc.get("runner_pings", [])
+
+    def get_runner_pings(self) -> list:
+        """
+        Fetch the last pings from the DB.
+        The content of the "runner_pings" document in the auxiliary collection.
+
+        Returns
+        -------
+        list
+            The list of the latests pings. Last element of the list is the last ping.
+        """
+        runner_pings_doc = self.auxiliary.find_one({"runner_pings": {"$exists": True}})
+        # Check if not None for compatibility with potentially not upgraded DBs and
+        # avoiding hard failures. Can probably be removed in the future.
+        if runner_pings_doc:
+            return runner_pings_doc.get("runner_pings", [])
+        return []
+
+    def clean_runner_pings(self) -> None:
+        """
+        Remove all the pings from the "runner_pings" document in the auxiliary collection.
+        """
+        self.auxiliary.find_one_and_update(
+            {"runner_pings": {"$exists": True}},
+            {"$set": {"runner_pings": []}},
+            upsert=True,
+        )
 
     def update_flow_state(
         self,

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -96,6 +96,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_MAX_ARCHIVED_RUNNER_PINGS = 50
+
+
 class JobController:
     """
     Main entry point for all the interactions with the Stores.
@@ -4436,7 +4439,8 @@ class JobController:
     def ping_running_runner(self, data: dict | None = None) -> tuple[bool, list]:
         """
         Ping the running_runner document, if exists and has been activated as a daemon.
-        Also add a ping in the runner_pings_doc auxiliary document
+        Also add a ping in the runner_pings auxiliary document. The length of the
+        runner_pings list is limited in size.
 
         Parameters
         ----------
@@ -4445,8 +4449,9 @@ class JobController:
 
         Returns
         -------
-        dict
-            The content of the running_runner document, if present.
+        tuple
+            a bool with True if the ping was successful and the list of pings
+            in the runner_pings document.
         """
         ping_time = datetime.now(timezone.utc)
         ping_result = self.auxiliary.find_one_and_update(
@@ -4459,7 +4464,14 @@ class JobController:
         data["time"] = ping_time
         runner_pings_doc = self.auxiliary.find_one_and_update(
             {"runner_pings": {"$exists": True}},
-            {"$push": {"runner_pings": {"$each": [data], "$slice": -50}}},
+            {
+                "$push": {
+                    "runner_pings": {
+                        "$each": [data],
+                        "$slice": -_MAX_ARCHIVED_RUNNER_PINGS,
+                    }
+                }
+            },
             return_document=pymongo.ReturnDocument.AFTER,
             upsert=True,
         )

--- a/src/jobflow_remote/jobs/runner.py
+++ b/src/jobflow_remote/jobs/runner.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import getpass
 import json
 import logging
 import math
 import shutil
 import signal
+import socket
 import time
 import traceback
 import uuid
@@ -89,6 +91,7 @@ class Runner:
         log_level: LogLevel | None = None,
         runner_id: str | None = None,
         connect_interactive: bool = False,
+        daemon_id: str | None = None,
     ) -> None:
         """
         Parameters
@@ -102,15 +105,18 @@ class Runner:
             A unique identifier for the Runner process. Used to identify the
             runner process in logging and in the DB locks.
             If None a uuid will be generated.
-        connect_interactive:
+        connect_interactive
             If True during initialization will open connections to the hosts
             marked as interactive.
+        daemon_id
+            A unique identifier for the daemon process that manages this Runner process.
         """
         self.stop_signal = False
         self.runner_id: str = runner_id or str(uuid.uuid4())
+        self.daemon_id = daemon_id
         self.config_manager: ConfigManager = ConfigManager()
-        self.project_name = project_name
         self.project: Project = self.config_manager.get_project(project_name)
+        self.project_name = self.project.name
         self.job_controller: JobController = JobController.from_project(self.project)
         self.workers: dict[str, WorkerBase] = self.project.workers
         # Build the dictionary of hosts. The reference is the worker name.
@@ -171,6 +177,8 @@ class Runner:
                     )
                 ):
                     host.connect()
+        self.runner_host = socket.gethostname()
+        self.pinged_db = False
 
     @property
     def runner_options(self) -> RunnerOptions:
@@ -384,8 +392,18 @@ class Runner:
 
         # all the processes will ping the running_runner document to signal
         # that at least one is still active.
+        run_options = dict(
+            transfer=transfer,
+            complete=complete,
+            queue=queue,
+            checkout=checkout,
+        )
+        try:
+            self.ping_running_runner(run_options=run_options)
+        except Exception:
+            logger.exception("Error during initial ping running runner")
         scheduler.every(self.project.runner.delay_ping_db).seconds.do(
-            self.ping_running_runner
+            self.ping_running_runner, run_options=run_options
         )
 
         ticks_remaining: int | bool = True
@@ -1584,10 +1602,35 @@ class Runner:
                     lock.update_on_release = set_output
             batch_manager.delete_run_finished([(job_id, job_index, batch_uid)])
 
-    def ping_running_runner(self):
-        ping_result = self.job_controller.ping_running_runner()
+    def ping_running_runner(self, run_options: dict | None = None):
+        ping_data = {
+            "daemon_id": self.daemon_id,
+            "runner_id": self.runner_id,
+            "project_name": self.project_name,
+            "hostname": self.runner_host,
+            "run_options": run_options,
+            "user": getpass.getuser(),
+            "daemon_dir": self.project.daemon_dir,
+        }
+        ping_result, runner_pings = self.job_controller.ping_running_runner(
+            data=ping_data
+        )
         if not ping_result:
             logger.info("Could not ping the running_runner document")
+
+        # The returned value include the latest ping from this process,
+        # Skip it for the first ping, as older pings may be in the DB.
+        if self.pinged_db and runner_pings and len(runner_pings) > 1:
+            prev_ping = runner_pings[-2]
+            daemon_id = prev_ping.get("daemon_id")
+            # note that here the remote daemon_id could be None, if it was not
+            # set. This would happen for example in case of runner started without
+            # a daemon. Warn anyway, since it can still lead to inconsistencies.
+            if daemon_id != self.daemon_id:
+                msg = f"A ping from a different set of Runner processes was found in the database: {prev_ping}"
+                logger.warning(msg)
+        if runner_pings:
+            self.pinged_db = True
 
     def cleanup(self) -> None:
         """Close all the connections after stopping the Runner."""

--- a/tests/db/cli/test_backup.py
+++ b/tests/db/cli/test_backup.py
@@ -56,7 +56,7 @@ def test_reset(
         required_out = [
             "Backup created",
             "flows collection: 2 documents",
-            "jf_auxiliary collection: 3 documents",
+            "jf_auxiliary collection: 4 documents",
             "jobs collection: 4 documents",
             "batches collection: 0 documents",
         ]
@@ -82,5 +82,5 @@ def test_reset(
         assert job_controller.count_jobs() == 4
         assert job_controller.count_flows() == 2
         aux_docs = list(job_controller.auxiliary.find({}))
-        assert len(aux_docs) == 3
+        assert len(aux_docs) == 4
         assert aux_docs[0]["next_id"] == 5

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -166,6 +166,14 @@ def test_info(
 
     running_runner = job_controller.get_running_runner()
     runner_info = daemon_manager._get_runner_info()
+
+    # wait for the runner to have pinged the DB before proceeding
+    for _ in range(30):
+        if len(job_controller.get_runner_pings()) > 0:
+            break
+    else:
+        raise RuntimeError("The runner did not ping the DB within the allocated time")
+
     ping_data = {
         "daemon_id": runner_info["processes_info"]["supervisord"]["pid"],
         "runner_id": runner_info["processes_info"]["runner_daemon:run_jobflow0"]["pid"],

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -61,7 +61,7 @@ def test_std_operations(
     assert rr_after["start_time"] > rr_before["start_time"]
 
     run_check_cli(
-        ["runner", "stop"],
+        ["runner", "stop-processes"],
         required_out="The stop signal has been sent to the Runner",
     )
 
@@ -75,6 +75,19 @@ def test_std_operations(
 
     run_check_cli(
         ["runner", "shutdown"],
+    )
+
+    wait_daemon_shutdown(daemon_manager)
+
+    run_check_cli(
+        ["runner", "start"],
+    )
+
+    wait_daemon_started(daemon_manager)
+
+    # "stop" means "shutdown", test this as well
+    run_check_cli(
+        ["runner", "stop"],
     )
 
     wait_daemon_shutdown(daemon_manager)
@@ -113,7 +126,7 @@ def test_reset(wait_daemon_started, daemon_manager, job_controller, run_check_cl
     run_check_cli(
         ["runner", "start"],
         required_out=[
-            "A daemon runner process may be running on a different machine",
+            "A daemon runner process associated to this database may be already running",
             "YYYYYYY",
             "jf runner reset",
         ],

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -151,3 +151,97 @@ def test_reset(wait_daemon_started, daemon_manager, job_controller, run_check_cl
 
     wait_daemon_started(daemon_manager)
     assert daemon_manager.check_status().value == "RUNNING"
+
+
+def test_info(
+    wait_daemon_started,
+    wait_daemon_shutdown,
+    daemon_manager,
+    job_controller,
+    run_check_cli,
+):
+    # start the daemon and test the correct behaviour
+    daemon_manager.start(single=True)
+    wait_daemon_started(daemon_manager)
+
+    running_runner = job_controller.get_running_runner()
+    runner_info = daemon_manager._get_runner_info()
+    ping_data = {
+        "daemon_id": runner_info["processes_info"]["supervisord"]["pid"],
+        "runner_id": runner_info["processes_info"]["runner_daemon:run_jobflow0"]["pid"],
+        "project_name": running_runner["project_name"],
+        "hostname": running_runner["hostname"],
+        "run_options": {},
+        "user": running_runner["user"],
+        "daemon_dir": running_runner["daemon_dir"],
+    }
+
+    run_check_cli(
+        ["runner", "info"],
+        required_out=[
+            "supervisord",
+            "runner_daemon",
+            "hostname",
+            running_runner["hostname"],
+        ],
+        excluded_out=[
+            "Daemon is not running",
+            "No running runner defined in the DB",
+            "Runner pings",
+            f"│ {ping_data['hostname']}",
+            "inconsistency",
+        ],
+    )
+
+    run_check_cli(
+        ["runner", "info", "--pings"],
+        required_out=[
+            "supervisord",
+            "runner_daemon",
+            "hostname",
+            running_runner["hostname"],
+            "Runner pings",
+            f"│ {ping_data['hostname']}",
+        ],
+        excluded_out=[
+            "Daemon is not running",
+            "No running runner defined in the DB",
+            "inconsistency",
+        ],
+    )
+
+    # now stop and restart the runner to trigger issues
+    daemon_manager.shut_down()
+    wait_daemon_shutdown(daemon_manager)
+
+    daemon_manager.start(single=True)
+    wait_daemon_started(daemon_manager)
+    job_controller.ping_running_runner(data=ping_data)
+
+    req_out = [
+        "supervisord",
+        "runner_daemon",
+        "hostname",
+        running_runner["hostname"],
+        "inconsistency between the actual runner information and the last ping in the database",
+        f"running under another supervisor process: {ping_data['daemon_id']}",
+    ]
+    excl_out = [
+        "Daemon is not running",
+        "No running runner defined in the DB",
+        "Runner pings",
+        f"│ {ping_data['hostname']}",
+    ]
+    run_check_cli(
+        ["runner", "info"],
+        required_out=req_out,
+        excluded_out=[*excl_out, "active on another machine"],
+    )
+
+    ping_data["hostname"] = "XXXX"
+    job_controller.ping_running_runner(data=ping_data)
+    run_check_cli(
+        ["runner", "info"],
+        required_out=[*req_out, "active on another machine"],
+        excluded_out=excl_out,
+    )

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -160,6 +160,8 @@ def test_info(
     job_controller,
     run_check_cli,
 ):
+    import time
+
     # start the daemon and test the correct behaviour
     daemon_manager.start(single=True)
     wait_daemon_started(daemon_manager)
@@ -169,6 +171,7 @@ def test_info(
 
     # wait for the runner to have pinged the DB before proceeding
     for _ in range(30):
+        time.sleep(1)
         if len(job_controller.get_runner_pings()) > 0:
             break
     else:

--- a/tests/db/jobs/test_daemon.py
+++ b/tests/db/jobs/test_daemon.py
@@ -83,6 +83,11 @@ def test_start_stop(
     wait_daemon_shutdown(daemon_manager)
     assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
 
+    assert daemon_manager.start(raise_on_error=True, single=single)
+    wait_daemon_started(daemon_manager)
+    assert daemon_manager.shut_down(raise_on_error=True, wait=True)
+    assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
+
     processes_info = daemon_manager.get_processes_info()
     assert processes_info is None
 
@@ -205,7 +210,7 @@ def test_runner_different_machine(
     assert daemon_manager.pid_filepath.exists()
     with pytest.raises(
         RunningDaemonError,
-        match=r"A daemon runner process may be running on a different machine",
+        match=r"A daemon runner process associated to this database may be already running",
     ):
         daemon_manager.start(raise_on_error=True, single=False)
     assert daemon_manager.pid_filepath.exists()
@@ -219,7 +224,7 @@ def test_runner_different_machine(
 
     with pytest.raises(
         RunningDaemonError,
-        match=r"A daemon runner process may be running on a different machine",
+        match=r"A daemon runner process associated to this database may be already running",
     ):
         daemon_manager.kill(raise_on_error=True)
     assert daemon_manager.pid_filepath.exists()
@@ -233,7 +238,7 @@ def test_runner_different_machine(
 
     with pytest.raises(
         RunningDaemonError,
-        match=r"A daemon runner process may be running on a different machine",
+        match=r"A daemon runner process associated to this database may be already running",
     ):
         daemon_manager.stop(raise_on_error=True)
     assert daemon_manager.pid_filepath.exists()
@@ -247,7 +252,7 @@ def test_runner_different_machine(
 
     with pytest.raises(
         RunningDaemonError,
-        match=r"A daemon runner process may be running on a different machine",
+        match=r"A daemon runner process associated to this database may be already running",
     ):
         daemon_manager.shut_down(raise_on_error=True)
     assert daemon_manager.pid_filepath.exists()

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1112,6 +1112,15 @@ def test_running_runner(job_controller, daemon_manager, wait_daemon_started):
     assert job_controller.get_running_runner() == "NO_DOCUMENT"
 
 
+def test_runner_pings(job_controller):
+    data = {"test": "XX"}
+    job_controller.ping_running_runner(data=data)
+    job_controller.ping_running_runner(data=data)
+    assert len(job_controller.get_runner_pings()) == 2
+    job_controller.clean_runner_pings()
+    assert len(job_controller.get_runner_pings()) == 0
+
+
 def test_stop_jobflow_resume(job_controller, runner) -> None:
     from jobflow import Flow
 

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1112,13 +1112,20 @@ def test_running_runner(job_controller, daemon_manager, wait_daemon_started):
     assert job_controller.get_running_runner() == "NO_DOCUMENT"
 
 
-def test_runner_pings(job_controller):
+def test_runner_pings(job_controller, monkeypatch):
     data = {"test": "XX"}
-    job_controller.ping_running_runner(data=data)
-    job_controller.ping_running_runner(data=data)
-    assert len(job_controller.get_runner_pings()) == 2
-    job_controller.clean_runner_pings()
-    assert len(job_controller.get_runner_pings()) == 0
+    import jobflow_remote.jobs.jobcontroller
+
+    with monkeypatch.context() as m:
+        m.setattr(jobflow_remote.jobs.jobcontroller, "_MAX_ARCHIVED_RUNNER_PINGS", 3)
+        job_controller.ping_running_runner(data=data)
+        job_controller.ping_running_runner(data=data)
+        assert len(job_controller.get_runner_pings()) == 2
+        for _ in range(3):
+            job_controller.ping_running_runner(data=data)
+        assert len(job_controller.get_runner_pings()) == 3
+        job_controller.clean_runner_pings()
+        assert len(job_controller.get_runner_pings()) == 0
 
 
 def test_stop_jobflow_resume(job_controller, runner) -> None:

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1113,17 +1113,18 @@ def test_running_runner(job_controller, daemon_manager, wait_daemon_started):
 
 
 def test_runner_pings(job_controller, monkeypatch):
-    data = {"test": "XX"}
     import jobflow_remote.jobs.jobcontroller
 
     with monkeypatch.context() as m:
         m.setattr(jobflow_remote.jobs.jobcontroller, "_MAX_ARCHIVED_RUNNER_PINGS", 3)
-        job_controller.ping_running_runner(data=data)
-        job_controller.ping_running_runner(data=data)
+        job_controller.ping_running_runner(data={"test": "1"})
+        job_controller.ping_running_runner(data={"test": "2"})
         assert len(job_controller.get_runner_pings()) == 2
-        for _ in range(3):
-            job_controller.ping_running_runner(data=data)
-        assert len(job_controller.get_runner_pings()) == 3
+        for i in range(3):
+            job_controller.ping_running_runner(data={"test": str(i + 3)})
+        pings = job_controller.get_runner_pings()
+        assert len(pings) == 3
+        assert [d["test"] for d in pings] == ["3", "4", "5"]
         job_controller.clean_runner_pings()
         assert len(job_controller.get_runner_pings()) == 0
 

--- a/tests/db/jobs/test_runner.py
+++ b/tests/db/jobs/test_runner.py
@@ -94,10 +94,14 @@ def test_delay_download(job_controller, runner, monkeypatch, one_job):
 def test_ping_runner_runner(job_controller, runner, monkeypatch, caplog):
     from datetime import datetime
 
-    assert not job_controller.ping_running_runner()
+    pinged_succeed, runner_pings = job_controller.ping_running_runner()
+    assert not pinged_succeed
     runner.ping_running_runner()
     # check that the ping does not create the document
     assert job_controller.get_running_runner() is None
+    # the runner pings are created (only one, because the runner
+    # will not ping the first time runner.ping_running_runner() is called)
+    assert len(runner_pings) == 1
 
     # create a fake running runner document
     t0 = datetime.now()


### PR DESCRIPTION
In light of improving the management of the Runner from the user:
* rewire `jf runner stop` to `jf runner shutdown`. It is still possible to "stop" the runner either with the hidden command `jf runner stop-processes` or with the python API. Internally there is thus still a difference between shutdown and stop. Only the CLI will see them as equivalent. This may cause confusion due to the clash of terms, but should avoid having to deal with both states.
* Improve (hopefully) the error message related to the runner being already active from the DB. I believe several errors may be related to the user not reading or not understanding properly the error message, which may be clear for us, but not for a first time user. The idea here is that the massage focuses only on specifying the relevant information and points to documentation resources about the meaning of the problem and how to deal with it. If this is fine I will add another section to the Runner page that targets explicitly this issue in a concise way (I assume most people will not survive reading all that stuff)