### PR TITLE
Shutdown all runners

### DIFF
--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -247,14 +247,25 @@ def stop_processes(
             ),
         ),
     ] = None,
+    max_wait: Annotated[
+        int,
+        typer.Option(
+            "--max-wait",
+            "-m",
+            help=(
+                "Maximum time in seconds to wait for the runner to stop when --wait is set. "
+                "0 means wait indefinitely."
+            ),
+        ),
+    ] = 120,
 ) -> None:
     """
     Send a stop signal to the Runner processes.
     Each of the Runner processes will stop when finished the task being executed.
     By default, return immediately.
     """
+    cm = get_config_manager()
     if all_projects:
-        cm = get_config_manager()
         stop_projects = []
         daemon_managers = {}
         with loading_spinner(processing=False) as progress:
@@ -267,7 +278,7 @@ def stop_processes(
                     if current_status not in (
                         DaemonStatus.SHUT_DOWN,
                         DaemonStatus.SHUTTING_DOWN,
-                        DaemonStatus,
+                        DaemonStatus.STOPPING,
                         DaemonStatus.STOPPED,
                     ):
                         dm.stop(raise_on_error=True, wait=False)
@@ -280,7 +291,6 @@ def stop_processes(
 
             if wait:
                 stopped_missing = set(stop_projects)
-                max_wait = 120
                 t0 = time.time()
                 while stopped_missing:
                     for project_name in list(stopped_missing):
@@ -295,7 +305,7 @@ def stop_processes(
                                 f"Error while checking runner for project {project_name}",
                                 exc_info=True,
                             )
-                    if time.time() - t0 > max_wait:
+                    if max_wait and time.time() - t0 > max_wait:
                         break
                     time.sleep(2)
 
@@ -319,7 +329,6 @@ def stop_processes(
         out_console.print(msg)
 
     else:
-        cm = get_config_manager()
         dm = DaemonManager.from_project(cm.get_project())
         stop_sent = False
         with loading_spinner(processing=False) as progress:
@@ -373,12 +382,23 @@ def stop(
             ),
         ),
     ] = None,
+    max_wait: Annotated[
+        int,
+        typer.Option(
+            "--max-wait",
+            "-m",
+            help=(
+                "Maximum time in seconds to wait for the runner to shut down when --wait is set. "
+                "0 means wait indefinitely."
+            ),
+        ),
+    ] = 120,
 ) -> None:
     """
     Shuts down the supervisord process.
     Note that the supervisord process will stop after all the runner processes have finished.
     """
-    shutdown(wait=wait, all_projects=all_projects, json_out=json_out)
+    shutdown(wait=wait, all_projects=all_projects, json_out=json_out, max_wait=max_wait)
 
 
 @app_runner.command()
@@ -433,13 +453,24 @@ def shutdown(
             ),
         ),
     ] = None,
+    max_wait: Annotated[
+        int,
+        typer.Option(
+            "--max-wait",
+            "-m",
+            help=(
+                "Maximum time in seconds to wait for the runner to shut down when --wait is set. "
+                "0 means wait indefinitely."
+            ),
+        ),
+    ] = 120,
 ) -> None:
     """
     Shuts down the supervisord process.
     Note that the supervisord process will stop after all the runner processes have finished
     """
+    cm = get_config_manager()
     if all_projects:
-        cm = get_config_manager()
         shutdown_projects = []
         daemon_managers = {}
         with loading_spinner(processing=False) as progress:
