### PR TITLE
New SeparatedTransferHost that accommodates SFTP-disabled submission nodes

### DIFF
--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -382,17 +382,14 @@ class ConnectionData(BaseModel):
         return connect_kwargs
 
 
-class RemoteWorker(WorkerBase):
+class BaseRemoteWorker(WorkerBase):
     """
-    Worker representing a remote host reached through an SSH connection.
+    Base class for workers that connect to remote hosts via SSH.
 
-    Uses a Fabric Connection. Check Fabric documentation for more details on the
-    options defining a Connection.
+    Contains all common SSH connection attributes. Subclasses must define
+    their own `type` field and implement `get_host()`.
     """
 
-    type: Literal["remote"] = Field(
-        "remote", description="The discriminator field to determine the worker type"
-    )
     host: str = Field(description="The host to which to connect")
     user: str | None = Field(None, description="Login username")
     port: int | None = Field(None, description="Port number")
@@ -439,6 +436,31 @@ class RemoteWorker(WorkerBase):
         default=False,
         description="Whether the authentication to the host should be interactive",
     )
+
+    def _get_connect_kwargs(self) -> dict:
+        """Build connect_kwargs dict with password/key/passphrase merged in."""
+        connect_kwargs = dict(self.connect_kwargs) if self.connect_kwargs else {}
+        if self.password:
+            connect_kwargs["password"] = self.password
+        if self.key_filename:
+            connect_kwargs["key_filename"] = self.key_filename
+        if self.passphrase:
+            connect_kwargs["passphrase"] = self.passphrase
+        return connect_kwargs
+
+
+class RemoteWorker(BaseRemoteWorker):
+    """
+    Worker representing a remote host reached through an SSH connection.
+
+    Uses a Fabric Connection. Check Fabric documentation for more details on the
+    options defining a Connection.
+    """
+
+    type: Literal["remote"] = Field(
+        "remote", description="The discriminator field to determine the worker type"
+    )
+
     def get_host(self) -> BaseHost:
         """
         Return the RemoteHost for this worker.
@@ -448,14 +470,6 @@ class RemoteWorker(WorkerBase):
         RemoteHost
             The RemoteHost instance for this worker.
         """
-        connect_kwargs = dict(self.connect_kwargs) if self.connect_kwargs else {}
-        if self.password:
-            connect_kwargs["password"] = self.password
-        if self.key_filename:
-            connect_kwargs["key_filename"] = self.key_filename
-        if self.passphrase:
-            connect_kwargs["passphrase"] = self.passphrase
-
         return RemoteHost(
             host=self.host,
             user=self.user,
@@ -463,7 +477,7 @@ class RemoteWorker(WorkerBase):
             gateway=self.gateway,
             forward_agent=self.forward_agent,
             connect_timeout=self.connect_timeout,
-            connect_kwargs=connect_kwargs,
+            connect_kwargs=self._get_connect_kwargs(),
             inline_ssh_env=self.inline_ssh_env,
             timeout_execute=self.timeout_execute,
             keepalive=self.keepalive,
@@ -490,7 +504,7 @@ class RemoteWorker(WorkerBase):
         )
 
 
-class SeparatedTransferWorker(RemoteWorker):
+class SeparatedTransferWorker(BaseRemoteWorker):
     """
     Worker with separate hosts for commands and file transfers.
 
@@ -526,13 +540,7 @@ class SeparatedTransferWorker(RemoteWorker):
         """
         from jobflow_remote.remote.host import SeparatedTransferHost
 
