### PR TITLE
qtoolkit 0.1.7

### DIFF
--- a/doc/source/user/tuning.rst
+++ b/doc/source/user/tuning.rst
@@ -116,10 +116,22 @@ a suitable submission script.
 
 .. note::
 
-    There are `SLURM <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.slurm.html>`_
-    and `PBS <https://matgenix.github.io/qtoolkit/api/qtoolkit.io.pbs.html>`_
-    specific keywords that can be passed to ``submit_flow`` to use the
-    respective queueing system commands.
+    If relying on the specific queueing system keywords, the values that can be
+    passed are those present in the `templates defined in qtoolkit <https://matgenix.github.io/qtoolkit/user/resources.html#scheduler-templates>`_
+    Given the large number of options usually available for each scheduler, the
+    templates for each scheduler only contains a subset of the available options.
+    However, in each of the templates it is possible to pass a ``qverbatim`` option
+    that will be added to the header as is, allowing to pass any scheduler-specific option.
+    For example, in the case of a Slurm scheduler:
+
+    .. code-block:: python
+
+        options = {
+            "partition": "standard",
+            "qverbatim": "#SBATCH --tmp=10G\n#SBATCH --nice=100",
+        }
+        script = slurm_io.get_submission_script(commands="echo 'Hello'", options=options)
+
 
 How to tune
 ===========

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,7 +3,7 @@ pydantic==2.12.5
 pymongo==4.10.1
 fabric==3.2.2
 tomlkit==0.13.3
-qtoolkit==0.1.6
+qtoolkit==0.1.7
 typer==0.21.1
 rich==14.2.0
 psutil==7.2.1


### PR DESCRIPTION
bump qtoolkit to 0.1.7 to check that all tests pass and update the documentation to point qtk templates