@@ -464,7 +495,6 @@ def shutdown(
 
             if wait:
                 shutdown_missing = set(shutdown_projects)
-                max_wait = 120
                 t0 = time.time()
                 while shutdown_missing:
                     for project_name in list(shutdown_missing):
@@ -479,13 +509,13 @@ def shutdown(
                                 f"Error while checking runner for project {project_name}",
                                 exc_info=True,
                             )
-                    if time.time() - t0 > max_wait:
+                    if max_wait and time.time() - t0 > max_wait:
                         break
                     time.sleep(2)
 
                 if shutdown_missing:
                     exit_with_error_msg(
-                        "Not all the runners stopped within the allocated time. "
+                        "Not all the runners shut down within the allocated time. "
                         f"Not shut-down: {shutdown_missing}. "
                         f"Shut-down: {set(shutdown_projects).difference(shutdown_missing)}"
                     )
@@ -503,7 +533,6 @@ def shutdown(
         out_console.print(msg)
 
     else:
-        cm = get_config_manager()
         dm = DaemonManager.from_project(cm.get_project())
         with loading_spinner(processing=False) as progress:
             progress.add_task(description="Shutting down supervisor...", total=None)

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -58,6 +58,145 @@ _running_daemon_error_msg = (
 )
 
 
+def _stop_runners(
+    wait: bool,
+    all_projects: bool,
+    json_out: str | None,
+    max_wait: int,
+    dm_method_name: str,
+    skip_action_statuses: tuple[DaemonStatus, ...],
+    completed_statuses: tuple[DaemonStatus, ...],
+    target_status: DaemonStatus,
+    action_name: str,
+    done_label: str,
+) -> None:
+    """
+    Shared implementation for the stopping the runners.
+
+    Parameters
+    ----------
+    wait
+        If True, poll until each affected runner reaches ``target_status``.
+    all_projects
+        If True, iterate over every configured project; otherwise act on the
+        currently selected project only.
+    json_out
+        Optional file path to dump the list of affected project names as JSON.
+    max_wait
+        Maximum time in seconds to wait when ``wait`` is True (0 = forever).
+    dm_method_name
+        Name of the ``DaemonManager`` method that issues the action
+        (e.g. ``"stop"`` or ``"shut_down"``).
+    skip_action_statuses
+        Statuses for which the action should NOT be issued (already complete
+        or in progress).
+    completed_statuses
+        Statuses considered fully terminal; projects in one of these are not
+        appended to the result list.
+    target_status
+        Status to poll for when ``wait`` is True.
+    action_name
+        Gerund describing the action (e.g. ``"stopping"`` or
+        ``"shutting down"``), used in spinner descriptions, per-project
+        warnings, single-project error messages, and the timeout message.
+    done_label
+        Label for completed projects in the timeout breakdown (e.g. ``"Stopped"``);
+        the "not done" counterpart is derived as ``f"Not {done_label.lower()}"``,
+        and the all-projects success summary uses the lowercased form too.
+    """
+    cm = get_config_manager()
+    if all_projects:
+        done_projects: list[str] = []
+        daemon_managers: dict[str, DaemonManager] = {}
+        with loading_spinner(processing=False) as progress:
+            progress.add_task(
+                description=f"{action_name.capitalize()} all runners...", total=None
+            )
+            for project_name in cm.projects_data:
+                try:
+                    dm = DaemonManager.from_project_name(project_name=project_name)
+                    daemon_managers[project_name] = dm
+                    current_status = dm.check_status(raise_on_shutdown=False)
+                    if current_status not in skip_action_statuses:
+                        getattr(dm, dm_method_name)(raise_on_error=True, wait=False)
+                    if current_status not in completed_statuses:
+                        done_projects.append(project_name)
+                except Exception:
+                    logger.warning(
+                        f"Error while checking or {action_name} runner for project {project_name}",
+                        exc_info=True,
+                    )
+
+            if wait:
+                pending = set(done_projects)
+                t0 = time.time()
+                while pending:
+                    for project_name in list(pending):
+                        try:
+                            current_status = daemon_managers[project_name].check_status(
+                                raise_on_shutdown=False
+                            )
+                            if current_status == target_status:
+                                pending.remove(project_name)
+                        except Exception:
+                            logger.warning(
+                                f"Error while checking runner for project {project_name}",
+                                exc_info=True,
+                            )
+                    if max_wait and time.time() - t0 > max_wait:
+                        break
+                    time.sleep(2)
+
+                if pending:
+                    exit_with_error_msg(
+                        f"Not all the runners finished {action_name} within the allocated time. "
+                        f"Not {done_label.lower()}: {pending}. "
+                        f"{done_label}: {set(done_projects).difference(pending)}"
+                    )
+
+        if json_out:
+            dumpfn(done_projects, json_out, fmt="json")
+
+        if not done_projects:
+            exit_with_warning_msg("No active runner found for any (parsable) project")
+
+        msg = Text.from_markup(
+            f"The runners for the following projects have been {done_label.lower()}:\n"
+            + "\n".join(f"- {pn}" for pn in done_projects)
+        )
+        out_console.print(msg)
+
+    else:
+        dm = DaemonManager.from_project(cm.get_project())
+        action_result = None
+        with loading_spinner(processing=False) as progress:
+            progress.add_task(
+                description=f"{action_name.capitalize()} the runner...", total=None
+            )
+            try:
+                action_result = getattr(dm, dm_method_name)(
+                    raise_on_error=True, wait=wait
+                )
+            except RunningDaemonError as e:
+                exit_with_error_msg(
+                    f"Error while {action_name} the runner:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                )
+            except DaemonError as e:
+                exit_with_error_msg(
+                    f"Error while {action_name} the runner: {getattr(e, 'message', e)}"
+                )
+
+        if action_result and not wait:
+            from jobflow_remote import SETTINGS
+
+            if SETTINGS.cli_suggestions:
+                msg = (
+                    f"The {dm_method_name} signal has been sent to the Runner. "
+                    f"Run 'jf runner status' to verify if it {done_label.lower()}"
+                )
+                out_console.print(msg, style="yellow")
+
+
 @app_runner.command()
 def run(
     log_level: log_level_opt = LogLevel.INFO,
@@ -264,92 +403,28 @@ def stop_processes(
     Each of the Runner processes will stop when finished the task being executed.
     By default, return immediately.
     """
-    cm = get_config_manager()
-    if all_projects:
-        stop_projects = []
-        daemon_managers = {}
-        with loading_spinner(processing=False) as progress:
-            progress.add_task(description="Stopping all runners...", total=None)
-            for project_name in cm.projects_data:
-                try:
-                    dm = DaemonManager.from_project_name(project_name=project_name)
-                    daemon_managers[project_name] = dm
-                    current_status = dm.check_status(raise_on_shutdown=False)
-                    if current_status not in (
-                        DaemonStatus.SHUT_DOWN,
-                        DaemonStatus.SHUTTING_DOWN,
-                        DaemonStatus.STOPPING,
-                        DaemonStatus.STOPPED,
-                    ):
-                        dm.stop(raise_on_error=True, wait=False)
-                        stop_projects.append(project_name)
-                except Exception:
-                    logger.warning(
-                        f"Error while checking or stopping runner for project {project_name}",
-                        exc_info=True,
-                    )
-
-            if wait:
-                stopped_missing = set(stop_projects)
-                t0 = time.time()
-                while stopped_missing:
-                    for project_name in list(stopped_missing):
-                        try:
-                            current_status = daemon_managers[project_name].check_status(
-                                raise_on_shutdown=False
-                            )
-                            if current_status == DaemonStatus.STOPPED:
-                                stopped_missing.remove(project_name)
-                        except Exception:
-                            logger.warning(
-                                f"Error while checking runner for project {project_name}",
-                                exc_info=True,
-                            )
-                    if max_wait and time.time() - t0 > max_wait:
-                        break
-                    time.sleep(2)
-
-                if stopped_missing:
-                    exit_with_error_msg(
-                        "Not all the runners stopped within the allocated time. "
-                        f"Not stopped: {stopped_missing}. "
-                        f"Stopped: {set(stop_projects).difference(stopped_missing)}"
-                    )
-
-        if json_out:
-            dumpfn(stop_projects, json_out, fmt="json")
-
-        if not stop_projects:
-            exit_with_warning_msg("No active runner found for any (parsable) project")
-
-        msg = Text.from_markup(
-            "The runners for the following projects have been stopped:\n"
-            + "\n".join(f"- {pn}" for pn in stop_projects)
-        )
-        out_console.print(msg)
-
-    else:
-        dm = DaemonManager.from_project(cm.get_project())
-        stop_sent = False
-        with loading_spinner(processing=False) as progress:
-            progress.add_task(description="Stopping the daemon...", total=None)
-            try:
-                stop_sent = dm.stop(wait=wait, raise_on_error=True)
-            except RunningDaemonError as e:
-                exit_with_error_msg(
-                    f"Error while stopping the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
-                )
-            except DaemonError as e:
-                exit_with_error_msg(
-                    f"Error while stopping the daemon: {getattr(e, 'message', e)}"
-                )
-        from jobflow_remote import SETTINGS
-
-        if stop_sent and not wait and SETTINGS.cli_suggestions:
-            out_console.print(
-                "The stop signal has been sent to the Runner. Run 'jf runner status' to verify if it stopped",
-                style="yellow",
-            )
+    _stop_runners(
+        wait=wait,
+        all_projects=all_projects,
+        json_out=json_out,
+        max_wait=max_wait,
+        dm_method_name="stop",
+        skip_action_statuses=(
+            DaemonStatus.SHUT_DOWN,
+            DaemonStatus.SHUTTING_DOWN,
+            DaemonStatus.STOPPING,
+            DaemonStatus.STOPPED,
+        ),
+        completed_statuses=(
+            DaemonStatus.SHUT_DOWN,
+            DaemonStatus.SHUTTING_DOWN,
+            DaemonStatus.STOPPING,
+            DaemonStatus.STOPPED,
+        ),
+        target_status=DaemonStatus.STOPPED,
+        action_name="stopping",
+        done_label="Stopped",
+    )
 
 
 @app_runner.command()
@@ -402,25 +477,61 @@ def stop(
 
 
 @app_runner.command()
-def kill() -> None:
+def kill(
+    wait: Annotated[
+        bool,
+        typer.Option(
+            "--wait",
+            "-w",
+            help=("Wait until the runner processes have been killed."),
+        ),
+    ] = False,
+    all_projects: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help=("Kill the runner for all the projects"),
+        ),
+    ] = False,
+    json_out: Annotated[
+        str | None,
+        typer.Option(
+            "--json",
+            "-j",
+            help=(
+                "if --all dump the list of killed runners in json format to a file at this path"
+            ),
+        ),
+    ] = None,
+    max_wait: Annotated[
+        int,
+        typer.Option(
+            "--max-wait",
+            "-m",
+            help=(
+                "Maximum time in seconds to wait for the runner to be killed when --wait is set. "
+                "0 means wait indefinitely."
+            ),
+        ),
+    ] = 120,
+) -> None:
     """
     Send a kill signal to the Runner processes.
-    Return immediately, does not wait for processes to be killed.
+    By default, return immediately and do not wait for processes to be killed.
     """
-    cm = get_config_manager()
-    dm = DaemonManager.from_project(cm.get_project())
-    with loading_spinner(processing=False) as progress:
-        progress.add_task(description="Killing the daemon...", total=None)
-        try:
-            dm.kill(raise_on_error=True)
-        except RunningDaemonError as e:
-            exit_with_error_msg(
-                f"Error while killing the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
-            )
-        except DaemonError as e:
-            exit_with_error_msg(
-                f"Error while killing the daemon: {getattr(e, 'message', e)}"
-            )
+    _stop_runners(
+        wait=wait,
+        all_projects=all_projects,
+        json_out=json_out,
+        max_wait=max_wait,
+        dm_method_name="kill",
+        skip_action_statuses=(DaemonStatus.SHUT_DOWN, DaemonStatus.STOPPED),
+        completed_statuses=(DaemonStatus.SHUT_DOWN, DaemonStatus.STOPPED),
+        target_status=DaemonStatus.STOPPED,
+        action_name="killing",
+        done_label="Killed",
+    )
 
 
 @app_runner.command()
@@ -469,83 +580,21 @@ def shutdown(
     Shuts down the supervisord process.
     Note that the supervisord process will stop after all the runner processes have finished
     """
-    cm = get_config_manager()
-    if all_projects:
-        shutdown_projects = []
-        daemon_managers = {}
-        with loading_spinner(processing=False) as progress:
-            progress.add_task(description="Shutting down all runners...", total=None)
-            for project_name in cm.projects_data:
-                try:
-                    dm = DaemonManager.from_project_name(project_name=project_name)
-                    daemon_managers[project_name] = dm
-                    current_status = dm.check_status(raise_on_shutdown=False)
-                    if current_status not in (
-                        DaemonStatus.SHUT_DOWN,
-                        DaemonStatus.SHUTTING_DOWN,
-                    ):
-                        dm.shut_down(raise_on_error=True, wait=False)
-                    if current_status != DaemonStatus.SHUT_DOWN:
-                        shutdown_projects.append(project_name)
-                except Exception:
-                    logger.warning(
-                        f"Error while checking or shutting down runner for project {project_name}",
-                        exc_info=True,
-                    )
-
-            if wait:
-                shutdown_missing = set(shutdown_projects)
-                t0 = time.time()
-                while shutdown_missing:
-                    for project_name in list(shutdown_missing):
-                        try:
-                            current_status = daemon_managers[project_name].check_status(
-                                raise_on_shutdown=False
-                            )
-                            if current_status == DaemonStatus.SHUT_DOWN:
-                                shutdown_missing.remove(project_name)
-                        except Exception:
-                            logger.warning(
-                                f"Error while checking runner for project {project_name}",
-                                exc_info=True,
-                            )
-                    if max_wait and time.time() - t0 > max_wait:
-                        break
-                    time.sleep(2)
-
-                if shutdown_missing:
-                    exit_with_error_msg(
-                        "Not all the runners shut down within the allocated time. "
-                        f"Not shut-down: {shutdown_missing}. "
-                        f"Shut-down: {set(shutdown_projects).difference(shutdown_missing)}"
-                    )
-
-        if json_out:
-            dumpfn(shutdown_projects, json_out, fmt="json")
-
-        if not shutdown_projects:
-            exit_with_warning_msg("No active runner found for any (parsable) project")
-
-        msg = Text.from_markup(
-            "The runners for the following projects have been shut-down:\n"
-            + "\n".join(f"- {pn}" for pn in shutdown_projects)
-        )
-        out_console.print(msg)
-
-    else:
-        dm = DaemonManager.from_project(cm.get_project())
-        with loading_spinner(processing=False) as progress:
-            progress.add_task(description="Shutting down supervisor...", total=None)
-            try:
-                dm.shut_down(raise_on_error=True, wait=wait)
-            except RunningDaemonError as e:
-                exit_with_error_msg(
-                    f"Error while shutting down supervisor:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
-                )
-            except DaemonError as e:
-                exit_with_error_msg(
-                    f"Error while shutting down supervisor: {getattr(e, 'message', e)}"
-                )
+    _stop_runners(
+        wait=wait,
+        all_projects=all_projects,
+        json_out=json_out,
+        max_wait=max_wait,
+        dm_method_name="shut_down",
+        skip_action_statuses=(
+            DaemonStatus.SHUT_DOWN,
+            DaemonStatus.SHUTTING_DOWN,
+        ),
+        completed_statuses=(DaemonStatus.SHUT_DOWN,),
+        target_status=DaemonStatus.SHUT_DOWN,
+        action_name="shutting down",
+        done_label="Shut-down",
+    )
 
 
 @app_runner.command()

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -1,8 +1,11 @@
 import datetime
+import logging
 import os
+import time
 from typing import Annotated
 
 import typer
+from monty.serialization import dumpfn
 from rich.prompt import Confirm
 from rich.scope import render_scope
 from rich.table import Table
@@ -37,6 +40,9 @@ from jobflow_remote.jobs.daemon import (
 )
 from jobflow_remote.jobs.runner import Runner
 from jobflow_remote.utils.data import convert_utc_time
+
+logger = logging.getLogger(__name__)
+
 
 app_runner = JFRTyper(
     name="runner", help="Commands for handling the Runner", no_args_is_help=True
@@ -223,34 +229,118 @@ def stop_processes(
             ),
         ),
     ] = False,
+    all_projects: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help=("Stop the runner for all the projects"),
+        ),
+    ] = False,
+    json_out: Annotated[
+        str | None,
+        typer.Option(
+            "--json",
+            "-j",
+            help=(
+                "if --all dump the list of stopped runners in json format to a file at this path"
+            ),
+        ),
+    ] = None,
 ) -> None:
     """
     Send a stop signal to the Runner processes.
     Each of the Runner processes will stop when finished the task being executed.
     By default, return immediately.
     """
-    cm = get_config_manager()
-    dm = DaemonManager.from_project(cm.get_project())
-    stop_sent = False
-    with loading_spinner(processing=False) as progress:
-        progress.add_task(description="Stopping the daemon...", total=None)
-        try:
-            stop_sent = dm.stop(wait=wait, raise_on_error=True)
-        except RunningDaemonError as e:
-            exit_with_error_msg(
-                f"Error while stopping the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
-            )
-        except DaemonError as e:
-            exit_with_error_msg(
-                f"Error while stopping the daemon: {getattr(e, 'message', e)}"
-            )
-    from jobflow_remote import SETTINGS
+    if all_projects:
+        cm = get_config_manager()
+        stop_projects = []
+        daemon_managers = {}
+        with loading_spinner(processing=False) as progress:
+            progress.add_task(description="Stopping all runners...", total=None)
+            for project_name in cm.projects_data:
+                try:
+                    dm = DaemonManager.from_project_name(project_name=project_name)
+                    daemon_managers[project_name] = dm
+                    current_status = dm.check_status(raise_on_shutdown=False)
+                    if current_status not in (
+                        DaemonStatus.SHUT_DOWN,
+                        DaemonStatus.SHUTTING_DOWN,
+                        DaemonStatus,
+                        DaemonStatus.STOPPED,
+                    ):
+                        dm.stop(raise_on_error=True, wait=False)
+                        stop_projects.append(project_name)
+                except Exception:
+                    logger.warning(
+                        f"Error while checking or stopping runner for project {project_name}",
+                        exc_info=True,
+                    )
 
-    if stop_sent and not wait and SETTINGS.cli_suggestions:
-        out_console.print(
-            "The stop signal has been sent to the Runner. Run 'jf runner status' to verify if it stopped",
-            style="yellow",
+            if wait:
+                stopped_missing = set(stop_projects)
+                max_wait = 120
+                t0 = time.time()
+                while stopped_missing:
+                    for project_name in list(stopped_missing):
+                        try:
+                            current_status = daemon_managers[project_name].check_status(
+                                raise_on_shutdown=False
+                            )
+                            if current_status == DaemonStatus.STOPPED:
+                                stopped_missing.remove(project_name)
+                        except Exception:
+                            logger.warning(
+                                f"Error while checking runner for project {project_name}",
+                                exc_info=True,
+                            )
+                    if time.time() - t0 > max_wait:
+                        break
+                    time.sleep(2)
+
+                if stopped_missing:
+                    exit_with_error_msg(
+                        "Not all the runners stopped within the allocated time. "
+                        f"Not stopped: {stopped_missing}. "
+                        f"Stopped: {set(stop_projects).difference(stopped_missing)}"
+                    )
+
+        if json_out:
+            dumpfn(stop_projects, json_out, fmt="json")
+
+        if not stop_projects:
+            exit_with_warning_msg("No active runner found for any (parsable) project")
+
+        msg = Text.from_markup(
+            "The runners for the following projects have been stopped:\n"
+            + "\n".join(f"- {pn}" for pn in stop_projects)
         )
+        out_console.print(msg)
+
+    else:
+        cm = get_config_manager()
+        dm = DaemonManager.from_project(cm.get_project())
+        stop_sent = False
+        with loading_spinner(processing=False) as progress:
+            progress.add_task(description="Stopping the daemon...", total=None)
+            try:
+                stop_sent = dm.stop(wait=wait, raise_on_error=True)
+            except RunningDaemonError as e:
+                exit_with_error_msg(
+                    f"Error while stopping the daemon:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                )
+            except DaemonError as e:
+                exit_with_error_msg(
+                    f"Error while stopping the daemon: {getattr(e, 'message', e)}"
+                )
+        from jobflow_remote import SETTINGS
+
+        if stop_sent and not wait and SETTINGS.cli_suggestions:
+            out_console.print(
+                "The stop signal has been sent to the Runner. Run 'jf runner status' to verify if it stopped",
+                style="yellow",
+            )
 
 
 @app_runner.command()
@@ -261,16 +351,34 @@ def stop(
             "--wait",
             "-w",
             help=(
-                "Wait until the daemon has stopped. NOTE: this may take a while if a large file is being transferred!"
+                "Wait until the daemon has shut down. NOTE: this may take a while if a large file is being transferred!"
             ),
         ),
     ] = False,
+    all_projects: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help=("Shutdown the runner for all the projects"),
+        ),
+    ] = False,
+    json_out: Annotated[
+        str | None,
+        typer.Option(
+            "--json",
+            "-j",
+            help=(
+                "if --all dump the list of shutdown runners in json format to a file at this path"
+            ),
+        ),
+    ] = None,
 ) -> None:
     """
     Shuts down the supervisord process.
     Note that the supervisord process will stop after all the runner processes have finished.
     """
