### PR TITLE
Fix failing tests

### DIFF
--- a/src/jobflow_remote/config/manager.py
+++ b/src/jobflow_remote/config/manager.py
@@ -103,11 +103,11 @@ class ConfigManager:
             for filepath in self.projects_folder.glob(str(f"*.{ext}")):
                 try:
                     if ext in ["json", "yaml"]:
-                        d = loadfn(filepath)
+                        d = loadfn(filepath, cls=None)
                     else:
                         with open(filepath) as f:
                             d = tomlkit.parse(f.read())
-                    project = Project.parse_obj(d)
+                    project = Project.model_validate(d)
                 except Exception:
                     if self.warn:
                         logger.warning(
@@ -270,7 +270,7 @@ class ConfigManager:
         """
         project_data = self.projects_data.pop(project_name)
         proj_dict = project_data.project.dict()
-        new_project = Project.parse_obj(deep_merge_dict(proj_dict, config))
+        new_project = Project.model_validate(deep_merge_dict(proj_dict, config))
         project_data = ProjectData(project_data.filepath, new_project, project_data.ext)
         self.dump_project(project_data)
         self.projects_data[project_data.project.name] = project_data
@@ -301,7 +301,7 @@ class ConfigManager:
             for filepath in glob.glob(str(self.projects_folder / f"*.{ext}")):
                 try:
                     if ext in ["json", "yaml"]:
-                        d = loadfn(filepath)
+                        d = loadfn(filepath, cls=None)
                     else:
                         with open(filepath) as f:
                             d = tomlkit.parse(f.read())

--- a/src/jobflow_remote/config/manager.py
+++ b/src/jobflow_remote/config/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import json
 import logging
 import os
 import shutil
@@ -11,7 +12,8 @@ from typing import TYPE_CHECKING, NamedTuple
 import tomlkit
 from monty.json import jsanitize
 from monty.os import makedirs_p
-from monty.serialization import dumpfn, loadfn
+from monty.serialization import dumpfn
+from ruamel.yaml import YAML
 
 from jobflow_remote.config.base import (
     ConfigError,
@@ -99,13 +101,17 @@ class ConfigManager:
             Dictionary with project name as key and ProjectData as value.
         """
         projects_data: dict[str, ProjectData] = {}
+        _yaml = None
         for ext in self.projects_ext:
             for filepath in self.projects_folder.glob(str(f"*.{ext}")):
                 try:
-                    if ext in ["json", "yaml"]:
-                        d = loadfn(filepath, cls=None)
-                    else:
-                        with open(filepath) as f:
+                    with open(filepath) as f:
+                        if ext == "json":
+                            d = json.load(f)
+                        elif ext == "yaml":
+                            _yaml = _yaml or YAML()
+                            d = _yaml.load(f)
+                        else:
                             d = tomlkit.parse(f.read())
                     project = Project.model_validate(d)
                 except Exception:
@@ -297,13 +303,18 @@ class ConfigManager:
         """
         project_names = []
         erroneous_files = []
+
         for ext in self.projects_ext:
+            _yaml = None
             for filepath in glob.glob(str(self.projects_folder / f"*.{ext}")):
                 try:
-                    if ext in ["json", "yaml"]:
-                        d = loadfn(filepath, cls=None)
-                    else:
-                        with open(filepath) as f:
+                    with open(filepath) as f:
+                        if ext == "json":
+                            d = json.load(f)
+                        elif ext == "yaml":
+                            _yaml = _yaml or YAML()
+                            d = _yaml.load(f)
+                        else:
                             d = tomlkit.parse(f.read())
                     if "name" in d:
                         project_names.append(d["name"])

--- a/src/jobflow_remote/config/manager.py
+++ b/src/jobflow_remote/config/manager.py
@@ -101,6 +101,7 @@ class ConfigManager:
             Dictionary with project name as key and ProjectData as value.
         """
         projects_data: dict[str, ProjectData] = {}
+        # avoid instantiating YAML multiple times
         _yaml = None
         for ext in self.projects_ext:
             for filepath in self.projects_folder.glob(str(f"*.{ext}")):
@@ -304,8 +305,9 @@ class ConfigManager:
         project_names = []
         erroneous_files = []
 
+        # avoid instantiating YAML multiple times
+        _yaml = None
         for ext in self.projects_ext:
-            _yaml = None
             for filepath in glob.glob(str(self.projects_folder / f"*.{ext}")):
                 try:
                     with open(filepath) as f:

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -434,9 +434,7 @@ def test_edit_replace(
                 "--all",
                 "--yes",
             ],
-            required_out=[
-                "✓ Modified: test_project_1",
-            ],
+            required_out=["✓ Modified: test_project_1", "No changes: test_project_2"],
             excluded_out="invalid_project",
         )
 

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -149,9 +149,13 @@ def test_check_fail(job_controller, monkeypatch, tmp_dir, run_check_cli) -> None
             },
             "testtest.yaml",
         )
-        import time
 
-        time.sleep(5)
+        print(os.listdir(os.getcwd()))
+
+        run_check_cli(
+            ["project", "list", "-w"],
+            required_out="XXXXXXXXX",
+        )
 
         # project check fails as it cannot connect
         err_required = ["Errors:", "x Worker fake_remote_worker"]

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -149,6 +149,9 @@ def test_check_fail(job_controller, monkeypatch, tmp_dir, run_check_cli) -> None
             },
             "testtest.yaml",
         )
+        import time
+
+        time.sleep(5)
 
         # project check fails as it cannot connect
         err_required = ["Errors:", "x Worker fake_remote_worker"]

--- a/tests/db/cli/test_project.py
+++ b/tests/db/cli/test_project.py
@@ -150,13 +150,6 @@ def test_check_fail(job_controller, monkeypatch, tmp_dir, run_check_cli) -> None
             "testtest.yaml",
         )
 
-        print(os.listdir(os.getcwd()))
-
-        run_check_cli(
-            ["project", "list", "-w"],
-            required_out="XXXXXXXXX",
-        )
-
         # project check fails as it cannot connect
         err_required = ["Errors:", "x Worker fake_remote_worker"]
         run_check_cli(

--- a/tests/db/cli/test_runner.py
+++ b/tests/db/cli/test_runner.py
@@ -230,6 +230,15 @@ def test_info(
 
     daemon_manager.start(single=True)
     wait_daemon_started(daemon_manager)
+
+    # wait for the runner to have pinged the DB before proceeding
+    for _ in range(30):
+        time.sleep(1)
+        if len(job_controller.get_runner_pings()) > 0:
+            break
+    else:
+        raise RuntimeError("The runner did not ping the DB within the allocated time")
+
     job_controller.ping_running_runner(data=ping_data)
 
     req_out = [


### PR DESCRIPTION
The latest version of monty changes something in `loadfn` (or `MontyDecoder`) so that deserializes some thing that it did not use to. Parsing json/yaml project files with the library. 
Also fixing timings for a test usually failing in CI