### PR TITLE
Fix dev docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,6 @@ instance/
 doc/_build/
 doc/source/api/*.rst
 
-doc/source/dev/index.rst
 doc/source/changelog.rst
 
 # PyBuilder

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,7 +31,7 @@ from jobflow_remote.config.settings import JobflowRemoteSettings
 # -- Project information -----------------------------------------------------
 
 project = "Jobflow Remote"
-copyright = "2023, Matgenix SRL"  # noqa: A001
+copyright = "2025, Matgenix SRL"  # noqa: A001
 author = "Guido Petretto, Matthew Evans, David Waroquiers"
 
 
@@ -116,11 +116,11 @@ html_theme_options = {
         "image_dark": "_static/img/jfr_logo.svg",
     },
     "collapse_navigation": True,
-    "announcement": (
-        "<p>"
-        "Jobflow Remote is still in beta phase. The API may change at any time."
-        "</p>"
-    ),
+    # "announcement": (
+    #     "<p>"
+    #     "Jobflow Remote is still in beta phase. The API may change at any time."
+    #     "</p>"
+    # ),
     # "announcement": "<p>This is still in development</p>",
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
     # "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],

--- a/doc/source/dev/cliplugin.rst
+++ b/doc/source/dev/cliplugin.rst
@@ -58,12 +58,12 @@ Create a module (e.g., ``my_package/jf_plugin.py``) with a ``setup_jf_plugin`` f
         This function should import typer apps and register commands.
         """
         from jobflow_remote.cli.job import app_job
-        import typer
+        from jobflow_remote.cli.utils import out_console
 
         @app_job.command()
         def my_command():
             """My custom command added to 'jf job' group."""
-            typer.echo("Hello from my plugin!")
+            out_console.print("Hello from my plugin!")
 
 This example adds a ``my-command`` to the ``jf job`` command group, accessible as:
 
@@ -81,7 +81,7 @@ You can also create entirely new command groups:
     def setup_jf_plugin():
         from jobflow_remote.cli.jf import app
         from jobflow_remote.cli.jfr_typer import JFRTyper
-        import typer
+        from jobflow_remote.cli.utils import out_console
 
         # Create a new command group
         app_backup = JFRTyper(
@@ -93,12 +93,12 @@ You can also create entirely new command groups:
         @app_backup.command()
         def create():
             """Create a backup."""
-            typer.echo("Creating backup...")
+            out_console.print("Creating backup...")
 
         @app_backup.command()
         def restore():
             """Restore from backup."""
-            typer.echo("Restoring backup...")
+            out_console.print("Restoring backup...")
 
         # Register the new command group
         app.add_typer(app_backup)

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -1,0 +1,17 @@
+.. _dev:
+
+##############################
+Jobflow Remote developer guide
+##############################
+
+This part of the guide contains information for developers of jobflow-remote
+and related packages. If you wish to contribute, you can check the
+`GitHub repository <https://github.com/Matgenix/jobflow-remote>`_ and follow
+the contributing guidelines at :ref:`contributing`.
+
+.. toctree::
+   :caption: Developer guide
+   :maxdepth: 1
+
+   devinstall
+   cliplugin


### PR DESCRIPTION
The `dev/index.rst` was excluded as it was in `.gitignore`. This should fix the missing development section.

Also removed the banner stating that jobflow-remote is in beta version, as next release will be 1.0.