-    shutdown(wait=wait)
+    shutdown(wait=wait, all_projects=all_projects, json_out=json_out)
 
 
 @app_runner.command()
@@ -307,25 +415,108 @@ def shutdown(
             ),
         ),
     ] = False,
+    all_projects: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            "-a",
+            help=("Shutdown the runner for all the projects"),
+        ),
+    ] = False,
+    json_out: Annotated[
+        str | None,
+        typer.Option(
+            "--json",
+            "-j",
+            help=(
+                "if --all dump the list of shutdown runners in json format to a file at this path"
+            ),
+        ),
+    ] = None,
 ) -> None:
     """
     Shuts down the supervisord process.
     Note that the supervisord process will stop after all the runner processes have finished
     """
-    cm = get_config_manager()
-    dm = DaemonManager.from_project(cm.get_project())
-    with loading_spinner(processing=False) as progress:
-        progress.add_task(description="Shutting down supervisor...", total=None)
-        try:
-            dm.shut_down(raise_on_error=True, wait=wait)
-        except RunningDaemonError as e:
-            exit_with_error_msg(
-                f"Error while shutting down supervisor:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
-            )
-        except DaemonError as e:
-            exit_with_error_msg(
-                f"Error while shutting down supervisor: {getattr(e, 'message', e)}"
-            )
+    if all_projects:
+        cm = get_config_manager()
+        shutdown_projects = []
+        daemon_managers = {}
+        with loading_spinner(processing=False) as progress:
+            progress.add_task(description="Shutting down all runners...", total=None)
+            for project_name in cm.projects_data:
+                try:
+                    dm = DaemonManager.from_project_name(project_name=project_name)
+                    daemon_managers[project_name] = dm
+                    current_status = dm.check_status(raise_on_shutdown=False)
+                    if current_status not in (
+                        DaemonStatus.SHUT_DOWN,
+                        DaemonStatus.SHUTTING_DOWN,
+                    ):
+                        dm.shut_down(raise_on_error=True, wait=False)
+                    if current_status != DaemonStatus.SHUT_DOWN:
+                        shutdown_projects.append(project_name)
+                except Exception:
+                    logger.warning(
+                        f"Error while checking or shutting down runner for project {project_name}",
+                        exc_info=True,
+                    )
+
+            if wait:
+                shutdown_missing = set(shutdown_projects)
+                max_wait = 120
+                t0 = time.time()
+                while shutdown_missing:
+                    for project_name in list(shutdown_missing):
+                        try:
+                            current_status = daemon_managers[project_name].check_status(
+                                raise_on_shutdown=False
+                            )
+                            if current_status == DaemonStatus.SHUT_DOWN:
+                                shutdown_missing.remove(project_name)
+                        except Exception:
+                            logger.warning(
+                                f"Error while checking runner for project {project_name}",
+                                exc_info=True,
+                            )
+                    if time.time() - t0 > max_wait:
+                        break
+                    time.sleep(2)
+
+                if shutdown_missing:
+                    exit_with_error_msg(
+                        "Not all the runners stopped within the allocated time. "
+                        f"Not shut-down: {shutdown_missing}. "
+                        f"Shut-down: {set(shutdown_projects).difference(shutdown_missing)}"
+                    )
+
+        if json_out:
+            dumpfn(shutdown_projects, json_out, fmt="json")
+
+        if not shutdown_projects:
+            exit_with_warning_msg("No active runner found for any (parsable) project")
+
+        msg = Text.from_markup(
+            "The runners for the following projects have been shut-down:\n"
+            + "\n".join(f"- {pn}" for pn in shutdown_projects)
+        )
+        out_console.print(msg)
+
+    else:
+        cm = get_config_manager()
+        dm = DaemonManager.from_project(cm.get_project())
+        with loading_spinner(processing=False) as progress:
+            progress.add_task(description="Shutting down supervisor...", total=None)
+            try:
+                dm.shut_down(raise_on_error=True, wait=wait)
+            except RunningDaemonError as e:
+                exit_with_error_msg(
+                    f"Error while shutting down supervisor:\n{getattr(e, 'message', e)}{_running_daemon_error_msg}"
+                )
+            except DaemonError as e:
+                exit_with_error_msg(
+                    f"Error while shutting down supervisor: {getattr(e, 'message', e)}"
+                )
 
 
 @app_runner.command()

