### PR TITLE
Update release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         token: ${{ secrets.ORG_RELEASE_PAT_BOT }}
         branch: ${{ env.PUBLISH_UPDATE_BRANCH }}
         unprotect_reviews: true
-        sleep: 15
+        pre_sleep: 15
         force: true
         tags: true
 
@@ -112,6 +112,13 @@ jobs:
         gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check repository status
+      run: |
+        git status
+        git rev-parse HEAD
+        git tag --list
+        git rev-parse "${GITHUB_REF#refs/tags/}"
 
     - name: Build source distribution
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "jobflow-remote"
 description = "Jobflow Remote is a Python package to run jobflow workflows on remote resources"
 readme = "README.md"
 keywords = []
-license = { text = "modified BSD" }
+license = "BSD-3-Clause"
 authors = [{ name = "Guido Petretto", email = "guido.petretto@matgenix.com" }]
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
Small updates to the release action and configuration:
* license in pyproject.toml should comply to new format: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
* in the `CasperWA/push-protected@v2` action the `sleep` keyword is deprecated in favor of `pre_sleep`: https://github.com/CasperWA/push-protected?tab=readme-ov-file#deprecated-inputs
* adding some checks to try to debug the release failure (to be removed afterwards)