### PR TITLE
compatibility for typer dropping click depenency

### DIFF
--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -19,7 +19,6 @@ from jobflow_remote.cli.formatting import (
 from jobflow_remote.cli.jf import app
 from jobflow_remote.cli.jfr_typer import JFRTyper
 from jobflow_remote.cli.types import (
-    OptionalStr,
     break_lock_opt,
     cli_output_keys_opt,
     count_opt,
@@ -1188,7 +1187,7 @@ def output(
     job_db_id: job_db_id_arg,
     job_index: job_index_arg = None,
     file_path: Annotated[
-        OptionalStr,
+        str | None,
         typer.Option(
             "--path",
             "-p",
@@ -1296,7 +1295,7 @@ def files_get(
     ],
     job_index: job_index_opt = None,
     path: Annotated[
-        OptionalStr,
+        str | None,
         typer.Option(
             "--path",
             "-p",

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -17,7 +17,7 @@ from jobflow_remote.jobs.state import BatchState, FlowState, JobState
 # since 0.26.0 typer dropped click and has its own ParamType
 # keep for backward compatibility
 try:
-    from typer._click.params import ParamType
+    from typer._click.types import ParamType
 except ImportError:
     from click import ParamType
 

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -14,13 +14,6 @@ from jobflow_remote.cli.utils import (
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import BatchState, FlowState, JobState
 
-# since 0.26.0 typer dropped click and has its own ParamType
-# keep for backward compatibility
-try:
-    from typer._click.types import ParamType
-except ImportError:
-    from click import ParamType
-
 
 def deprecated_option(old_name: str, new_name: str):
     """Callback that warns about deprecated options and exits."""
@@ -477,27 +470,12 @@ cli_output_keys_opt = Annotated[
 ]
 
 
-# as of typer version 0.9.0 the dict is not a supported type. Define a custom one
-class DictType(dict):
-    pass
-
-
-# Python 3.10+ union types are fully supported now
-# These type aliases are kept for backward compatibility with typer's click integration
-OptionalStr = str | None
-OptionalDictType = DictType | None
-
-
-class DictTypeParser(ParamType):
-    name = "DictType"
-
-    def convert(self, value, param, ctx):
-        value = str_to_dict(value)
-        return DictType(value)
+def dict_type_parser(value: str) -> dict | None:
+    return str_to_dict(value)
 
 
 query_opt = Annotated[
-    OptionalDictType,
+    dict | None,
     typer.Option(
         "--query",
         "-q",
@@ -507,13 +485,13 @@ query_opt = Annotated[
         "Can be either a list of comma separated key=value pairs or a string with the JSON"
         " representation of a dictionary containing the mongoDB query that "
         'should be performed (e.g \'{"key1.key2": 1, "key3": "test"}\')',
-        click_type=DictTypeParser(),
+        parser=dict_type_parser,
     ),
 ]
 
 
 metadata_opt = Annotated[
-    OptionalDictType,
+    dict | None,
     typer.Option(
         "--metadata",
         "-meta",
@@ -521,6 +499,6 @@ metadata_opt = Annotated[
         " a list of comma separated key=value pairs or a string with the JSON"
         " representation of a dictionary containing the mongoDB query for "
         'the metadata subdocument (e.g \'{"key1.key2": 1, "key3": "test"}\')',
-        click_type=DictTypeParser(),
+        parser=dict_type_parser,
     ),
 ]

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Annotated
 
-import click
 import typer
 
 from jobflow_remote.cli.formatting import header_name_data_getter_map
@@ -14,6 +13,13 @@ from jobflow_remote.cli.utils import (
 )
 from jobflow_remote.config.base import LogLevel
 from jobflow_remote.jobs.state import BatchState, FlowState, JobState
+
+# since 0.26.0 typer dropped click and has its own ParamType
+# keep for backward compatibility
+try:
+    from typer.params import ParamType
+except ImportError:
+    from click import ParamType
 
 
 def deprecated_option(old_name: str, new_name: str):
@@ -482,7 +488,7 @@ OptionalStr = str | None
 OptionalDictType = DictType | None
 
 
-class DictTypeParser(click.ParamType):
+class DictTypeParser(ParamType):
     name = "DictType"
 
     def convert(self, value, param, ctx):

--- a/src/jobflow_remote/cli/types.py
+++ b/src/jobflow_remote/cli/types.py
@@ -17,7 +17,7 @@ from jobflow_remote.jobs.state import BatchState, FlowState, JobState
 # since 0.26.0 typer dropped click and has its own ParamType
 # keep for backward compatibility
 try:
-    from typer.params import ParamType
+    from typer._click.params import ParamType
 except ImportError:
     from click import ParamType
 

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -13,7 +13,6 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, NoReturn
 
 import typer
-from click import ClickException
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm
@@ -24,6 +23,22 @@ from typer.core import TyperCommand, TyperGroup
 from jobflow_remote import ConfigManager, JobController
 from jobflow_remote.config.base import ProjectParsingError, ProjectUndefinedError
 from jobflow_remote.jobs.daemon import DaemonError, DaemonManager, DaemonStatus
+
+# From version 0.26.0 typer does not rely on click anymore.
+# As of 0.26.5 ClickException has been moved to an internal module
+# that will probably be removed in the future.
+# Handle all the possible cases for broder compatibility with typer
+# older versions. Remove if the minimum typer version is increased.
+try:
+    from click import ClickException
+except ImportError:
+    try:
+        from typer._click import ClickException
+    except ImportError:
+
+        class ClickException(Exception):  # type: ignore[no-redef] # noqa: N818
+            pass
+
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping

--- a/src/jobflow_remote/cli/utils.py
+++ b/src/jobflow_remote/cli/utils.py
@@ -30,10 +30,10 @@ from jobflow_remote.jobs.daemon import DaemonError, DaemonManager, DaemonStatus
 # Handle all the possible cases for broder compatibility with typer
 # older versions. Remove if the minimum typer version is increased.
 try:
-    from click import ClickException
+    from typer._click import ClickException
 except ImportError:
     try:
-        from typer._click import ClickException
+        from click import ClickException
     except ImportError:
 
         class ClickException(Exception):  # type: ignore[no-redef] # noqa: N818


### PR DESCRIPTION
Typer dropped click as a backend from 0.26.0 and this breaks an import from click.
Here the attempt is to cover all the possible cases and cover different typer versions.