### PR TITLE
fix: correct enum comparison in stop_job for SUBMITTED/RUNNING states

### DIFF
--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -1969,7 +1969,7 @@ class JobController:
             job_doc = job_lock.locked_document
 
             job_state = JobState(job_doc["state"])
-            if job_state in [JobState.SUBMITTED.value, JobState.RUNNING.value]:
+            if job_state in [JobState.SUBMITTED, JobState.RUNNING]:
                 # try cancelling the job submitted to the remote queue
                 try:
                     self._cancel_queue_process(job_doc)

--- a/tests/db/jobs/test_jobcontroller.py
+++ b/tests/db/jobs/test_jobcontroller.py
@@ -1518,3 +1518,68 @@ def test_batches(job_controller):
     )
     assert job_controller.count_batches(db_ids="1") == 1
     assert job_controller.count_batches(db_ids=["1", "3"]) == 2
+
+
+def test_stop_job_submitted(job_controller, runner) -> None:
+    """Test stopping a job in SUBMITTED state cancels the queue process."""
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.testing import add_sleep
+
+    job = add_sleep(1, 30)
+    flow = Flow([job])
+    submit_flow(flow, worker="test_local_worker")
+
+    runner.run_one_job(max_seconds=20, target_state=JobState.RUNNING)
+
+    qm = runner.get_queue_manager("test_local_worker")
+    job_info = job_controller.get_job_info(job_id=job.uuid, job_index=job.index)
+    process_id = job_info.remote.process_id
+
+    jobs_list = qm.get_jobs_list([process_id])
+    assert len(jobs_list) == 1
+
+    # Manually set state back to SUBMITTED to test that branch
+    job_controller.set_job_state(
+        JobState.SUBMITTED, job_id=job.uuid, job_index=job.index
+    )
+    assert job_controller.get_job_info(job_id=job.uuid).state == JobState.SUBMITTED
+
+    job_controller.stop_job(job_id=job.uuid)
+
+    jobs_list = qm.get_jobs_list([process_id])
+    assert len(jobs_list) == 0
+    assert job_controller.get_job_info(job_id=job.uuid).state == JobState.USER_STOPPED
+    assert job_controller.get_flows_info(job_ids=job.uuid)[0].state == FlowState.STOPPED
+
+
+def test_stop_job_running(job_controller, runner) -> None:
+    """Test stopping a job in RUNNING state cancels the queue process."""
+    from jobflow import Flow
+
+    from jobflow_remote import submit_flow
+    from jobflow_remote.jobs.state import FlowState, JobState
+    from jobflow_remote.testing import add_sleep
+
+    job = add_sleep(1, 30)
+    flow = Flow([job])
+    submit_flow(flow, worker="test_local_worker")
+
+    runner.run_one_job(max_seconds=20, target_state=JobState.RUNNING)
+
+    qm = runner.get_queue_manager("test_local_worker")
+    job_info = job_controller.get_job_info(job_id=job.uuid, job_index=job.index)
+    process_id = job_info.remote.process_id
+
+    assert job_info.state == JobState.RUNNING
+    jobs_list = qm.get_jobs_list([process_id])
+    assert len(jobs_list) == 1
+
+    job_controller.stop_job(job_id=job.uuid)
+
+    jobs_list = qm.get_jobs_list([process_id])
+    assert len(jobs_list) == 0
+    assert job_controller.get_job_info(job_id=job.uuid).state == JobState.USER_STOPPED
+    assert job_controller.get_flows_info(job_ids=job.uuid)[0].state == FlowState.STOPPED


### PR DESCRIPTION
Hi,

Thanks a lot for maintaining jobflow-remote! It's been really helpful for our workflow.

We ran into this bug recently and thought this small fix might be useful. Happy to make any changes if needed.

## Summary

Fix a bug in `JobController.stop_job()` where `SUBMITTED` and `RUNNING` jobs were never properly cancelled from the remote queue.

**Root cause**: The condition compared a `JobState` enum member against `.value` strings, which always evaluates to `False`:

```python
# Before (broken)
job_state = JobState(job_doc["state"])  # JobState enum member
if job_state in [JobState.SUBMITTED.value, JobState.RUNNING.value]:  # Enum in [str, str] → False
    self._cancel_queue_process(job_doc)

# After (fixed)
job_state = JobState(job_doc["state"])
if job_state in [JobState.SUBMITTED, JobState.RUNNING]:  # Enum in [Enum, Enum] → True
    self._cancel_queue_process(job_doc)
```

**Impact**: Since v0.1.0, calling `stop_job()` on a `SUBMITTED` or `RUNNING` job would update the database state to `USER_STOPPED` but **never cancel the actual queue process**. The job would continue running on the scheduler.

## Changes

1. **Fix** (`src/jobflow_remote/jobs/jobcontroller.py:1972`): Compare enum member against enum members
2. **Tests** (`tests/db/jobs/test_jobcontroller.py`): Add `test_stop_job_submitted` and `test_stop_job_running`

## Testing

- New tests pass: `pytest tests/db/jobs/test_jobcontroller.py::test_stop_job_submitted tests/db/jobs/test_jobcontroller.py::test_stop_job_running`
- Existing `test_stop` continues to pass

## Risk Assessment

- **Low risk**: This is a localized fix to a condition check
- **No regression**: Only affects the `SUBMITTED`/`RUNNING` branch; `READY` and `BATCH_*` paths unchanged
- **Positive side effect**: `stop_jobs()` (plural) also benefits since it delegates to `stop_job()`

## Acknowledgment

Thanks to the maintainers for this great project. Bug discovered by [@zhang-changwei](https://github.com/zhang-changwei) while investigating why stopped jobs continued running on the scheduler.