### PR TITLE
Improve project validation and add project cross checks

### DIFF
--- a/doc/source/user/advancedoptions.rst
+++ b/doc/source/user/advancedoptions.rst
@@ -133,6 +133,14 @@ An minimal configuration for a *batch* worker would thus be:
 See the :ref:`projectconf` section for the list of all the configuration options available
 in the ``batch`` section.
 
+.. warning::
+
+    The ``jobs_handle_dir`` is used by the runner to exchange information with
+    the jobs being executed and cannot be shared between *batch* workers that
+    point to the same host, whether they belong to the same project or to
+    different projects. Sharing the same folder on the same filesystem may lead
+    to unpredictable behaviour at run time.
+
 Note that, since the completion of a Job and the subsequent potential switch of ``WAITING``
 Jobs to their ``READY`` state is still managed by the runner, this functionality is effective
 if several Jobs and Flows are managed at the same time. If too much time passes between the

--- a/doc/source/user/projectconf.rst
+++ b/doc/source/user/projectconf.rst
@@ -55,6 +55,16 @@ You can generate the example in the other formats using the ``--format`` option.
 
         jf project list --warn
 
+.. warning::
+
+    Some configuration options should not be shared among different projects.
+    For example, sharing the same queue store between two different projects will result in
+    unpredictable behaviour. The following command checks the presence of potentially
+    problematic collisions among different projects::
+
+        jf project check-conflicts
+
+
 Name and folders
 ----------------
 

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -197,13 +197,14 @@ def check(
     import os
 
     from jobflow_remote import SETTINGS
+    from jobflow_remote.config.settings import JobflowRemoteSettings
 
     prefix = SETTINGS.model_config["env_prefix"]
     extra_vars = [
         k
         for k in os.environ
         if k.lower().startswith(prefix)
-        and k[len(prefix) :].lower() not in SETTINGS.model_fields
+        and k[len(prefix) :].lower() not in JobflowRemoteSettings.model_fields
     ]
     if extra_vars:
         out_console.print(
@@ -321,6 +322,12 @@ def check(
         for e in errors:
             out_console.print(e[0], style="bold")
             out_console.print(e[1])
+    if not errors and SETTINGS.cli_suggestions:
+        out_console.print(
+            "The project configuration is correct. You might want to check for "
+            "conflicts with other project by running `jf project check-conflicts`",
+            style="green",
+        )
 
 
 @app_project.command(name="check-conflicts")
@@ -349,10 +356,11 @@ def check_conflicts() -> None:
         out_console.print(msg, style="yellow")
 
     if len(cm.projects) < 2:
-        exit_with_warning_msg(
-            f"Only {len(cm.projects)} project(s) parsed in {cm.projects_folder}; "
-            "nothing to cross-check."
-        )
+        if len(cm.projects) == 1:
+            msg = f"Only 1 project parsed in {cm.projects_folder}; "
+        else:
+            msg = f"No projects parsed in {cm.projects_folder}; "
+        exit_with_warning_msg(msg + "nothing to cross-check.")
 
     with loading_spinner(processing=False) as progress:
         progress.add_task("Checking projects for conflicts")

--- a/src/jobflow_remote/cli/project.py
+++ b/src/jobflow_remote/cli/project.py
@@ -33,6 +33,7 @@ from jobflow_remote.cli.utils import (
 from jobflow_remote.config import ConfigError, ConfigManager, Project
 from jobflow_remote.config.helper import (
     check_jobstore,
+    check_projects_conflicts,
     check_queue_store,
     check_worker,
     generate_dummy_project,
@@ -320,6 +321,59 @@ def check(
         for e in errors:
             out_console.print(e[0], style="bold")
             out_console.print(e[1])
+
+
+@app_project.command(name="check-conflicts")
+def check_conflicts() -> None:
+    """Check for configuration conflicts between different projects.
+
+    Verifies that resources that must be unique are not shared between the projects
+    defined in the projects folder.
+    """
+    cm = ConfigManager(warn=False)
+
+    # Warn about the files that could not be parsed
+    all_project_names, erroneous_files = cm.project_names_from_files(
+        suppress_warnings=True
+    )
+    not_parsed = sorted(set(all_project_names).difference(cm.projects_data))
+    if not_parsed or erroneous_files:
+        msg = (
+            "The following projects could not be parsed and are NOT included "
+            "in the conflict check:"
+        )
+        if not_parsed:
+            msg += f"\n - projects: {', '.join(not_parsed)}"
+        if erroneous_files:
+            msg += f"\n - files: {', '.join(erroneous_files)}"
+        out_console.print(msg, style="yellow")
+
+    if len(cm.projects) < 2:
+        exit_with_warning_msg(
+            f"Only {len(cm.projects)} project(s) parsed in {cm.projects_folder}; "
+            "nothing to cross-check."
+        )
+
+    with loading_spinner(processing=False) as progress:
+        progress.add_task("Checking projects for conflicts")
+        issues = check_projects_conflicts(cm.projects)
+
+    if not issues:
+        print_success_msg(f"No conflicts found across {len(cm.projects)} projects.")
+        return
+
+    grouped: dict[str, list] = {}
+    for issue in issues:
+        grouped.setdefault(issue.kind, []).append(issue)
+
+    out_console.print(
+        f"Found {len(issues)} conflict(s) across projects:", style="red bold"
+    )
+    for kind, kind_issues in grouped.items():
+        out_console.print(f"\n{kind}:", style="bold")
+        for issue in kind_issues:
+            out_console.print(f" - {issue.message}")
+    raise typer.Exit(1)
 
 
 @app_project.command()

--- a/src/jobflow_remote/cli/runner.py
+++ b/src/jobflow_remote/cli/runner.py
@@ -71,7 +71,7 @@ def _stop_runners(
     done_label: str,
 ) -> None:
     """
-    Shared implementation for the stopping the runners.
+    Shared implementation for the stopping of the runners.
 
     Parameters
     ----------

--- a/src/jobflow_remote/config/base.py
+++ b/src/jobflow_remote/config/base.py
@@ -17,6 +17,7 @@ from pydantic import (
     Field,
     ValidationInfo,
     field_validator,
+    model_validator,
 )
 from qtoolkit.io import BaseSchedulerIO, scheduler_mapping
 
@@ -834,6 +835,34 @@ class Project(BaseModel):
                     f"error while converting jobstore to JobStore. Error: {traceback.format_exc()}"
                 ) from e
         return jobstore
+
+    @model_validator(mode="after")
+    def check_unique_jobs_handle_dir(self) -> Project:
+        """
+        Ensure ``batch.jobs_handle_dir`` is unique among batch workers that
+        share a host.
+
+        Sharing the same directory on the same host among multiple batch
+        workers leads to unpredictable behaviour at run time, since the runner
+        uses it to exchange information with the jobs being executed. The same
+        path on different hosts is fine, as the two filesystems are
+        independent. Hosts are compared via the ``__eq__`` of the
+        ``BaseHost`` returned by ``worker.get_host()``.
+        """
+        seen: dict[tuple[BaseHost, Path], str] = {}
+        for worker_name, worker in self.workers.items():
+            if worker.batch is None:
+                continue
+            key = (worker.get_host(), Path(worker.batch.jobs_handle_dir))
+            if key in seen:
+                raise ValueError(
+                    f"Workers {seen[key]!r} and {worker_name!r} share the "
+                    f"same `jobs_handle_dir` ({key[1]}) on the same host. It "
+                    "must be unique across batch workers that share a host, "
+                    "to avoid unpredictable behaviour at run time."
+                )
+            seen[key] = worker_name
+        return self
 
     @field_validator("optional_jobstores")
     @classmethod

--- a/src/jobflow_remote/config/helper.py
+++ b/src/jobflow_remote/config/helper.py
@@ -4,6 +4,8 @@ import importlib.metadata
 import json
 import logging
 import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from jobflow_remote.config.base import (
@@ -21,6 +23,27 @@ if TYPE_CHECKING:
     from jobflow_remote.remote.host import BaseHost
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ConflictIssue:
+    """A single configuration conflict detected across projects.
+
+    Attributes
+    ----------
+    kind
+        Short identifier for the type of conflict (e.g. ``jobs_handle_dir``,
+        ``queue_collection``, ``directory``). Useful for grouping when
+        rendering.
+    message
+        Human-readable description of the conflict.
+    projects
+        Names of the projects involved in the conflict.
+    """
+
+    kind: str
+    message: str
+    projects: list[str] = field(default_factory=list)
 
 
 def generate_dummy_project(name: str, full: bool = False) -> Project:
@@ -120,8 +143,10 @@ def _check_workdir(worker: WorkerBase, host: BaseHost) -> str | None:
 
     Parameters
     ----------
-        worker: The worker configuration.
-        host: A connected host.
+        worker
+            The worker configuration.
+        host
+            A connected host.
 
     """
     try:
@@ -285,3 +310,139 @@ def _check_environment(
         msg += f"Mismatching versions: {', '.join(mismatch_str)}"
 
     return msg
+
+
+def _project_queue_stores(project: Project) -> dict[str, Store]:
+    """
+    Build one maggma ``Store`` per queue collection used by the project.
+
+    The auxiliary collections (``flows_collection``, ``auxiliary_collection``,
+    ``batches_collection``) live in the same database as ``queue.store``, so
+    they are obtained by deep-copying the queue store and overriding its
+    ``collection_name``.
+    """
+    import copy
+
+    main = project.get_queue_store()
+    if main is None:
+        return {}
+    stores: dict[str, Store] = {"queue.store": main}
+    sibling_fields = (
+        ("flows_collection", project.queue.flows_collection),
+        ("auxiliary_collection", project.queue.auxiliary_collection),
+        ("batches_collection", project.queue.batches_collection),
+    )
+    for field_name, collection_name in sibling_fields:
+        if not collection_name:
+            continue
+        sibling = copy.deepcopy(main)
+        sibling.collection_name = collection_name
+        stores[field_name] = sibling
+    return stores
+
+
+def check_projects_conflicts(
+    projects: dict[str, Project],
+) -> list[ConflictIssue]:
+    """
+    Detect configuration conflicts between different projects.
+
+    The rules checked are:
+
+    * ``batch.jobs_handle_dir`` of batch workers must be unique across all
+      batch workers that share a host. Hosts are compared via the ``__eq__``
+      of the ``BaseHost`` returned by ``worker.get_host()``.
+    * Queue collections (``queue.store`` collection plus ``flows_collection``,
+      ``auxiliary_collection`` and ``batches_collection``) must not be shared
+      across projects. Equality is determined by the maggma ``Store``
+      ``__eq__``.
+    * Project directories (``base_dir``, ``tmp_dir``, ``log_dir``,
+      ``daemon_dir``) must not be shared between projects.
+
+    Parameters
+    ----------
+    projects
+        Mapping of project name to ``Project`` instance, typically taken from
+        ``ConfigManager.projects``.
+
+    Returns
+    -------
+    list of ConflictIssue
+        One entry per detected conflict. Empty when no conflicts are found.
+    """
+    issues: list[ConflictIssue] = []
+
+    # 1. jobs_handle_dir across batch workers, grouped by (host, path)
+    handle_owners: dict[tuple[BaseHost, Path], list[tuple[str, str]]] = {}
+    for project_name, project in projects.items():
+        for worker_name, worker in project.workers.items():
+            if worker.batch is None:
+                continue
+            key = (worker.get_host(), Path(worker.batch.jobs_handle_dir))
+            handle_owners.setdefault(key, []).append((project_name, worker_name))
+    for (_, path_value), owners in handle_owners.items():
+        distinct_projects = {p for p, _ in owners}
+        if len(distinct_projects) < 2:
+            continue
+        owners_str = ", ".join(f"{p}/{w}" for p, w in owners)
+        issues.append(
+            ConflictIssue(
+                kind="jobs_handle_dir",
+                message=(
+                    f"Workers {owners_str} share the same `jobs_handle_dir` "
+                    f"({path_value}) on the same host. It must be unique "
+                    "across batch workers that share a host."
+                ),
+                projects=sorted(distinct_projects),
+            )
+        )
+
+    # 2. Queue collections across projects, grouped by Store equality
+    store_owners: dict[Store, list[tuple[str, str]]] = {}
+    for project_name, project in projects.items():
+        for field_name, store in _project_queue_stores(project).items():
+            store_owners.setdefault(store, []).append((project_name, field_name))
+    for store, owners in store_owners.items():
+        distinct_projects = {p for p, _ in owners}
+        if len(distinct_projects) < 2:
+            continue
+        owners_str = ", ".join(f"{p}.{f}" for p, f in owners)
+        collection_name = getattr(store, "collection_name", None)
+        issues.append(
+            ConflictIssue(
+                kind="queue_collection",
+                message=(
+                    f"Queue collection {collection_name!r} is used by "
+                    f"{owners_str}. Queue collections must not be shared "
+                    "across projects."
+                ),
+                projects=sorted(distinct_projects),
+            )
+        )
+
+    # 3. Project directories shared across projects (all on the local machine)
+    dir_fields = ("base_dir", "tmp_dir", "log_dir", "daemon_dir")
+    dir_owners: dict[Path, list[tuple[str, str]]] = {}
+    for project_name, project in projects.items():
+        for field_name in dir_fields:
+            value = getattr(project, field_name)
+            if value is None:
+                continue
+            dir_owners.setdefault(Path(value), []).append((project_name, field_name))
+    for path_value, owners in dir_owners.items():
+        distinct_projects = {p for p, _ in owners}
+        if len(distinct_projects) < 2:
+            continue
+        owners_str = ", ".join(f"{p}.{f}" for p, f in owners)
+        issues.append(
+            ConflictIssue(
+                kind="directory",
+                message=(
+                    f"Directory {path_value} is shared by {owners_str}. "
+                    "Project folders must not be shared between projects."
+                ),
+                projects=sorted(distinct_projects),
+            )
+        )
+
+    return issues

--- a/src/jobflow_remote/jobs/jobcontroller.py
+++ b/src/jobflow_remote/jobs/jobcontroller.py
@@ -4273,7 +4273,10 @@ class JobController:
             on_missing_ref = (
                 job.get("job", {}).get("config", {}).get("on_missing_references", None)
             )
-            if on_missing_ref == jobflow.OnMissing.NONE.value:
+            if on_missing_ref in (
+                jobflow.OnMissing.NONE.value,
+                jobflow.OnMissing.PASS.value,
+            ):
                 allowed_states.extend(
                     (JobState.FAILED.value, JobState.USER_STOPPED.value)
                 )

--- a/src/jobflow_remote/remote/host/local.py
+++ b/src/jobflow_remote/remote/host/local.py
@@ -19,6 +19,9 @@ class LocalHost(BaseHost):
     def __eq__(self, other):
         return isinstance(other, LocalHost)
 
+    def __hash__(self):
+        return hash(LocalHost)
+
     def execute(
         self,
         command: str | list[str],

--- a/src/jobflow_remote/remote/host/remote.py
+++ b/src/jobflow_remote/remote/host/remote.py
@@ -149,6 +149,11 @@ class RemoteHost(BaseHost):
             return False
         return self.as_dict() == other.as_dict()
 
+    def __hash__(self):
+        import json
+
+        return hash(json.dumps(self.as_dict(), sort_keys=True, default=str))
+
     @property
     def connection(self):
         return self._connection

--- a/src/jobflow_remote/remote/host/separated.py
+++ b/src/jobflow_remote/remote/host/separated.py
@@ -57,6 +57,9 @@ class SeparatedTransferHost(BaseHost):
             and self.transfer_host == other.transfer_host
         )
 
+    def __hash__(self):
+        return hash((SeparatedTransferHost, self.command_host, self.transfer_host))
+
     # -------------------------------------------------------------------------
     # Command execution - delegated to command_host
     # -------------------------------------------------------------------------

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -176,6 +176,104 @@ def test_check_fail(job_controller, monkeypatch, tmp_dir, run_check_cli) -> None
         )
 
 
+def test_check_conflicts(job_controller, monkeypatch, tmp_dir, run_check_cli) -> None:
+    import os
+
+    from monty.serialization import dumpfn
+
+    from jobflow_remote import SETTINGS
+
+    queue_dict = {
+        "type": "MongoStore",
+        "host": "h",
+        "port": 27017,
+        "database": "db_x",
+        "collection_name": "jobs",
+    }
+    local_batch_worker = {
+        "scheduler_type": "shell",
+        "type": "local",
+        "work_dir": "/some/test/path/work",
+        "batch": {
+            "jobs_handle_dir": "/some/test/path/shared_handles",
+            "work_dir": "/some/test/path/batch",
+        },
+    }
+
+    with monkeypatch.context() as m:
+        m.setattr(SETTINGS, "projects_folder", os.getcwd())
+
+        # Only one parseable project: nothing to cross-check.
+        dumpfn(
+            {
+                "name": "proj_a",
+                "queue": {"store": queue_dict},
+                "workers": {"w": local_batch_worker},
+                "base_dir": "/shared/base",
+            },
+            "proj_a.yaml",
+        )
+        run_check_cli(
+            ["project", "check-conflicts"],
+            required_out="nothing to cross-check",
+        )
+
+        # Two projects with no conflicts
+        dumpfn(
+            {
+                "name": "proj_b",
+                "queue": {"store": dict(queue_dict, host="h2")},
+                "base_dir": "/shared/base2",
+            },
+            "proj_b.yaml",
+        )
+        run_check_cli(
+            ["project", "check-conflicts"],
+            required_out="No conflicts found across 2 projects",
+        )
+
+        # Overwrite the second project with conflicts: jobs_handle_dir, queue
+        # collections (same DB + default names) and base_dir all collide.
+        dumpfn(
+            {
+                "name": "proj_b",
+                "queue": {"store": dict(queue_dict, collection_name="jobs_b")},
+                "workers": {"w": local_batch_worker},
+                "base_dir": "/shared/base",
+            },
+            "proj_b.yaml",
+        )
+
+        required = [
+            "Found 8 conflict(s)",
+            "jobs_handle_dir:",
+            "/some/test/path/shared_handles",
+            "queue_collection:",
+            "directory:",
+            "/shared/base",
+        ]
+        run_check_cli(
+            ["project", "check-conflicts"],
+            required_out=required,
+            error=True,
+        )
+
+        # Add an unparsable file: the command must warn about it but still
+        # run the check on the parsable projects.
+        with open("broken.yaml", "w") as f:
+            f.write("name: broken\nqueue: not_a_valid_queue\n")
+
+        run_check_cli(
+            ["project", "check-conflicts"],
+            required_out=[
+                *required,
+                "The following projects could not be parsed and are NOT included in the conflict check",
+                "broken",
+            ],
+            error=True,
+        )
+
+
 def test_remove(
     job_controller, random_project_name, monkeypatch, tmp_dir, run_check_cli
 ) -> None:

--- a/tests/unit/config/test_base.py
+++ b/tests/unit/config/test_base.py
@@ -113,6 +113,116 @@ def test_separated_transfer_worker_cli_info():
     assert info["transfer_host"] == "dtn.cluster.edu"
 
 
+def test_project_unique_jobs_handle_dir():
+    """Test that the Project rejects duplicate ``batch.jobs_handle_dir``
+    only when the workers share a host."""
+    from jobflow_remote.config.base import Project
+
+    def _local_worker(work_dir: str, handle_dir: str) -> dict:
+        return {
+            "type": "local",
+            "scheduler_type": "shell",
+            "work_dir": work_dir,
+            "batch": {
+                "jobs_handle_dir": handle_dir,
+                "work_dir": work_dir + "_batch",
+            },
+        }
+
+    def _remote_worker(host: str, work_dir: str, handle_dir: str) -> dict:
+        return {
+            "type": "remote",
+            "host": host,
+            "scheduler_type": "slurm",
+            "work_dir": work_dir,
+            "batch": {
+                "jobs_handle_dir": handle_dir,
+                "work_dir": work_dir + "_batch",
+            },
+        }
+
+    def _project_dict(workers: dict) -> dict:
+        return {
+            "name": "test_project",
+            "queue": {"store": {}},
+            "workers": workers,
+        }
+
+    # Distinct directories on the same host are accepted
+    Project.model_validate(
+        _project_dict(
+            {
+                "w1": _local_worker("/some/test/path/work1", "/some/test/path/h1"),
+                "w2": _local_worker("/some/test/path/work2", "/some/test/path/h2"),
+            }
+        )
+    )
+
+    # Identical directories on the same host are rejected
+    with pytest.raises(
+        ValidationError,
+        match=r"share the same `jobs_handle_dir`",
+    ):
+        Project.model_validate(
+            _project_dict(
+                {
+                    "w1": _local_worker(
+                        "/some/test/path/work1", "/some/test/path/same"
+                    ),
+                    "w2": _local_worker(
+                        "/some/test/path/work2", "/some/test/path/same"
+                    ),
+                }
+            )
+        )
+
+    # Trailing-slash variants on the same host are treated as equal by Path
+    with pytest.raises(
+        ValidationError,
+        match=r"share the same `jobs_handle_dir`",
+    ):
+        Project.model_validate(
+            _project_dict(
+                {
+                    "w1": _local_worker(
+                        "/some/test/path/work1", "/some/test/path/same/"
+                    ),
+                    "w2": _local_worker(
+                        "/some/test/path/work2", "/some/test/path/same"
+                    ),
+                }
+            )
+        )
+
+    # The same path on different hosts is fine: the filesystems are independent
+    Project.model_validate(
+        _project_dict(
+            {
+                "w1": _remote_worker(
+                    "host_a", "/some/test/path/work1", "/some/test/path/same"
+                ),
+                "w2": _remote_worker(
+                    "host_b", "/some/test/path/work2", "/some/test/path/same"
+                ),
+            }
+        )
+    )
+
+    # Different paths on different remote hosts are also accepted
+    Project.model_validate(
+        _project_dict(
+            {
+                "w1": _remote_worker(
+                    "host_a", "/some/test/path/work1", "/some/test/path/h1"
+                ),
+                "w2": _remote_worker(
+                    "host_b", "/some/test/path/work2", "/some/test/path/h2"
+                ),
+            }
+        )
+    )
+
+
 def test_separated_transfer_worker_transfer_own_credentials():
     """Test that transfer host uses its own credentials when specified."""
     from jobflow_remote.config.base import SeparatedTransferWorker

--- a/tests/unit/config/test_helper.py
+++ b/tests/unit/config/test_helper.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+
+def _queue_dict(database: str = "db", collection: str = "jobs") -> dict:
+    return {
+        "type": "MongoStore",
+        "host": "h",
+        "port": 27017,
+        "database": database,
+        "collection_name": collection,
+    }
+
+
+def _local_batch_worker(handle_dir: str) -> dict:
+    return {
+        "type": "local",
+        "scheduler_type": "shell",
+        "work_dir": "/some/test/path/w",
+        "batch": {"jobs_handle_dir": handle_dir, "work_dir": "/some/test/path/batch"},
+    }
+
+
+def _remote_batch_worker(handle_dir: str, *, host: str) -> dict:
+    return {
+        "type": "remote",
+        "scheduler_type": "slurm",
+        "host": host,
+        "user": "alice",
+        "work_dir": "/scratch/work",
+        "batch": {"jobs_handle_dir": handle_dir, "work_dir": "/scratch/batch"},
+    }
+
+
+def test_check_projects_conflicts():
+    from jobflow_remote.config.base import Project
+    from jobflow_remote.config.helper import check_projects_conflicts
+
+    # A & B share a local host, queue database, and base_dir. B's
+    # flows_collection also collides with A's main queue collection so the
+    # cross-field check is verified.
+    p_a = Project.model_validate(
+        {
+            "name": "A",
+            "queue": {"store": _queue_dict(database="db_x", collection="shared_jobs")},
+            "workers": {"w": _local_batch_worker("/some/test/path/handles")},
+            "base_dir": "/shared/base",
+        }
+    )
+    p_b = Project.model_validate(
+        {
+            "name": "B",
+            "queue": {
+                "store": _queue_dict(database="db_x", collection="jobs_b"),
+                "flows_collection": "shared_jobs",
+            },
+            "workers": {"w": _local_batch_worker("/some/test/path/handles")},
+            "base_dir": "/shared/base",
+        }
+    )
+    # C & D have the same handle path on *different* remote hosts and
+    # different queue databases, so they must not produce any conflict.
+    p_c = Project.model_validate(
+        {
+            "name": "C",
+            "queue": {"store": _queue_dict(database="db_c", collection="jobs_c")},
+            "workers": {
+                "w": _remote_batch_worker("/scratch/handles", host="host1.example.com")
+            },
+            "base_dir": "/projects/c",
+        }
+    )
+    p_d = Project.model_validate(
+        {
+            "name": "D",
+            "queue": {"store": _queue_dict(database="db_d", collection="jobs_d")},
+            "workers": {
+                "w": _remote_batch_worker("/scratch/handles", host="host2.example.com")
+            },
+            "base_dir": "/projects/d",
+        }
+    )
+
+    issues = check_projects_conflicts({"A": p_a, "B": p_b, "C": p_c, "D": p_d})
+
+    by_kind: dict[str, list] = {}
+    for issue in issues:
+        by_kind.setdefault(issue.kind, []).append(issue)
+
+    # jobs_handle_dir: only A/B (same local host); C/D are on different
+    # remote hosts and must NOT collide despite the identical path.
+    handle_issues = by_kind["jobs_handle_dir"]
+    assert len(handle_issues) == 1
+    assert handle_issues[0].projects == ["A", "B"]
+    assert "/some/test/path/handles" in handle_issues[0].message
+
+    # Queue collections: only A/B; the cross-field hit must pair A.queue.store
+    # with B.flows_collection.
+    queue_issues = by_kind["queue_collection"]
+    assert all(set(i.projects) == {"A", "B"} for i in queue_issues)
+    assert any(
+        "A.queue.store" in i.message and "B.flows_collection" in i.message
+        for i in queue_issues
+    )
+
+    # Directories: A/B share base_dir, and tmp/log/daemon all default to
+    # subfolders of base_dir, so we get 4 separate directory issues.
+    dir_issues = by_kind["directory"]
+    assert len(dir_issues) == 4
+    assert all(i.projects == ["A", "B"] for i in dir_issues)
+
+    # C and D must not appear in any issue.
+    for kind_issues in by_kind.values():
+        for issue in kind_issues:
+            assert "C" not in issue.projects
+            assert "D" not in issue.projects


### PR DESCRIPTION
Following #483, this PR adds a check to prevent having the same `jobs_handle_dir` for two batch workers on the same host.
As a general improvement, also added a `jf project check-conflicts` that will verify this and a few other incompatibilities among different projects. This is not executed when the projects are read, so it needs to be called explicitly. I don't think it would be good to enfornce it and having the need to perform all the checks every time.

Also, basically unrelated, I have realized that the case `OnMissing.PASS` from jobflow was not handled at all in jobflow-remote. This should fix it.