### PR TITLE
Add --latest-flow / -lf option to jf job list

### DIFF
--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -99,7 +99,7 @@ def jobs_list(
     locked: locked_opt = False,
     custom_query: query_opt = None,
     latest_flow: Annotated[
-        int,
+        int | None,
         typer.Option(
             "--latest-flow",
             "-lf",
@@ -108,7 +108,7 @@ def jobs_list(
             "consider, e.g. '--latest-flow 3' or '-lf 1' for the single latest Flow. "
             "Incompatible with --flow-id; applied before all other filters.",
         ),
-    ] = 0,
+    ] = None,
     error: Annotated[
         bool,
         typer.Option(
@@ -153,7 +153,7 @@ def jobs_list(
 
     jc = get_job_controller()
 
-    if latest_flow:
+    if latest_flow is not None:
         if flow_id:
             raise typer.BadParameter("--latest-flow cannot be combined with --flow-id")
         if latest_flow < 1:

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -103,12 +103,10 @@ def jobs_list(
         typer.Option(
             "--latest-flow",
             "-lf",
-            is_flag=False,
-            flag_value=1,
             help="Only show Jobs belonging to the most recently created Flows (by "
-            "creation date). Optionally provide an integer to set the number of latest "
-            "Flows to consider (e.g. --latest-flow=3); the bare flag selects the single "
-            "latest Flow. Incompatible with --flow-id; applied before all other filters.",
+            "creation date). Provide an integer to set the number of latest Flows to "
+            "consider, e.g. '--latest-flow 3' or '-lf 1' for the single latest Flow. "
+            "Incompatible with --flow-id; applied before all other filters.",
         ),
     ] = 0,
     error: Annotated[

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -98,6 +98,19 @@ def jobs_list(
     reverse_sort: reverse_sort_flag_opt = False,
     locked: locked_opt = False,
     custom_query: query_opt = None,
+    latest_flow: Annotated[
+        int,
+        typer.Option(
+            "--latest-flow",
+            "-lf",
+            is_flag=False,
+            flag_value=1,
+            help="Only show Jobs belonging to the most recently created Flows (by "
+            "creation date). Optionally provide an integer to set the number of latest "
+            "Flows to consider (e.g. --latest-flow=3); the bare flag selects the single "
+            "latest Flow. Incompatible with --flow-id; applied before all other filters.",
+        ),
+    ] = 0,
     error: Annotated[
         bool,
         typer.Option(
@@ -141,6 +154,21 @@ def jobs_list(
     job_ids_indexes = get_job_ids_indexes(job_id)
 
     jc = get_job_controller()
+
+    if latest_flow:
+        if flow_id:
+            raise typer.BadParameter(
+                "--latest-flow cannot be combined with --flow-id"
+            )
+        if latest_flow < 1:
+            raise typer.BadParameter("--latest-flow must be a positive integer")
+        flows_info = jc.get_flows_info(
+            sort=[("created_on", -1)],
+            limit=latest_flow,
+        )
+        if not flows_info:
+            exit_with_error_msg("No Flows in the database")
+        flow_id = [fi.flow_id for fi in flows_info]
 
     start_date = get_start_date(start_date, days, hours)
 

--- a/src/jobflow_remote/cli/job.py
+++ b/src/jobflow_remote/cli/job.py
@@ -155,17 +155,13 @@ def jobs_list(
 
     if latest_flow:
         if flow_id:
-            raise typer.BadParameter(
-                "--latest-flow cannot be combined with --flow-id"
-            )
+            raise typer.BadParameter("--latest-flow cannot be combined with --flow-id")
         if latest_flow < 1:
             raise typer.BadParameter("--latest-flow must be a positive integer")
         flows_info = jc.get_flows_info(
             sort=[("created_on", -1)],
             limit=latest_flow,
         )
-        if not flows_info:
-            exit_with_error_msg("No Flows in the database")
         flow_id = [fi.flow_id for fi in flows_info]
 
     start_date = get_start_date(start_date, days, hours)

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -147,6 +147,59 @@ def test_jobs_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     )
 
 
+def test_jobs_list_latest_flow(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+
+    run_check_cli(
+        ["job", "list", "-lf", "1"],
+        required_out=["add_job3", "add_job4"],
+        excluded_out=["add_job1", "add_job2"],
+    )
+    run_check_cli(
+        ["job", "list", "-lf", "1", "--count"], required_out="Number of jobs: 2"
+    )
+
+    run_check_cli(
+        ["job", "list", "--latest-flow", "2", "--count"],
+        required_out="Number of jobs: 4",
+    )
+
+    run_check_cli(
+        ["job", "list", "-lf", "5", "--count"], required_out="Number of jobs: 4"
+    )
+
+    run_check_cli(
+        ["job", "list", "-lf", "1", "-s", "READY"],
+        required_out=["add_job3"],
+        excluded_out=["add_job1", "add_job2", "add_job4"],
+    )
+    run_check_cli(
+        ["job", "list", "-lf", "1", "--name", "add_job4", "--count"],
+        required_out="Number of jobs: 1",
+    )
+
+    run_check_cli(
+        ["job", "list", "-lf", "1", "-fid", "1"],
+        error=True,
+        required_out="--latest-flow cannot be combined with --flow-id",
+    )
+    run_check_cli(
+        ["job", "list", "--latest-flow", "0"],
+        error=True,
+        required_out="--latest-flow must be a positive integer",
+    )
+    run_check_cli(
+        ["job", "list", "--latest-flow=-1"],
+        error=True,
+        required_out="--latest-flow must be a positive integer",
+    )
+
+
+def test_jobs_list_latest_flow_empty_db(job_controller, run_check_cli) -> None:
+    run_check_cli(
+        ["job", "list", "-lf", "1", "--count"], required_out="Number of jobs: 0"
+    )
+
+
 def test_jobs_list_settings(
     job_controller, two_flows_four_jobs, monkeypatch, run_check_cli
 ) -> None:

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -147,7 +147,9 @@ def test_jobs_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
     )
 
 
-def test_jobs_list_latest_flow(job_controller, two_flows_four_jobs, run_check_cli) -> None:
+def test_jobs_list_latest_flow(
+        job_controller, two_flows_four_jobs, run_check_cli
+) -> None:
 
     run_check_cli(
         ["job", "list", "-lf", "1"],

--- a/tests/db/cli/test_job.py
+++ b/tests/db/cli/test_job.py
@@ -148,9 +148,8 @@ def test_jobs_list(job_controller, two_flows_four_jobs, run_check_cli) -> None:
 
 
 def test_jobs_list_latest_flow(
-        job_controller, two_flows_four_jobs, run_check_cli
+    job_controller, two_flows_four_jobs, run_check_cli
 ) -> None:
-
     run_check_cli(
         ["job", "list", "-lf", "1"],
         required_out=["add_job3", "add_job4"],


### PR DESCRIPTION
### Summary
Adds a new --latest-flow (-lf) option to the jf job list command that restricts the output to Jobs belonging to the most recently created Flows. This makes it easy to inspect the jobs from your latest submission(s) without having to look up flow IDs manually.

### Behavior
jf job list -lf 3 — show jobs from the 3 most recently created Flows (by creation date).
jf job list -lf 1 — show jobs from the single latest Flow.
The filter is applied before all other filters.
Incompatible with --flow-id; passing both raises a BadParameter error.
Must be a positive integer; values < 1 are rejected.
Errors out cleanly if there are no Flows in the database.

### Notes
The option takes its value space-separated (-lf 3) or with = (-lf=3). It is a plain integer option — the bare flag form is intentionally not supported, since Click 8.2 removed options with an optional value; use -lf 1 for the single latest Flow.