-        connect_kwargs = dict(self.connect_kwargs) if self.connect_kwargs else {}
-        if self.password:
-            connect_kwargs["password"] = self.password
-        if self.key_filename:
-            connect_kwargs["key_filename"] = self.key_filename
-        if self.passphrase:
-            connect_kwargs["passphrase"] = self.passphrase
+        connect_kwargs = self._get_connect_kwargs()
 
         command_host = RemoteHost(
             host=self.host,
@@ -850,7 +858,7 @@ class Project(BaseModel):
         True if any of the workers have interactive_login set to True.
         """
         for worker in self.workers.values():
-            if isinstance(worker, RemoteWorker) and worker.interactive_login:
+            if isinstance(worker, BaseRemoteWorker) and worker.interactive_login:
                 return True
         return False
 

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -439,27 +439,93 @@ class RemoteWorker(WorkerBase):
         default=False,
         description="Whether the authentication to the host should be interactive",
     )
-    transfer: ConnectionData | None = Field(
-        None,
-        description="Connection data for a separate file transfer host. Use this when "
-        "the main host has SFTP disabled but a dedicated transfer node is available "
-        "(e.g., HPC systems with separate login and data transfer nodes). File "
-        "operations (put/get) will use this connection while commands use the main host.",
+    def get_host(self) -> BaseHost:
+        """
+        Return the RemoteHost for this worker.
+
+        Returns
+        -------
+        RemoteHost
+            The RemoteHost instance for this worker.
+        """
+        connect_kwargs = dict(self.connect_kwargs) if self.connect_kwargs else {}
+        if self.password:
+            connect_kwargs["password"] = self.password
+        if self.key_filename:
+            connect_kwargs["key_filename"] = self.key_filename
+        if self.passphrase:
+            connect_kwargs["passphrase"] = self.passphrase
+
+        return RemoteHost(
+            host=self.host,
+            user=self.user,
+            port=self.port,
+            gateway=self.gateway,
+            forward_agent=self.forward_agent,
+            connect_timeout=self.connect_timeout,
+            connect_kwargs=connect_kwargs,
+            inline_ssh_env=self.inline_ssh_env,
+            timeout_execute=self.timeout_execute,
+            keepalive=self.keepalive,
+            shell_cmd=self.shell_cmd,
+            login_shell=self.login_shell,
+            interactive_login=self.interactive_login,
+            sanitize=self.sanitize_command,
+        )
+
+    @property
+    def cli_info(self) -> dict:
+        """
+        Short information about the worker to be displayed in the command line
+        interface.
+
+        Returns
+        -------
+        A dictionary with the Worker short information.
+        """
+        return dict(
+            host=self.host,
+            scheduler_type=self.scheduler_type,
+            work_dir=self.work_dir,
+        )
+
+
+class SeparatedTransferWorker(RemoteWorker):
+    """
+    Worker with separate hosts for commands and file transfers.
+
+    This is useful for HPC systems where login nodes have SFTP disabled but a
+    dedicated data transfer node is available (e.g., LRC at LBNL).
+
+    Command execution goes through the main host connection, while file operations
+    (put, get, mkdir, etc.) go through the transfer host.
+    """
+
+    type: Literal["separated_transfer"] = Field(
+        "separated_transfer",
+        description="The discriminator field to determine the worker type",
+    )
+    transfer: ConnectionData = Field(
+        description="Connection data for the file transfer host. Use this when "
+        "the main host has SFTP disabled but a dedicated transfer node is available. "
+        "File operations (put/get) will use this connection while commands use the "
+        "main host.",
     )
 
     def get_host(self) -> BaseHost:
         """
-        Return the Host for this worker.
+        Return a SeparatedTransferHost for this worker.
 
-        If a transfer host is configured, returns a SeparatedTransferHost that
-        delegates commands to the main host and file operations to the transfer host.
-        Otherwise, returns a standard RemoteHost.
+        Creates a host that delegates commands to the main connection and file
+        operations to the transfer connection.
 
         Returns
         -------
-        BaseHost
-            The host instance for this worker.
+        SeparatedTransferHost
+            The host instance with separate command and transfer connections.
         """
+        from jobflow_remote.remote.host import SeparatedTransferHost
+
         connect_kwargs = dict(self.connect_kwargs) if self.connect_kwargs else {}
         if self.password:
             connect_kwargs["password"] = self.password
@@ -484,12 +550,6 @@ class RemoteWorker(WorkerBase):
             interactive_login=self.interactive_login,
             sanitize=self.sanitize_command,
         )
-
-        if self.transfer is None:
-            return command_host
-
-        # Create separate transfer host
-        from jobflow_remote.remote.host import SeparatedTransferHost
 
         transfer_connect_kwargs = self.transfer.get_connect_kwargs()
         if not transfer_connect_kwargs:
@@ -521,21 +581,24 @@ class RemoteWorker(WorkerBase):
     @property
     def cli_info(self) -> dict:
         """
-        Short information about the worker to be displayed in the command line
-        interface.
+        Short information about the worker to be displayed in the CLI.
 
         Returns
         -------
-        A dictionary with the Worker short information.
+        dict
+            A dictionary with the Worker short information.
         """
         return dict(
             host=self.host,
+            transfer_host=self.transfer.host,
             scheduler_type=self.scheduler_type,
             work_dir=self.work_dir,
         )
 
 
-WorkerConfig = Annotated[LocalWorker | RemoteWorker, Field(discriminator="type")]
+WorkerConfig = Annotated[
+    LocalWorker | RemoteWorker | SeparatedTransferWorker, Field(discriminator="type")
+]
 
 
 class ExecutionConfig(BaseModel):

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -439,14 +439,26 @@ class RemoteWorker(WorkerBase):
         default=False,
         description="Whether the authentication to the host should be interactive",
     )
+    transfer: ConnectionData | None = Field(
+        None,
+        description="Connection data for a separate file transfer host. Use this when "
+        "the main host has SFTP disabled but a dedicated transfer node is available "
+        "(e.g., HPC systems with separate login and data transfer nodes). File "
+        "operations (put/get) will use this connection while commands use the main host.",
+    )
 
     def get_host(self) -> BaseHost:
         """
-        Return the RemoteHost.
+        Return the Host for this worker.
+
+        If a transfer host is configured, returns a SeparatedTransferHost that
+        delegates commands to the main host and file operations to the transfer host.
+        Otherwise, returns a standard RemoteHost.
 
         Returns
         -------
-        The RemoteHost.
+        BaseHost
+            The host instance for this worker.
         """
         connect_kwargs = dict(self.connect_kwargs) if self.connect_kwargs else {}
         if self.password:
@@ -455,7 +467,8 @@ class RemoteWorker(WorkerBase):
             connect_kwargs["key_filename"] = self.key_filename
         if self.passphrase:
             connect_kwargs["passphrase"] = self.passphrase
-        return RemoteHost(
+
+        command_host = RemoteHost(
             host=self.host,
             user=self.user,
             port=self.port,
@@ -470,6 +483,39 @@ class RemoteWorker(WorkerBase):
             login_shell=self.login_shell,
             interactive_login=self.interactive_login,
             sanitize=self.sanitize_command,
+        )
+
+        if self.transfer is None:
+            return command_host
+
+        # Create separate transfer host
+        from jobflow_remote.remote.host import SeparatedTransferHost
+
+        transfer_connect_kwargs = self.transfer.get_connect_kwargs()
+        if not transfer_connect_kwargs:
+            # Fall back to main connection credentials if not specified
+            transfer_connect_kwargs = connect_kwargs
+
+        transfer_host = RemoteHost(
+            host=self.transfer.host,
+            user=self.transfer.user or self.user,
+            port=self.transfer.port or self.port,
+            gateway=self.transfer.gateway,
+            forward_agent=self.forward_agent,
+            connect_timeout=self.connect_timeout,
+            connect_kwargs=transfer_connect_kwargs,
+            inline_ssh_env=self.inline_ssh_env,
+            timeout_execute=self.timeout_execute,
+            keepalive=self.keepalive,
+            shell_cmd=self.shell_cmd,
+            login_shell=self.login_shell,
+            interactive_login=self.interactive_login,
+            sanitize=self.sanitize_command,
+        )
+
+        return SeparatedTransferHost(
+            command_host=command_host,
+            transfer_host=transfer_host,
         )
 
     @property

--- a/src/jobflow_remote/remote/host/__init__.py
+++ b/src/jobflow_remote/remote/host/__init__.py
@@ -1,5 +1,6 @@
 from jobflow_remote.remote.host.base import BaseHost
 from jobflow_remote.remote.host.local import LocalHost
 from jobflow_remote.remote.host.remote import RemoteHost
+from jobflow_remote.remote.host.separated import SeparatedTransferHost
 
-__all__ = ("BaseHost", "LocalHost", "RemoteHost")
+__all__ = ("BaseHost", "LocalHost", "RemoteHost", "SeparatedTransferHost")

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -165,7 +165,7 @@ class SeparatedTransferHost(BaseHost):
         return self.command_host.rmtree(path, raise_on_error)
 
     # -------------------------------------------------------------------------
-    # File operations via SSH commands - delegated to command_host
+    # File operations via SFTP commands - delegated to transfer_host
     # -------------------------------------------------------------------------
 
     def write_text_file(self, filepath: str | Path, content: str) -> None:

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -162,7 +162,7 @@ class SeparatedTransferHost(BaseHost):
         bool
             True if the directory tree was successfully removed.
         """
-        return self.command_host.rmtree(path, raise_on_error)
+        return self.command_host.rmtree(path, raise_on_error=raise_on_error)
 
     # -------------------------------------------------------------------------
     # File operations via SFTP commands - delegated to transfer_host

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -101,14 +101,10 @@ class SeparatedTransferHost(BaseHost):
         """
         return self.command_host.shell(pre_cmd, shell)
 
-    # -------------------------------------------------------------------------
-    # File operations - delegated to transfer_host
-    # -------------------------------------------------------------------------
-
     def mkdir(
         self, directory: str | Path, recursive: bool = True, exist_ok: bool = True
     ) -> bool:
-        """Create directory on the transfer host.
+        """Create directory on the command host.
 
         Parameters
         ----------
@@ -124,7 +120,53 @@ class SeparatedTransferHost(BaseHost):
         bool
             True if the directory was created successfully.
         """
-        return self.transfer_host.mkdir(directory, recursive, exist_ok)
+        return self.command_host.mkdir(directory, recursive, exist_ok)
+
+    def copy(self, src, dst) -> None:
+        """Copy a file on the command host.
+
+        Parameters
+        ----------
+        src : str or Path
+            Source path on remote host.
+        dst : str or Path
+            Destination path on remote host.
+        """
+        return self.command_host.copy(src, dst)
+
+    def move(self, src, dst) -> None:
+        """Move a file on the command host.
+
+        Parameters
+        ----------
+        src : str or Path
+            Source path on remote host.
+        dst : str or Path
+            Destination path on remote host.
+        """
+        return self.command_host.move(src, dst)
+
+    def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        """Recursively delete a directory tree on the command host.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the directory tree to be removed.
+        raise_on_error : bool
+            If False (default), errors will be ignored. Otherwise, errors
+            will raise an exception.
+
+        Returns
+        -------
+        bool
+            True if the directory tree was successfully removed.
+        """
+        return self.command_host.rmtree(path, raise_on_error)
+
+    # -------------------------------------------------------------------------
+    # File operations via SSH commands - delegated to command_host
+    # -------------------------------------------------------------------------
 
     def write_text_file(self, filepath: str | Path, content: str) -> None:
         """Write content to a file on the transfer host.
@@ -177,30 +219,6 @@ class SeparatedTransferHost(BaseHost):
         """
         return self.transfer_host.get(src, dst)
 
-    def copy(self, src, dst) -> None:
-        """Copy a file on the transfer host.
-
-        Parameters
-        ----------
-        src : str or Path
-            Source path on remote host.
-        dst : str or Path
-            Destination path on remote host.
-        """
-        return self.transfer_host.copy(src, dst)
-
-    def move(self, src, dst) -> None:
-        """Move a file on the transfer host.
-
-        Parameters
-        ----------
-        src : str or Path
-            Source path on remote host.
-        dst : str or Path
-            Destination path on remote host.
-        """
-        return self.transfer_host.move(src, dst)
-
     def listdir(self, path: str | Path) -> list[str]:
         """List directory contents on the transfer host.
 
@@ -225,24 +243,6 @@ class SeparatedTransferHost(BaseHost):
             Path to the file to remove.
         """
         return self.transfer_host.remove(path)
-
-    def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
-        """Recursively delete a directory tree on the transfer host.
-
-        Parameters
-        ----------
-        path : str or Path
-            Path to the directory tree to be removed.
-        raise_on_error : bool
-            If False (default), errors will be ignored. Otherwise, errors
-            will raise an exception.
-
-        Returns
-        -------
-        bool
-            True if the directory tree was successfully removed.
-        """
-        return self.transfer_host.rmtree(path, raise_on_error)
 
     def exists(self, path: str | Path) -> bool:
         """Check if a path exists on the transfer host.

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -20,9 +20,11 @@ logger = logging.getLogger(__name__)
 
 
 class SeparatedTransferHost(BaseHost):
-    """Host that delegates commands and file transfers to separate connections.
+    """
+    Host that delegates commands and file transfers to separate connections.
 
     This enables HPC systems where:
+
     - Login node: SSH/scheduler commands work, but SFTP is disabled
     - Transfer node: SFTP works, but scheduler commands don't work
 
@@ -65,11 +67,38 @@ class SeparatedTransferHost(BaseHost):
         workdir: str | Path | None = None,
         timeout: int | None = None,
     ) -> tuple[str, str, int]:
-        """Execute the given command on the command host."""
+        """Execute the given command on the command host.
+
+        Parameters
+        ----------
+        command : str or list of str
+            Command to execute, as a str or list of str.
+        workdir : str or Path or None
+            Path where the command will be executed.
+        timeout : int or None
+            Timeout for the execution of the command.
+
+        Returns
+        -------
+        stdout : str
+            Standard output of the command.
+        stderr : str
+            Standard error of the command.
+        exit_code : int
+            Exit code of the command.
+        """
         return self.command_host.execute(command, workdir, timeout)
 
     def shell(self, pre_cmd: str | None = None, shell: str = "bash"):
-        """Open a shell on the command host."""
+        """Open a shell on the command host.
+
+        Parameters
+        ----------
+        pre_cmd : str or None
+            Any command to be executed before starting the shell.
+        shell : str
+            The name of the shell to start.
+        """
         return self.command_host.shell(pre_cmd, shell)
 
     # -------------------------------------------------------------------------
@@ -79,47 +108,155 @@ class SeparatedTransferHost(BaseHost):
     def mkdir(
         self, directory: str | Path, recursive: bool = True, exist_ok: bool = True
     ) -> bool:
-        """Create directory via transfer host."""
+        """Create directory on the transfer host.
+
+        Parameters
+        ----------
+        directory : str or Path
+            Path of the directory to create.
+        recursive : bool
+            If True, create parent directories as needed.
+        exist_ok : bool
+            If True, do not raise an error if directory exists.
+
+        Returns
+        -------
+        bool
+            True if the directory was created successfully.
+        """
         return self.transfer_host.mkdir(directory, recursive, exist_ok)
 
     def write_text_file(self, filepath: str | Path, content: str) -> None:
-        """Write content to a file via transfer host."""
+        """Write content to a file on the transfer host.
+
+        Parameters
+        ----------
+        filepath : str or Path
+            Path to the file to write.
+        content : str
+            Content to write to the file.
+        """
         return self.transfer_host.write_text_file(filepath, content)
 
     def read_text_file(self, filepath: str | Path) -> str:
-        """Read content from a file via transfer host."""
+        """Read content from a file on the transfer host.
+
+        Parameters
+        ----------
+        filepath : str or Path
+            Path to the file to read.
+
+        Returns
+        -------
+        str
+            Content of the file.
+        """
         return self.transfer_host.read_text_file(filepath)
 
     def put(self, src, dst) -> None:
-        """Upload file via transfer host."""
+        """Upload a file to the transfer host.
+
+        Parameters
+        ----------
+        src : str or Path or file-like
+            Local source path or file-like object.
+        dst : str or Path
+            Remote destination path.
+        """
         return self.transfer_host.put(src, dst)
 
     def get(self, src, dst) -> None:
-        """Download file via transfer host."""
+        """Download a file from the transfer host.
+
+        Parameters
+        ----------
+        src : str or Path
+            Remote source path.
+        dst : str or Path or file-like
+            Local destination path or file-like object.
+        """
         return self.transfer_host.get(src, dst)
 
     def copy(self, src, dst) -> None:
-        """Copy file on transfer host."""
+        """Copy a file on the transfer host.
+
+        Parameters
+        ----------
+        src : str or Path
+            Source path on remote host.
+        dst : str or Path
+            Destination path on remote host.
+        """
         return self.transfer_host.copy(src, dst)
 
     def move(self, src, dst) -> None:
-        """Move file on transfer host."""
+        """Move a file on the transfer host.
+
+        Parameters
+        ----------
+        src : str or Path
+            Source path on remote host.
+        dst : str or Path
+            Destination path on remote host.
+        """
         return self.transfer_host.move(src, dst)
 
     def listdir(self, path: str | Path) -> list[str]:
-        """List directory via transfer host."""
+        """List directory contents on the transfer host.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the directory to list.
+
+        Returns
+        -------
+        list of str
+            List of filenames in the directory.
+        """
         return self.transfer_host.listdir(path)
 
     def remove(self, path: str | Path) -> None:
-        """Remove file via transfer host."""
+        """Remove a file on the transfer host.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the file to remove.
+        """
         return self.transfer_host.remove(path)
 
     def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
-        """Recursively delete directory tree via transfer host."""
+        """Recursively delete a directory tree on the transfer host.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the directory tree to be removed.
+        raise_on_error : bool
+            If False (default), errors will be ignored. Otherwise, errors
+            will raise an exception.
+
+        Returns
+        -------
+        bool
+            True if the directory tree was successfully removed.
+        """
         return self.transfer_host.rmtree(path, raise_on_error)
 
     def exists(self, path: str | Path) -> bool:
-        """Check if path exists via transfer host."""
+        """Check if a path exists on the transfer host.
+
+        Parameters
+        ----------
+        path : str or Path
+            The path to check.
+
+        Returns
+        -------
+        bool
+            True if the path exists.
+        """
         return self.transfer_host.exists(path)
 
     # -------------------------------------------------------------------------
@@ -127,24 +264,42 @@ class SeparatedTransferHost(BaseHost):
     # -------------------------------------------------------------------------
 
     def connect(self) -> None:
-        """Open both connections."""
+        """Open connections to both the command and transfer hosts."""
         self.command_host.connect()
         self.transfer_host.connect()
 
     def close(self) -> bool:
-        """Close both connections."""
+        """Close connections to both hosts.
+
+        Returns
+        -------
+        bool
+            True if both connections were closed successfully.
+        """
         cmd_closed = self.command_host.close()
         transfer_closed = self.transfer_host.close()
         return cmd_closed and transfer_closed
 
     @property
     def is_connected(self) -> bool:
-        """True if both connections are open."""
+        """Check if both connections are open.
+
+        Returns
+        -------
+        bool
+            True if both command and transfer hosts are connected.
+        """
         return self.command_host.is_connected and self.transfer_host.is_connected
 
     @property
     def interactive_login(self) -> bool:
-        """True if either host requires interactive login."""
+        """Check if either host requires interactive login.
+
+        Returns
+        -------
+        bool
+            True if either host requires interactive login.
+        """
         return (
             self.command_host.interactive_login
             or self.transfer_host.interactive_login

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -301,6 +301,5 @@ class SeparatedTransferHost(BaseHost):
             True if either host requires interactive login.
         """
         return (
-            self.command_host.interactive_login
-            or self.transfer_host.interactive_login
+            self.command_host.interactive_login or self.transfer_host.interactive_login
         )

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -1,0 +1,151 @@
+"""Host implementation that uses separate connections for commands and file transfers.
+
+This is useful for HPC systems where login nodes have SFTP disabled but a dedicated
+data transfer node is available (e.g., LRC at LBNL).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from jobflow_remote.remote.host.base import BaseHost
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from jobflow_remote.remote.host.remote import RemoteHost
+
+logger = logging.getLogger(__name__)
+
+
+class SeparatedTransferHost(BaseHost):
+    """Host that delegates commands and file transfers to separate connections.
+
+    This enables HPC systems where:
+    - Login node: SSH/scheduler commands work, but SFTP is disabled
+    - Transfer node: SFTP works, but scheduler commands don't work
+
+    Command execution (execute, shell) goes through the command_host.
+    File operations (put, get, mkdir, etc.) go through the transfer_host.
+
+    Parameters
+    ----------
+    command_host : RemoteHost
+        Host for executing commands (e.g., login node with SLURM access).
+    transfer_host : RemoteHost
+        Host for file transfers (e.g., data transfer node with SFTP).
+    """
+
+    def __init__(
+        self,
+        command_host: RemoteHost,
+        transfer_host: RemoteHost,
+    ) -> None:
+        self.command_host = command_host
+        self.transfer_host = transfer_host
+        # Use sanitize setting from command host
+        super().__init__(sanitize=command_host.sanitize)
+
+    def __eq__(self, other):
+        if not isinstance(other, SeparatedTransferHost):
+            return False
+        return (
+            self.command_host == other.command_host
+            and self.transfer_host == other.transfer_host
+        )
+
+    # -------------------------------------------------------------------------
+    # Command execution - delegated to command_host
+    # -------------------------------------------------------------------------
+
+    def execute(
+        self,
+        command: str | list[str],
+        workdir: str | Path | None = None,
+        timeout: int | None = None,
+    ) -> tuple[str, str, int]:
+        """Execute the given command on the command host."""
+        return self.command_host.execute(command, workdir, timeout)
+
+    def shell(self, pre_cmd: str | None = None, shell: str = "bash"):
+        """Open a shell on the command host."""
+        return self.command_host.shell(pre_cmd, shell)
+
+    # -------------------------------------------------------------------------
+    # File operations - delegated to transfer_host
+    # -------------------------------------------------------------------------
+
+    def mkdir(
+        self, directory: str | Path, recursive: bool = True, exist_ok: bool = True
+    ) -> bool:
+        """Create directory via transfer host."""
+        return self.transfer_host.mkdir(directory, recursive, exist_ok)
+
+    def write_text_file(self, filepath: str | Path, content: str) -> None:
+        """Write content to a file via transfer host."""
+        return self.transfer_host.write_text_file(filepath, content)
+
+    def read_text_file(self, filepath: str | Path) -> str:
+        """Read content from a file via transfer host."""
+        return self.transfer_host.read_text_file(filepath)
+
+    def put(self, src, dst) -> None:
+        """Upload file via transfer host."""
+        return self.transfer_host.put(src, dst)
+
+    def get(self, src, dst) -> None:
+        """Download file via transfer host."""
+        return self.transfer_host.get(src, dst)
+
+    def copy(self, src, dst) -> None:
+        """Copy file on transfer host."""
+        return self.transfer_host.copy(src, dst)
+
+    def move(self, src, dst) -> None:
+        """Move file on transfer host."""
+        return self.transfer_host.move(src, dst)
+
+    def listdir(self, path: str | Path) -> list[str]:
+        """List directory via transfer host."""
+        return self.transfer_host.listdir(path)
+
+    def remove(self, path: str | Path) -> None:
+        """Remove file via transfer host."""
+        return self.transfer_host.remove(path)
+
+    def rmtree(self, path: str | Path, raise_on_error: bool = False) -> bool:
+        """Recursively delete directory tree via transfer host."""
+        return self.transfer_host.rmtree(path, raise_on_error)
+
+    def exists(self, path: str | Path) -> bool:
+        """Check if path exists via transfer host."""
+        return self.transfer_host.exists(path)
+
+    # -------------------------------------------------------------------------
+    # Connection management - manages both hosts
+    # -------------------------------------------------------------------------
+
+    def connect(self) -> None:
+        """Open both connections."""
+        self.command_host.connect()
+        self.transfer_host.connect()
+
+    def close(self) -> bool:
+        """Close both connections."""
+        cmd_closed = self.command_host.close()
+        transfer_closed = self.transfer_host.close()
+        return cmd_closed and transfer_closed
+
+    @property
+    def is_connected(self) -> bool:
+        """True if both connections are open."""
+        return self.command_host.is_connected and self.transfer_host.is_connected
+
+    @property
+    def interactive_login(self) -> bool:
+        """True if either host requires interactive login."""
+        return (
+            self.command_host.interactive_login
+            or self.transfer_host.interactive_login
+        )

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -40,12 +40,11 @@ def test_scheduler_type_subclass():
     assert sched_io.USERNAME_MAXCHARS == MyShellIO.USERNAME_MAXCHARS
 
 
-def test_remote_worker_with_transfer():
-    """Test that RemoteWorker with transfer option returns SeparatedTransferHost."""
+def test_remote_worker_returns_remote_host():
+    """Test that RemoteWorker returns a RemoteHost."""
     from jobflow_remote.config.base import RemoteWorker
-    from jobflow_remote.remote.host import RemoteHost, SeparatedTransferHost
+    from jobflow_remote.remote.host import RemoteHost
 
-    # Without transfer option - returns RemoteHost
     worker = RemoteWorker.model_validate(
         {
             "host": "login.cluster.edu",
@@ -55,9 +54,15 @@ def test_remote_worker_with_transfer():
     )
     host = worker.get_host()
     assert isinstance(host, RemoteHost)
+    assert host.host == "login.cluster.edu"
 
-    # With transfer option - returns SeparatedTransferHost
-    worker = RemoteWorker.model_validate(
+
+def test_separated_transfer_worker():
+    """Test that SeparatedTransferWorker returns a SeparatedTransferHost."""
+    from jobflow_remote.config.base import SeparatedTransferWorker
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    worker = SeparatedTransferWorker.model_validate(
         {
             "host": "login.cluster.edu",
             "work_dir": "/scratch/work",
@@ -69,3 +74,40 @@ def test_remote_worker_with_transfer():
     assert isinstance(host, SeparatedTransferHost)
     assert host.command_host.host == "login.cluster.edu"
     assert host.transfer_host.host == "dtn.cluster.edu"
+
+
+def test_separated_transfer_worker_inherits_credentials():
+    """Test that transfer host inherits credentials from main host if not specified."""
+    from jobflow_remote.config.base import SeparatedTransferWorker
+
+    worker = SeparatedTransferWorker.model_validate(
+        {
+            "host": "login.cluster.edu",
+            "user": "testuser",
+            "port": 2222,
+            "work_dir": "/scratch/work",
+            "scheduler_type": "slurm",
+            "transfer": {"host": "dtn.cluster.edu"},
+        }
+    )
+    host = worker.get_host()
+    # Transfer host should inherit user and port from main host
+    assert host.transfer_host.user == "testuser"
+    assert host.transfer_host.port == 2222
+
+
+def test_separated_transfer_worker_cli_info():
+    """Test that cli_info includes transfer host information."""
+    from jobflow_remote.config.base import SeparatedTransferWorker
+
+    worker = SeparatedTransferWorker.model_validate(
+        {
+            "host": "login.cluster.edu",
+            "work_dir": "/scratch/work",
+            "scheduler_type": "slurm",
+            "transfer": {"host": "dtn.cluster.edu"},
+        }
+    )
+    info = worker.cli_info
+    assert info["host"] == "login.cluster.edu"
+    assert info["transfer_host"] == "dtn.cluster.edu"

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -111,3 +111,31 @@ def test_separated_transfer_worker_cli_info():
     info = worker.cli_info
     assert info["host"] == "login.cluster.edu"
     assert info["transfer_host"] == "dtn.cluster.edu"
+
+
+def test_separated_transfer_worker_transfer_own_credentials():
+    """Test that transfer host uses its own credentials when specified."""
+    from jobflow_remote.config.base import SeparatedTransferWorker
+
+    worker = SeparatedTransferWorker.model_validate(
+        {
+            "host": "login.cluster.edu",
+            "user": "mainuser",
+            "password": "mainpassword",
+            "work_dir": "/scratch/work",
+            "scheduler_type": "slurm",
+            "transfer": {
+                "host": "dtn.cluster.edu",
+                "user": "transferuser",
+                "password": "transferpassword",
+            },
+        }
+    )
+    host = worker.get_host()
+    # Transfer host should use its own credentials
+    assert host.transfer_host.user == "transferuser"
+    # Connect kwargs should include the transfer password
+    assert host.transfer_host.connect_kwargs.get("password") == "transferpassword"
+    # Command host should use main credentials
+    assert host.command_host.user == "mainuser"
+    assert host.command_host.connect_kwargs.get("password") == "mainpassword"

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -38,3 +38,34 @@ def test_scheduler_type_subclass():
     assert isinstance(sched_io, MyShellIO)
     assert isinstance(sched_io, BaseSchedulerIO)
     assert sched_io.USERNAME_MAXCHARS == MyShellIO.USERNAME_MAXCHARS
+
+
+def test_remote_worker_with_transfer():
+    """Test that RemoteWorker with transfer option returns SeparatedTransferHost."""
+    from jobflow_remote.config.base import RemoteWorker
+    from jobflow_remote.remote.host import RemoteHost, SeparatedTransferHost
+
+    # Without transfer option - returns RemoteHost
+    worker = RemoteWorker.model_validate(
+        {
+            "host": "login.cluster.edu",
+            "work_dir": "/scratch/work",
+            "scheduler_type": "slurm",
+        }
+    )
+    host = worker.get_host()
+    assert isinstance(host, RemoteHost)
+
+    # With transfer option - returns SeparatedTransferHost
+    worker = RemoteWorker.model_validate(
+        {
+            "host": "login.cluster.edu",
+            "work_dir": "/scratch/work",
+            "scheduler_type": "slurm",
+            "transfer": {"host": "dtn.cluster.edu"},
+        }
+    )
+    host = worker.get_host()
+    assert isinstance(host, SeparatedTransferHost)
+    assert host.command_host.host == "login.cluster.edu"
+    assert host.transfer_host.host == "dtn.cluster.edu"

--- a/tests/unit/remote/test_separated_host.py
+++ b/tests/unit/remote/test_separated_host.py
@@ -1,0 +1,82 @@
+"""Tests for SeparatedTransferHost."""
+
+from unittest.mock import MagicMock, PropertyMock
+
+
+def test_execute_delegates_to_command_host():
+    """Test that execute() delegates to command_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    command_host.execute.return_value = ("stdout", "stderr", 0)
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.execute("ls -la")
+
+    command_host.execute.assert_called_once()
+    transfer_host.execute.assert_not_called()
+    assert result == ("stdout", "stderr", 0)
+
+
+def test_put_delegates_to_transfer_host():
+    """Test that put() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.put("/local/file", "/remote/file")
+
+    transfer_host.put.assert_called_once_with("/local/file", "/remote/file")
+    command_host.put.assert_not_called()
+
+
+def test_mkdir_delegates_to_transfer_host():
+    """Test that mkdir() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+    transfer_host.mkdir.return_value = True
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.mkdir("/path/to/dir")
+
+    transfer_host.mkdir.assert_called_once()
+    command_host.mkdir.assert_not_called()
+    assert result is True
+
+
+def test_connect_connects_both_hosts():
+    """Test that connect() connects both hosts."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.connect()
+
+    command_host.connect.assert_called_once()
+    transfer_host.connect.assert_called_once()
+
+
+def test_is_connected_requires_both_hosts():
+    """Test that is_connected requires both hosts to be connected."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    type(command_host).is_connected = PropertyMock(return_value=True)
+    transfer_host = MagicMock()
+    type(transfer_host).is_connected = PropertyMock(return_value=False)
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+
+    assert host.is_connected is False

--- a/tests/unit/remote/test_separated_host.py
+++ b/tests/unit/remote/test_separated_host.py
@@ -35,20 +35,20 @@ def test_put_delegates_to_transfer_host():
     command_host.put.assert_not_called()
 
 
-def test_mkdir_delegates_to_transfer_host():
-    """Test that mkdir() delegates to transfer_host."""
+def test_mkdir_delegates_to_command_host():
+    """Test that mkdir() delegates to command_host (uses SSH, not SFTP)."""
     from jobflow_remote.remote.host import SeparatedTransferHost
 
     command_host = MagicMock()
     command_host.sanitize = False
+    command_host.mkdir.return_value = True
     transfer_host = MagicMock()
-    transfer_host.mkdir.return_value = True
 
     host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
     result = host.mkdir("/path/to/dir")
 
-    transfer_host.mkdir.assert_called_once()
-    command_host.mkdir.assert_not_called()
+    command_host.mkdir.assert_called_once()
+    transfer_host.mkdir.assert_not_called()
     assert result is True
 
 

--- a/tests/unit/remote/test_separated_host.py
+++ b/tests/unit/remote/test_separated_host.py
@@ -106,7 +106,7 @@ def test_shell_delegates_to_command_host():
     transfer_host = MagicMock()
 
     host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
-    host.shell(pre_cmd="source ~/.bashrc", shell="zsh")
+    host.shell(pre_cmd="source ~/.bashrc", shell="zsh")  # noqa: S604
 
     command_host.shell.assert_called_once_with("source ~/.bashrc", "zsh")
     transfer_host.shell.assert_not_called()
@@ -154,7 +154,7 @@ def test_rmtree_delegates_to_command_host():
     host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
     result = host.rmtree("/remote/dir", raise_on_error=True)
 
-    command_host.rmtree.assert_called_once_with("/remote/dir", True)
+    command_host.rmtree.assert_called_once_with("/remote/dir", raise_on_error=True)
     transfer_host.rmtree.assert_not_called()
     assert result is True
 

--- a/tests/unit/remote/test_separated_host.py
+++ b/tests/unit/remote/test_separated_host.py
@@ -80,3 +80,298 @@ def test_is_connected_requires_both_hosts():
     host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
 
     assert host.is_connected is False
+
+
+def test_is_connected_both_connected():
+    """Test that is_connected returns True when both hosts are connected."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    type(command_host).is_connected = PropertyMock(return_value=True)
+    transfer_host = MagicMock()
+    type(transfer_host).is_connected = PropertyMock(return_value=True)
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+
+    assert host.is_connected is True
+
+
+def test_shell_delegates_to_command_host():
+    """Test that shell() delegates to command_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.shell(pre_cmd="source ~/.bashrc", shell="zsh")
+
+    command_host.shell.assert_called_once_with("source ~/.bashrc", "zsh")
+    transfer_host.shell.assert_not_called()
+
+
+def test_copy_delegates_to_command_host():
+    """Test that copy() delegates to command_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.copy("/remote/src", "/remote/dst")
+
+    command_host.copy.assert_called_once_with("/remote/src", "/remote/dst")
+    transfer_host.copy.assert_not_called()
+
+
+def test_move_delegates_to_command_host():
+    """Test that move() delegates to command_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.move("/remote/src", "/remote/dst")
+
+    command_host.move.assert_called_once_with("/remote/src", "/remote/dst")
+    transfer_host.move.assert_not_called()
+
+
+def test_rmtree_delegates_to_command_host():
+    """Test that rmtree() delegates to command_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    command_host.rmtree.return_value = True
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.rmtree("/remote/dir", raise_on_error=True)
+
+    command_host.rmtree.assert_called_once_with("/remote/dir", True)
+    transfer_host.rmtree.assert_not_called()
+    assert result is True
+
+
+def test_write_text_file_delegates_to_transfer_host():
+    """Test that write_text_file() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.write_text_file("/remote/file.txt", "content")
+
+    transfer_host.write_text_file.assert_called_once_with("/remote/file.txt", "content")
+    command_host.write_text_file.assert_not_called()
+
+
+def test_read_text_file_delegates_to_transfer_host():
+    """Test that read_text_file() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+    transfer_host.read_text_file.return_value = "file content"
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.read_text_file("/remote/file.txt")
+
+    transfer_host.read_text_file.assert_called_once_with("/remote/file.txt")
+    command_host.read_text_file.assert_not_called()
+    assert result == "file content"
+
+
+def test_get_delegates_to_transfer_host():
+    """Test that get() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.get("/remote/file", "/local/file")
+
+    transfer_host.get.assert_called_once_with("/remote/file", "/local/file")
+    command_host.get.assert_not_called()
+
+
+def test_listdir_delegates_to_transfer_host():
+    """Test that listdir() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+    transfer_host.listdir.return_value = ["file1.txt", "file2.txt"]
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.listdir("/remote/dir")
+
+    transfer_host.listdir.assert_called_once_with("/remote/dir")
+    command_host.listdir.assert_not_called()
+    assert result == ["file1.txt", "file2.txt"]
+
+
+def test_remove_delegates_to_transfer_host():
+    """Test that remove() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    host.remove("/remote/file.txt")
+
+    transfer_host.remove.assert_called_once_with("/remote/file.txt")
+    command_host.remove.assert_not_called()
+
+
+def test_exists_delegates_to_transfer_host():
+    """Test that exists() delegates to transfer_host."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+    transfer_host.exists.return_value = True
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.exists("/remote/path")
+
+    transfer_host.exists.assert_called_once_with("/remote/path")
+    command_host.exists.assert_not_called()
+    assert result is True
+
+
+def test_close_closes_both_hosts():
+    """Test that close() closes both hosts and returns combined result."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    command_host.close.return_value = True
+    transfer_host = MagicMock()
+    transfer_host.close.return_value = True
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.close()
+
+    command_host.close.assert_called_once()
+    transfer_host.close.assert_called_once()
+    assert result is True
+
+
+def test_close_returns_false_if_one_fails():
+    """Test that close() returns False if either host fails to close."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    command_host.close.return_value = True
+    transfer_host = MagicMock()
+    transfer_host.close.return_value = False
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+    result = host.close()
+
+    assert result is False
+
+
+def test_interactive_login_either_host():
+    """Test that interactive_login returns True if either host requires it."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    type(command_host).interactive_login = PropertyMock(return_value=False)
+    transfer_host = MagicMock()
+    type(transfer_host).interactive_login = PropertyMock(return_value=True)
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+
+    assert host.interactive_login is True
+
+
+def test_interactive_login_neither_host():
+    """Test that interactive_login returns False if neither host requires it."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    type(command_host).interactive_login = PropertyMock(return_value=False)
+    transfer_host = MagicMock()
+    type(transfer_host).interactive_login = PropertyMock(return_value=False)
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+
+    assert host.interactive_login is False
+
+
+def test_equality_same_hosts():
+    """Test that two SeparatedTransferHosts with equal hosts are equal."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host1 = MagicMock()
+    command_host1.sanitize = False
+    transfer_host1 = MagicMock()
+
+    command_host2 = command_host1
+    transfer_host2 = transfer_host1
+
+    host1 = SeparatedTransferHost(
+        command_host=command_host1, transfer_host=transfer_host1
+    )
+    host2 = SeparatedTransferHost(
+        command_host=command_host2, transfer_host=transfer_host2
+    )
+
+    assert host1 == host2
+
+
+def test_equality_different_hosts():
+    """Test that two SeparatedTransferHosts with different hosts are not equal."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host1 = MagicMock()
+    command_host1.sanitize = False
+    transfer_host1 = MagicMock()
+
+    command_host2 = MagicMock()
+    command_host2.sanitize = False
+    transfer_host2 = MagicMock()
+
+    host1 = SeparatedTransferHost(
+        command_host=command_host1, transfer_host=transfer_host1
+    )
+    host2 = SeparatedTransferHost(
+        command_host=command_host2, transfer_host=transfer_host2
+    )
+
+    assert host1 != host2
+
+
+def test_equality_not_separated_transfer_host():
+    """Test that SeparatedTransferHost is not equal to other types."""
+    from jobflow_remote.remote.host import SeparatedTransferHost
+
+    command_host = MagicMock()
+    command_host.sanitize = False
+    transfer_host = MagicMock()
+
+    host = SeparatedTransferHost(command_host=command_host, transfer_host=transfer_host)
+
+    assert host != "not a host"
+    assert host != command_host
+    assert host != 123


### PR DESCRIPTION
Hi all! I have been using jobflow-remote lately and it is such a joy. Thank you for the work you've put into it, and for the thoughtful designs.

The purpose of this PR is to accommodate the situation where the node that accommodates SSH access and queue access cannot also accommodate file transfer protocols. At our supercomputing cluster, we have separate data-transfer nodes and login nodes (a common arrangement I think). The data-transfer nodes do not allow job submission, and the login nodes do not allow SFTP connections. As a result, the jobflow-remote copy-files-then-submit process cannot occur on either one of these node types. To get around this, I introduced a new type of host which routes command execution and file movement to different nodes (these nodes would canonically be the SFTP-enabled data transfer node and the SLURM/PBS-enabled login node).

This implementation has been working for me, so I thought I would offer it to upstream. I am looking forward to hearing your thoughts on it, and also to potentially be corrected if there is a way to do this already with jobflow-remote configuration that I missed.

Thanks again!
Max