--- a/src/jobflow_remote/jobs/daemon.py
+++ b/src/jobflow_remote/jobs/daemon.py
@@ -781,7 +781,22 @@ class DaemonManager:
 
         return None
 
-    def kill(self, raise_on_error: bool = False) -> bool:
+    def kill(self, raise_on_error: bool = False, wait: bool = False) -> bool:
+        """
+        Kill the processes daemon.
+
+        Parameters
+        ----------
+        wait
+            If True wait until the processes have been killed.
+        raise_on_error
+            Raise an exception if the processes cannot be killed.
+
+        Returns
+        -------
+        bool
+            True if the processes were killed successfully, False otherwise.
+        """
         with self.lock_runner_doc() as lock:
             doc_error = self._check_running_runner(
                 lock.locked_document, raise_on_error=raise_on_error
@@ -822,6 +837,21 @@ class DaemonManager:
 
                 if error is None:
                     lock.update_on_release = {"$set": {"running_runner": None}}
+                    if wait:
+                        while True:
+                            time.sleep(1)
+                            try:
+                                current_status = self.check_status(
+                                    raise_on_shutdown=False
+                                )
+                            except Exception as exc:
+                                if raise_on_error:
+                                    raise DaemonError(
+                                        "Error while waiting for the daemon to be killed"
+                                    ) from exc
+                                return False
+                            if current_status == DaemonStatus.STOPPED:
+                                break
                 return error is None
 
         raise DaemonError(f"Daemon status {status} could not be handled")

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -1,3 +1,6 @@
+import pytest
+
+
 def test_std_operations(
     wait_daemon_started,
     wait_daemon_stopped,
@@ -258,7 +261,16 @@ def test_info(
     )
 
 
-def test_stop_all_runners(
+@pytest.mark.parametrize(
+    ("subcommand", "started_suffix", "final_status_name"),
+    [
+        ("stop-processes", "_2", "STOPPED"),
+        ("shutdown", "_1", "SHUT_DOWN"),
+        ("kill", "_2", "STOPPED"),
+    ],
+    ids=["stop", "shutdown", "kill"],
+)
+def test_all_runners_termination(
     job_controller,
     wait_daemon_started,
     run_check_cli,
@@ -266,43 +278,51 @@ def test_stop_all_runners(
     daemon_manager,
     tmp_dir,
     random_project_name,
+    subcommand,
+    started_suffix,
+    final_status_name,
 ):
     from monty.serialization import loadfn
 
     from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
 
-    jc1, pn1 = create_tmp_project(suffix="_1")
-    jc2, pn2 = create_tmp_project(suffix="_2")
-    dm1 = DaemonManager.from_project_name(pn1)
-    dm2 = DaemonManager.from_project_name(pn2)
+    final_status = DaemonStatus[final_status_name]
+    unstarted_suffix = "_1" if started_suffix == "_2" else "_2"
+    _, pn_started = create_tmp_project(suffix=started_suffix)
+    _, pn_unstarted = create_tmp_project(suffix=unstarted_suffix)
+    dm_started = DaemonManager.from_project_name(pn_started)
+    dm_unstarted = DaemonManager.from_project_name(pn_unstarted)
 
     daemon_manager.start()
-    dm2.start()
-
+    dm_started.start()
     wait_daemon_started(daemon_manager)
-    wait_daemon_started(dm2)
+    wait_daemon_started(dm_started)
 
+    assert dm_unstarted.check_status() == DaemonStatus.SHUT_DOWN
+
+    json_path = tmp_dir / "affected_proj.json"
     run_check_cli(
-        [
-            "runner",
-            "stop-processes",
-            "--all",
-            "--wait",
-            "--json",
-            tmp_dir / "stopped_proj.json",
-        ],
-        required_out=[random_project_name, f"{random_project_name}_2"],
-        excluded_out=f"{random_project_name}_1",
+        ["runner", subcommand, "--all", "--wait", "--json", json_path],
+        required_out=[random_project_name, pn_started],
+        excluded_out=pn_unstarted,
     )
 
-    assert daemon_manager.check_status() == DaemonStatus.STOPPED
-    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
-    assert dm2.check_status() == DaemonStatus.STOPPED
-    stopped_set = set(loadfn(tmp_dir / "stopped_proj.json"))
-    assert stopped_set == {random_project_name, f"{random_project_name}_2"}
+    assert daemon_manager.check_status() == final_status
+    assert dm_started.check_status() == final_status
+    assert dm_unstarted.check_status() == DaemonStatus.SHUT_DOWN
+    assert set(loadfn(json_path)) == {random_project_name, pn_started}
 
 
-def test_shutdown_all_runners(
+@pytest.mark.parametrize(
+    ("subcommand", "patched_method_name", "action_name", "final_status_name"),
+    [
+        ("stop-processes", "stop", "stopping", "STOPPED"),
+        ("shutdown", "shut_down", "shutting down", "SHUT_DOWN"),
+        ("kill", "kill", "killing", "STOPPED"),
+    ],
+    ids=["stop", "shutdown", "kill"],
+)
+def test_all_runners_termination_with_error(
     job_controller,
     wait_daemon_started,
     run_check_cli,
@@ -310,51 +330,10 @@ def test_shutdown_all_runners(
     daemon_manager,
     tmp_dir,
     random_project_name,
-):
-    from monty.serialization import loadfn
-
-    from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
-
-    jc1, pn1 = create_tmp_project(suffix="_1")
-    jc2, pn2 = create_tmp_project(suffix="_2")
-    dm1 = DaemonManager.from_project_name(pn1)
-    dm2 = DaemonManager.from_project_name(pn2)
-
-    daemon_manager.start()
-    dm1.start()
-    wait_daemon_started(daemon_manager)
-    wait_daemon_started(dm1)
-
-    assert dm2.check_status() == DaemonStatus.SHUT_DOWN
-
-    run_check_cli(
-        [
-            "runner",
-            "shutdown",
-            "--all",
-            "--wait",
-            "--json",
-            tmp_dir / "shutdown_proj.json",
-        ],
-        required_out=[random_project_name, f"{random_project_name}_1"],
-        excluded_out=f"{random_project_name}_2",
-    )
-
-    assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
-    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
-    assert dm2.check_status() == DaemonStatus.SHUT_DOWN
-    shutdown_set = set(loadfn(tmp_dir / "shutdown_proj.json"))
-    assert shutdown_set == {random_project_name, f"{random_project_name}_1"}
-
-
-def test_stop_all_runners_with_error(
-    job_controller,
-    wait_daemon_started,
-    run_check_cli,
-    create_tmp_project,
-    daemon_manager,
-    tmp_dir,
-    random_project_name,
+    subcommand,
+    patched_method_name,
+    action_name,
+    final_status_name,
 ):
     from unittest.mock import Mock, patch
 
@@ -362,8 +341,9 @@ def test_stop_all_runners_with_error(
 
     from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
 
-    jc1, pn1 = create_tmp_project(suffix="_1")
-    jc2, pn2 = create_tmp_project(suffix="_2")
+    final_status = DaemonStatus[final_status_name]
+    _, pn1 = create_tmp_project(suffix="_1")
+    _, pn2 = create_tmp_project(suffix="_2")
     dm1 = DaemonManager.from_project_name(pn1)
     dm2 = DaemonManager.from_project_name(pn2)
 
@@ -375,131 +355,55 @@ def test_stop_all_runners_with_error(
     wait_daemon_started(dm1)
     wait_daemon_started(dm2)
 
-    original_stop = DaemonManager.stop
+    original_method = getattr(DaemonManager, patched_method_name)
+    error_project = pn1
 
-    def stop_with_error(self, **kwargs):
-        if self.project.name == pn1:
-            raise RuntimeError(f"Simulated stop error for project {pn1}")
-        return original_stop(self, **kwargs)
+    def with_error(self, **kwargs):
+        if self.project.name == error_project:
+            raise RuntimeError(f"Simulated test error for project {error_project}")
+        return original_method(self, **kwargs)
 
-    with patch.object(DaemonManager, "stop", stop_with_error):
+    json_path = tmp_dir / "affected_proj_err.json"
+
+    with patch.object(DaemonManager, patched_method_name, with_error):
         run_check_cli(
             [
                 "runner",
-                "stop-processes",
+                subcommand,
                 "--all",
                 "--wait",
                 "--json",
-                tmp_dir / "stopped_proj_err.json",
+                json_path,
             ],
             required_out=[
                 f"- {random_project_name}",
-                f"- {random_project_name}_2",
-                f"Simulated stop error for project {random_project_name}_1",
+                f"- {pn2}",
+                f"Simulated test error for project {error_project}",
             ],
         )
 
-    assert daemon_manager.check_status() == DaemonStatus.STOPPED
-    # dm1 was not stopped due to the error; restart by the fixture teardown is fine
-    assert dm2.check_status() == DaemonStatus.STOPPED
-    stopped_set = set(loadfn(tmp_dir / "stopped_proj_err.json"))
-    assert stopped_set == {random_project_name, f"{random_project_name}_2"}
-    assert pn1 not in stopped_set
+    assert daemon_manager.check_status() == final_status
+    assert dm2.check_status() == final_status
+    # dm1 was not affected due to the error
+    affected_set = set(loadfn(json_path))
+    assert affected_set == {random_project_name, pn2}
+    assert pn1 not in affected_set
 
-    # Test timeout: dm1 is still running; mock stop so the daemon stays
+    # Test timeout: dm1 is still running; mock the action so the daemon stays
     # alive while the wait loop polls check_status, triggering the max-wait timeout.
-    with patch.object(DaemonManager, "stop", Mock(return_value=True)):
+    with patch.object(DaemonManager, patched_method_name, Mock(return_value=True)):
         run_check_cli(
             [
                 "runner",
-                "stop-processes",
+                subcommand,
                 "--all",
                 "--wait",
                 "--max-wait",
                 "1",
             ],
             required_out=[
-                "Not all the runners stopped within the allocated time",
-                f"{random_project_name}_1",
-            ],
-            error=True,
-        )
-
-
-def test_shutdown_all_runners_with_error(
-    job_controller,
-    wait_daemon_started,
-    run_check_cli,
-    create_tmp_project,
-    daemon_manager,
-    tmp_dir,
-    random_project_name,
-):
-    from unittest.mock import Mock, patch
-
-    from monty.serialization import loadfn
-
-    from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
-
-    jc1, pn1 = create_tmp_project(suffix="_1")
-    jc2, pn2 = create_tmp_project(suffix="_2")
-    dm1 = DaemonManager.from_project_name(pn1)
-    dm2 = DaemonManager.from_project_name(pn2)
-
-    daemon_manager.start()
-    dm1.start()
-    dm2.start()
-
-    wait_daemon_started(daemon_manager)
-    wait_daemon_started(dm1)
-    wait_daemon_started(dm2)
-
-    original_shut_down = DaemonManager.shut_down
-
-    def shut_down_with_error(self, **kwargs):
-        if self.project.name == pn2:
-            raise RuntimeError(f"Simulated shutdown error for project {pn2}")
-        return original_shut_down(self, **kwargs)
-
-    with patch.object(DaemonManager, "shut_down", shut_down_with_error):
-        run_check_cli(
-            [
-                "runner",
-                "shutdown",
-                "--all",
-                "--wait",
-                "--json",
-                tmp_dir / "shutdown_proj_err.json",
-            ],
-            required_out=[
-                f"- {random_project_name}",
-                f"- {random_project_name}_1",
-                f"Simulated shutdown error for project {random_project_name}_2",
-            ],
-        )
-
-    assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
-    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
-    # dm2 was not shut down due to the error
-    shutdown_set = set(loadfn(tmp_dir / "shutdown_proj_err.json"))
-    assert shutdown_set == {random_project_name, f"{random_project_name}_1"}
-    assert pn2 not in shutdown_set
-
-    # Test timeout: dm1 is still running; mock shutdown so the daemon stays
-    # alive while the wait loop polls check_status, triggering the max-wait timeout.
-    with patch.object(DaemonManager, "shut_down", Mock(return_value=True)):
-        run_check_cli(
-            [
-                "runner",
-                "shutdown",
-                "--all",
-                "--wait",
-                "--max-wait",
-                "1",
-            ],
-            required_out=[
-                "Not all the runners shut down within the allocated time",
-                f"{random_project_name}_2",
+                f"Not all the runners finished {action_name} within the allocated time",
+                pn1,
             ],
             error=True,
         )

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -277,6 +277,50 @@ def test_stop_all_runners(
     dm2 = DaemonManager.from_project_name(pn2)
 
     daemon_manager.start()
+    dm2.start()
+
+    wait_daemon_started(daemon_manager)
+    wait_daemon_started(dm2)
+
+    run_check_cli(
+        [
+            "runner",
+            "stop-processes",
+            "--all",
+            "--wait",
+            "--json",
+            tmp_dir / "stopped_proj.json",
+        ],
+        required_out=[random_project_name, f"{random_project_name}_2"],
+        excluded_out=f"{random_project_name}_1",
+    )
+
+    assert daemon_manager.check_status() == DaemonStatus.STOPPED
+    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
+    assert dm2.check_status() == DaemonStatus.STOPPED
+    stopped_set = set(loadfn(tmp_dir / "stopped_proj.json"))
+    assert stopped_set == {random_project_name, f"{random_project_name}_2"}
+
+
+def test_shutdown_all_runners(
+    job_controller,
+    wait_daemon_started,
+    run_check_cli,
+    crete_tmp_project,
+    daemon_manager,
+    tmp_dir,
+    random_project_name,
+):
+    from monty.serialization import loadfn
+
+    from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
+
+    jc1, pn1 = crete_tmp_project(suffix="_1")
+    jc2, pn2 = crete_tmp_project(suffix="_2")
+    dm1 = DaemonManager.from_project_name(pn1)
+    dm2 = DaemonManager.from_project_name(pn2)
+
+    daemon_manager.start()
     dm1.start()
     wait_daemon_started(daemon_manager)
     wait_daemon_started(dm1)
@@ -302,27 +346,160 @@ def test_stop_all_runners(
     shutdown_set = set(loadfn(tmp_dir / "shutdown_proj.json"))
     assert shutdown_set == {random_project_name, f"{random_project_name}_1"}
 
+
+def test_stop_all_runners_with_error(
+    job_controller,
+    wait_daemon_started,
+    run_check_cli,
+    crete_tmp_project,
+    daemon_manager,
+    tmp_dir,
+    random_project_name,
+):
+    from unittest.mock import Mock, patch
+
+    from monty.serialization import loadfn
+
+    from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
+
+    jc1, pn1 = crete_tmp_project(suffix="_1")
+    jc2, pn2 = crete_tmp_project(suffix="_2")
+    dm1 = DaemonManager.from_project_name(pn1)
+    dm2 = DaemonManager.from_project_name(pn2)
+
     daemon_manager.start()
+    dm1.start()
     dm2.start()
 
     wait_daemon_started(daemon_manager)
+    wait_daemon_started(dm1)
     wait_daemon_started(dm2)
 
-    run_check_cli(
-        [
-            "runner",
-            "stop-processes",
-            "--all",
-            "--wait",
-            "--json",
-            tmp_dir / "stopped_proj.json",
-        ],
-        required_out=[random_project_name, f"{random_project_name}_2"],
-        excluded_out=f"{random_project_name}_1",
-    )
+    original_stop = DaemonManager.stop
+
+    def stop_with_error(self, **kwargs):
+        if self.project.name == pn1:
+            raise RuntimeError(f"Simulated stop error for project {pn1}")
+        return original_stop(self, **kwargs)
+
+    with patch.object(DaemonManager, "stop", stop_with_error):
+        run_check_cli(
+            [
+                "runner",
+                "stop-processes",
+                "--all",
+                "--wait",
+                "--json",
+                tmp_dir / "stopped_proj_err.json",
+            ],
+            required_out=[
+                f"- {random_project_name}",
+                f"- {random_project_name}_2",
+                f"Simulated stop error for project {random_project_name}_1",
+            ],
+        )
 
     assert daemon_manager.check_status() == DaemonStatus.STOPPED
-    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
+    # dm1 was not stopped due to the error; restart by the fixture teardown is fine
     assert dm2.check_status() == DaemonStatus.STOPPED
-    stopped_set = set(loadfn(tmp_dir / "stopped_proj.json"))
+    stopped_set = set(loadfn(tmp_dir / "stopped_proj_err.json"))
     assert stopped_set == {random_project_name, f"{random_project_name}_2"}
+    assert pn1 not in stopped_set
+
+    # Test timeout: dm1 is still running; mock stop so the daemon stays
+    # alive while the wait loop polls check_status, triggering the max-wait timeout.
+    with patch.object(DaemonManager, "stop", Mock(return_value=True)):
+        run_check_cli(
+            [
+                "runner",
+                "stop-processes",
+                "--all",
+                "--wait",
+                "--max-wait",
+                "1",
+            ],
+            required_out=[
+                "Not all the runners stopped within the allocated time",
+                f"{random_project_name}_1",
+            ],
+            error=True,
+        )
+
+
+def test_shutdown_all_runners_with_error(
+    job_controller,
+    wait_daemon_started,
+    run_check_cli,
+    crete_tmp_project,
+    daemon_manager,
+    tmp_dir,
+    random_project_name,
+):
+    from unittest.mock import Mock, patch
+
+    from monty.serialization import loadfn
+
+    from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
+
+    jc1, pn1 = crete_tmp_project(suffix="_1")
+    jc2, pn2 = crete_tmp_project(suffix="_2")
+    dm1 = DaemonManager.from_project_name(pn1)
+    dm2 = DaemonManager.from_project_name(pn2)
+
+    daemon_manager.start()
+    dm1.start()
+    dm2.start()
+
+    wait_daemon_started(daemon_manager)
+    wait_daemon_started(dm1)
+    wait_daemon_started(dm2)
+
+    original_shut_down = DaemonManager.shut_down
+
+    def shut_down_with_error(self, **kwargs):
+        if self.project.name == pn2:
+            raise RuntimeError(f"Simulated shutdown error for project {pn2}")
+        return original_shut_down(self, **kwargs)
+
+    with patch.object(DaemonManager, "shut_down", shut_down_with_error):
+        run_check_cli(
+            [
+                "runner",
+                "shutdown",
+                "--all",
+                "--wait",
+                "--json",
+                tmp_dir / "shutdown_proj_err.json",
+            ],
+            required_out=[
+                f"- {random_project_name}",
+                f"- {random_project_name}_1",
+                f"Simulated shutdown error for project {random_project_name}_2",
+            ],
+        )
+
+    assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
+    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
+    # dm2 was not shut down due to the error
+    shutdown_set = set(loadfn(tmp_dir / "shutdown_proj_err.json"))
+    assert shutdown_set == {random_project_name, f"{random_project_name}_1"}
+    assert pn2 not in shutdown_set
+
+    # Test timeout: dm1 is still running; mock shutdown so the daemon stays
+    # alive while the wait loop polls check_status, triggering the max-wait timeout.
+    with patch.object(DaemonManager, "shut_down", Mock(return_value=True)):
+        run_check_cli(
+            [
+                "runner",
+                "shutdown",
+                "--all",
+                "--wait",
+                "--max-wait",
+                "1",
+            ],
+            required_out=[
+                "Not all the runners shut down within the allocated time",
+                f"{random_project_name}_2",
+            ],
+            error=True,
+        )

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -262,7 +262,7 @@ def test_stop_all_runners(
     job_controller,
     wait_daemon_started,
     run_check_cli,
-    crete_tmp_project,
+    create_tmp_project,
     daemon_manager,
     tmp_dir,
     random_project_name,
@@ -271,8 +271,8 @@ def test_stop_all_runners(
 
     from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
 
-    jc1, pn1 = crete_tmp_project(suffix="_1")
-    jc2, pn2 = crete_tmp_project(suffix="_2")
+    jc1, pn1 = create_tmp_project(suffix="_1")
+    jc2, pn2 = create_tmp_project(suffix="_2")
     dm1 = DaemonManager.from_project_name(pn1)
     dm2 = DaemonManager.from_project_name(pn2)
 
@@ -306,7 +306,7 @@ def test_shutdown_all_runners(
     job_controller,
     wait_daemon_started,
     run_check_cli,
-    crete_tmp_project,
+    create_tmp_project,
     daemon_manager,
     tmp_dir,
     random_project_name,
@@ -315,8 +315,8 @@ def test_shutdown_all_runners(
 
     from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
 
-    jc1, pn1 = crete_tmp_project(suffix="_1")
-    jc2, pn2 = crete_tmp_project(suffix="_2")
+    jc1, pn1 = create_tmp_project(suffix="_1")
+    jc2, pn2 = create_tmp_project(suffix="_2")
     dm1 = DaemonManager.from_project_name(pn1)
     dm2 = DaemonManager.from_project_name(pn2)
 
@@ -351,7 +351,7 @@ def test_stop_all_runners_with_error(
     job_controller,
     wait_daemon_started,
     run_check_cli,
-    crete_tmp_project,
+    create_tmp_project,
     daemon_manager,
     tmp_dir,
     random_project_name,
@@ -362,8 +362,8 @@ def test_stop_all_runners_with_error(
 
     from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
 
-    jc1, pn1 = crete_tmp_project(suffix="_1")
-    jc2, pn2 = crete_tmp_project(suffix="_2")
+    jc1, pn1 = create_tmp_project(suffix="_1")
+    jc2, pn2 = create_tmp_project(suffix="_2")
     dm1 = DaemonManager.from_project_name(pn1)
     dm2 = DaemonManager.from_project_name(pn2)
 
@@ -430,7 +430,7 @@ def test_shutdown_all_runners_with_error(
     job_controller,
     wait_daemon_started,
     run_check_cli,
-    crete_tmp_project,
+    create_tmp_project,
     daemon_manager,
     tmp_dir,
     random_project_name,
@@ -441,8 +441,8 @@ def test_shutdown_all_runners_with_error(
 
     from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
 
-    jc1, pn1 = crete_tmp_project(suffix="_1")
-    jc2, pn2 = crete_tmp_project(suffix="_2")
+    jc1, pn1 = create_tmp_project(suffix="_1")
+    jc2, pn2 = create_tmp_project(suffix="_2")
     dm1 = DaemonManager.from_project_name(pn1)
     dm2 = DaemonManager.from_project_name(pn2)
 

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -256,3 +256,73 @@ def test_info(
         required_out=[*req_out, "active on another machine"],
         excluded_out=excl_out,
     )
+
+
+def test_stop_all_runners(
+    job_controller,
+    wait_daemon_started,
+    run_check_cli,
+    crete_tmp_project,
+    daemon_manager,
+    tmp_dir,
+    random_project_name,
+):
+    from monty.serialization import loadfn
+
+    from jobflow_remote.jobs.daemon import DaemonManager, DaemonStatus
+
+    jc1, pn1 = crete_tmp_project(suffix="_1")
+    jc2, pn2 = crete_tmp_project(suffix="_2")
+    dm1 = DaemonManager.from_project_name(pn1)
+    dm2 = DaemonManager.from_project_name(pn2)
+
+    daemon_manager.start()
+    dm1.start()
+    wait_daemon_started(daemon_manager)
+    wait_daemon_started(dm1)
+
+    assert dm2.check_status() == DaemonStatus.SHUT_DOWN
+
+    run_check_cli(
+        [
+            "runner",
+            "shutdown",
+            "--all",
+            "--wait",
+            "--json",
+            tmp_dir / "shutdown_proj.json",
+        ],
+        required_out=[random_project_name, f"{random_project_name}_1"],
+        excluded_out=f"{random_project_name}_2",
+    )
+
+    assert daemon_manager.check_status() == DaemonStatus.SHUT_DOWN
+    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
+    assert dm2.check_status() == DaemonStatus.SHUT_DOWN
+    shutdown_set = set(loadfn(tmp_dir / "shutdown_proj.json"))
+    assert shutdown_set == {random_project_name, f"{random_project_name}_1"}
+
+    daemon_manager.start()
+    dm2.start()
+
+    wait_daemon_started(daemon_manager)
+    wait_daemon_started(dm2)
+
+    run_check_cli(
+        [
+            "runner",
+            "stop-processes",
+            "--all",
+            "--wait",
+            "--json",
+            tmp_dir / "stopped_proj.json",
+        ],
+        required_out=[random_project_name, f"{random_project_name}_2"],
+        excluded_out=f"{random_project_name}_1",
+    )
+
+    assert daemon_manager.check_status() == DaemonStatus.STOPPED
+    assert dm1.check_status() == DaemonStatus.SHUT_DOWN
+    assert dm2.check_status() == DaemonStatus.STOPPED
+    stopped_set = set(loadfn(tmp_dir / "stopped_proj.json"))
+    assert stopped_set == {random_project_name, f"{random_project_name}_2"}

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -187,7 +187,7 @@ def write_project_conf(mongoclient, project_name, database_name, tmp_proj_dir, w
 
 
 @pytest.fixture()
-def crete_tmp_project(
+def create_tmp_project(
     random_project_name,
     store_database_name,
     mongoclient,

--- a/tests/db/conftest.py
+++ b/tests/db/conftest.py
@@ -80,14 +80,28 @@ def write_tmp_settings(
     os.environ["JFREMOTE_CONFIG_FILE"] = _get_random_name(length=10) + ".json"
     # This import must come after setting the env vars as jobflow loads the default
     # config on import
+    write_project_conf(
+        mongoclient, random_project_name, store_database_name, tmp_proj_dir, workdir
+    )
+
+    # In some cases it seems that the SETTINGS have already been imported
+    # and thus not taking the new configurations into account.
+    # Regenerate the JobflowRemoteSettings after setting paths and project
+    import jobflow_remote
+    from jobflow_remote.config.settings import JobflowRemoteSettings
+
+    jobflow_remote.SETTINGS = JobflowRemoteSettings()
+
+
+def write_project_conf(mongoclient, project_name, database_name, tmp_proj_dir, workdir):
     from jobflow_remote.config import Project
 
     project = Project(
-        name=random_project_name,
+        name=project_name,
         jobstore={
             "docs_store": {
                 "type": "MongoStore",
-                "database": store_database_name,
+                "database": database_name,
                 "host": mongoclient.HOST,
                 "port": mongoclient.PORT,
                 "collection_name": "docs",
@@ -95,7 +109,7 @@ def write_tmp_settings(
             "additional_stores": {
                 "big_data": {
                     "type": "GridFSStore",
-                    "database": store_database_name,
+                    "database": database_name,
                     "host": mongoclient.HOST,
                     "port": mongoclient.PORT,
                     "collection_name": "data",
@@ -105,7 +119,7 @@ def write_tmp_settings(
         queue={
             "store": {
                 "type": "MongoStore",
-                "database": store_database_name,
+                "database": database_name,
                 "host": mongoclient.HOST,
                 "port": mongoclient.PORT,
                 "collection_name": "jobs",
@@ -138,7 +152,7 @@ def write_tmp_settings(
                 max_jobs=4,
             ),
         },
-        exec_config={"test": {"export": {"TESTING_ENV_VAR": random_project_name}}},
+        exec_config={"test": {"export": {"TESTING_ENV_VAR": project_name}}},
         runner=dict(
             delay_checkout=1,
             delay_check_run_status=1,
@@ -150,7 +164,7 @@ def write_tmp_settings(
             "other_jobstore": {
                 "docs_store": {
                     "type": "MongoStore",
-                    "database": store_database_name,
+                    "database": database_name,
                     "host": mongoclient.HOST,
                     "port": mongoclient.PORT,
                     "collection_name": "other_docs",
@@ -158,7 +172,7 @@ def write_tmp_settings(
                 "additional_stores": {
                     "big_data": {
                         "type": "GridFSStore",
-                        "database": store_database_name,
+                        "database": database_name,
                         "host": mongoclient.HOST,
                         "port": mongoclient.PORT,
                         "collection_name": "other_data",
@@ -168,16 +182,60 @@ def write_tmp_settings(
         },
     )
     project_json = project.model_dump_json(indent=2)
-    with open(tmp_proj_dir / f"{random_project_name}.json", "w") as f:
+    with open(tmp_proj_dir / f"{project_name}.json", "w") as f:
         f.write(project_json)
 
-    # In some cases it seems that the SETTINGS have already been imported
-    # and thus not taking the new configurations into account.
-    # Regenerate the JobflowRemoteSettings after setting paths and project
-    import jobflow_remote
-    from jobflow_remote.config.settings import JobflowRemoteSettings
 
-    jobflow_remote.SETTINGS = JobflowRemoteSettings()
+@pytest.fixture()
+def crete_tmp_project(
+    random_project_name,
+    store_database_name,
+    mongoclient,
+    tmp_proj_work_dirs,
+    wait_daemon_shutdown,
+):
+    from jobflow_remote import JobController
+    from jobflow_remote.jobs.daemon import DaemonManager
+
+    project_names = []
+    database_names = []
+    tmp_proj_dir, workdir = tmp_proj_work_dirs
+
+    def create_with_suffix(suffix):
+        project_name = random_project_name + suffix
+        database_name = store_database_name + suffix
+        project_names.append(project_name)
+        database_names.append(database_name)
+        write_project_conf(
+            mongoclient=mongoclient,
+            project_name=project_name,
+            database_name=database_name,
+            tmp_proj_dir=tmp_proj_dir,
+            workdir=workdir,
+        )
+        jc = JobController.from_project_name(project_name)
+        jc.reset()
+        return jc, project_name
+
+    try:
+        yield create_with_suffix
+    finally:
+        for pn in project_names:
+            try:
+                dm = DaemonManager.from_project_name(pn)
+                dm.shut_down()
+                wait_daemon_shutdown(dm)
+            except Exception:
+                pass
+            try:
+                (tmp_proj_dir / f"{pn}.json").unlink(missing_ok=True)
+            except Exception:
+                pass
+        for dn in database_names:
+            try:
+                mongoclient.drop_database(dn)
+            except Exception:
+                pass
 
 
 @pytest.fixture()

--- a/tests/db/jobs/test_daemon.py
+++ b/tests/db/jobs/test_daemon.py
@@ -107,6 +107,11 @@ def test_kill(job_controller, daemon_manager, wait_daemon_started) -> None:
     time.sleep(1)
     assert daemon_manager.check_status() == DaemonStatus.STOPPED
 
+    assert daemon_manager.start(raise_on_error=True)
+    wait_daemon_started(daemon_manager)
+    assert daemon_manager.kill(raise_on_error=True, wait=True)
+    assert daemon_manager.check_status() == DaemonStatus.STOPPED
+
 
 def test_kill_supervisord(job_controller, daemon_manager, wait_daemon_started) -> None:
     import signal


### PR DESCRIPTION
Adding an option to shutdown all the runners in the projects folder. 
Useful in light of backups to be performed. So also adding an option to dump the list of shutdown runners, so that they can be restarted afterward.

Posting it as draft as I would like to test it in the backup procedure before merging, but so that can already be reviewed if needed. 